### PR TITLE
[codex] Harden remote login chat UI

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -41,6 +41,7 @@ import { useEffect, useCallback, useMemo, useRef, useState } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Chat, useAgentSDK, ModeStatusBar, PlanModeBanner, UlwModeBanner } from '@/components/chat'
 import type { UI, ApprovalMode } from '@/components/chat/types'
+import { dedupeUI } from '@/components/chat/dedupe-ui'
 import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
@@ -150,17 +151,18 @@ export default function ChatSessionPage() {
   // Use stored UI if available, otherwise use hook UI
   const displayUI = useMemo((): UI[] => {
     if (hookUI.length > 0) {
-      return hookUI as UI[]
+      return dedupeUI(hookUI as UI[])
     }
-    return conversation?.ui || []
+    return dedupeUI(conversation?.ui || [])
   }, [hookUI, conversation?.ui])
 
   // Sync UI changes back to store
   useEffect(() => {
     if (sessionId && hookUI.length > 0) {
-      updateUI(sessionId, hookUI as UI[])
+      const cleanUI = dedupeUI(hookUI as UI[])
+      updateUI(sessionId, cleanUI)
 
-      const firstUser = hookUI.find(e => e.type === 'user')
+      const firstUser = cleanUI.find(e => e.type === 'user')
       if (firstUser && 'content' in firstUser) {
         updateTitle(sessionId, firstUser.content)
       }

--- a/components/chat/chat-ask-user.tsx
+++ b/components/chat/chat-ask-user.tsx
@@ -17,9 +17,24 @@ interface ChatAskUserProps {
 }
 
 export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps) {
-  const { question, options, multi_select } = askUser
+  const { multi_select, input_type, fields } = askUser
+  const question = typeof askUser.question === 'string' ? askUser.question : ''
+  const options = Array.isArray(askUser.options) ? askUser.options : []
   const [selected, setSelected] = useState<string[]>([])
   const [textInput, setTextInput] = useState('')
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({})
+  const hasOptions = options.length > 0
+  const isCredentialPrompt = input_type === 'credentials' || question.includes('账号和密码') || question.includes('账号或密码')
+  const formFields = fields && fields.length > 0
+    ? fields
+    : isCredentialPrompt
+      ? [
+          { name: 'username', label: '账号', type: 'text' as const, required: true, autocomplete: 'username' },
+          { name: 'password', label: '密码', type: 'password' as const, required: true, autocomplete: 'current-password' },
+        ]
+      : []
+  const hasFieldForm = formFields.length > 0
+  const hasMissingRequiredField = formFields.some(field => field.required && !fieldValues[field.name]?.trim())
 
   const handleOptionClick = (option: string) => {
     if (multi_select) {
@@ -41,10 +56,24 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
     }
   }
 
+  const handleFieldSubmit = () => {
+    if (hasMissingRequiredField) return
+
+    const answer = formFields.reduce<Record<string, string>>((acc, field) => {
+      acc[field.name] = fieldValues[field.name]?.trim() || ''
+      return acc
+    }, {})
+    onResponse(JSON.stringify(answer))
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit()
+      if (hasFieldForm) {
+        handleFieldSubmit()
+      } else {
+        handleSubmit()
+      }
     }
   }
 
@@ -65,7 +94,36 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
 
       {/* Input area */}
       <div className="p-4 space-y-4">
-        {options && (
+        {hasFieldForm ? (
+          <div className="space-y-3">
+            {formFields.map(field => (
+              <label key={field.name} className="block space-y-1.5">
+                <span className="text-xs font-semibold text-amber-950">{field.label}</span>
+                <input
+                  type={field.type === 'password' ? 'password' : 'text'}
+                  value={fieldValues[field.name] || ''}
+                  onChange={(e) => setFieldValues(prev => ({ ...prev, [field.name]: e.target.value }))}
+                  onKeyDown={handleKeyDown}
+                  placeholder={field.placeholder || field.label}
+                  autoComplete={field.autocomplete}
+                  className="w-full rounded-xl border border-amber-100 bg-white px-3 py-3 text-sm font-medium text-neutral-900 shadow-sm outline-none transition-all placeholder:text-neutral-400 focus:border-amber-300 focus:ring-4 focus:ring-amber-500/5"
+                  autoFocus={field.name === formFields[0]?.name}
+                />
+              </label>
+            ))}
+
+            <div className="flex justify-end pt-1">
+              <button
+                onClick={handleFieldSubmit}
+                disabled={hasMissingRequiredField}
+                className="flex items-center gap-2 rounded-xl bg-neutral-900 px-5 py-2.5 text-xs font-bold text-white shadow-md transition-all hover:bg-neutral-800 disabled:opacity-20 active:scale-95"
+              >
+                <HiOutlinePaperAirplane className="w-4 h-4 rotate-90" />
+                提交
+              </button>
+            </div>
+          </div>
+        ) : hasOptions && (
           <div className="space-y-1.5">
             <div className="grid grid-cols-1 gap-1.5">
               {options.map((option, idx) => {
@@ -121,8 +179,9 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
         )}
 
         {/* Input Fallback */}
+        {!hasFieldForm && (
         <div className="space-y-3 pt-1">
-          {options && (
+          {hasOptions && (
             <div className="flex items-center gap-2 px-1">
               <div className="h-px flex-1 bg-amber-100" />
               <span className="text-[10px] font-bold text-amber-600/60 uppercase tracking-widest">Or enter custom value</span>
@@ -136,9 +195,9 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
               value={textInput}
               onChange={(e) => setTextInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder={options ? "Custom answer..." : "Type your answer..."}
+              placeholder={hasOptions ? "Custom answer..." : "Type your answer..."}
               className="flex-1 bg-transparent px-3 py-2 text-sm focus:outline-none placeholder:text-neutral-400 text-neutral-900 font-medium"
-              autoFocus={!options}
+              autoFocus={!hasOptions}
             />
             <button
               onClick={handleSubmit}
@@ -149,6 +208,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
             </button>
           </div>
         </div>
+        )}
       </div>
     </div>
   )

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useMemo } from 'react'
 import { cn } from './utils'
 import { User, Agent, Thinking, ToolCall, AskUser, OnboardRequired, OnboardSuccess, Intent, Eval, Compact, ToolBlocked, FilesReceived } from './messages'
+import { ChatAskUser } from './chat-ask-user'
 import { ChatUlwCheckpoint } from './chat-ulw-checkpoint'
 import type { ChatMessagesProps, OnboardRequiredUI, OnboardSuccessUI, IntentUI, EvalUI, CompactUI, ToolBlockedUI, UlwTurnsReachedUI, PendingPlanReview, FilesReceivedUI } from './types'
 
@@ -53,6 +54,11 @@ export function ChatMessages({
         .pop()?.id
     : null
 
+  const pendingStandaloneAskUserId = pendingAskUser && !pendingAskUserToolId
+    ? ui.filter(item => item.type === 'ask_user' && !(item as { answered?: boolean }).answered)
+        .pop()?.id
+    : null
+
   // Find the running exit_plan_and_implement tool call for plan review
   const pendingPlanToolId = pendingPlanReview
     ? ui.filter(item => item.type === 'tool_call' && item.name.toLowerCase() === 'exit_plan_and_implement' && item.status === 'running')
@@ -96,6 +102,15 @@ export function ChatMessages({
               )
             }
             case 'ask_user':
+              if (item.id === pendingStandaloneAskUserId && pendingAskUser && onAskUserResponse) {
+                return (
+                  <ChatAskUser
+                    key={item.id}
+                    askUser={pendingAskUser}
+                    onResponse={onAskUserResponse}
+                  />
+                )
+              }
               return <AskUser key={item.id} question={item} />
             case 'approval_needed':
               // Don't render separate approval message - it's shown inline in tool card

--- a/components/chat/dedupe-ui.ts
+++ b/components/chat/dedupe-ui.ts
@@ -1,0 +1,198 @@
+import type { AgentUI, AskUserField, UI, UIType } from './types'
+
+const VALID_TYPES = new Set<UIType>([
+  'user',
+  'agent',
+  'thinking',
+  'tool_call',
+  'ask_user',
+  'approval_needed',
+  'onboard_required',
+  'onboard_success',
+  'intent',
+  'eval',
+  'compact',
+  'tool_blocked',
+  'ulw_turns_reached',
+  'plan_review',
+  'files_received',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const items = value.filter((item): item is string => typeof item === 'string')
+  return items.length ? items : undefined
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {}
+}
+
+function sanitizeFields(value: unknown): AskUserField[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const fields = value
+    .filter(isRecord)
+    .map((field): AskUserField => ({
+      name: stringValue(field.name),
+      label: stringValue(field.label || field.name),
+      type: field.type === 'password' ? 'password' : 'text',
+      placeholder: stringValue(field.placeholder),
+      required: field.required === true,
+      autocomplete: stringValue(field.autocomplete),
+    }))
+    .filter(field => field.name && field.label)
+  return fields.length ? fields : undefined
+}
+
+function statusValue(value: unknown): 'running' | 'done' | 'error' {
+  return value === 'running' || value === 'error' ? value : 'done'
+}
+
+function normalizeItem(rawItem: unknown, index: number): UI | null {
+  if (!isRecord(rawItem) || typeof rawItem.type !== 'string' || !VALID_TYPES.has(rawItem.type as UIType)) {
+    return null
+  }
+
+  const type = rawItem.type as UIType
+  const id = stringValue(rawItem.id, `recovered-${type}-${index}`)
+  const item = { ...rawItem, id, type } as Record<string, unknown>
+
+  switch (type) {
+    case 'user':
+      return {
+        ...item,
+        content: stringValue(item.content),
+        images: stringArray(item.images),
+      } as UI
+    case 'agent':
+      return {
+        ...item,
+        content: stringValue(item.content),
+        images: uniqueImages(stringArray(item.images)),
+      } as UI
+    case 'thinking':
+      return { ...item, status: statusValue(item.status), content: stringValue(item.content) } as UI
+    case 'tool_call':
+      return {
+        ...item,
+        name: stringValue(item.name, 'tool'),
+        args: recordValue(item.args),
+        status: statusValue(item.status),
+        result: stringValue(item.result),
+      } as UI
+    case 'ask_user':
+      return {
+        ...item,
+        text: stringValue(item.text || item.question),
+        options: stringArray(item.options) || [],
+        multi_select: item.multi_select === true,
+        input_type: stringValue(item.input_type),
+        fields: sanitizeFields(item.fields),
+      } as UI
+    case 'approval_needed':
+      return {
+        ...item,
+        tool: stringValue(item.tool, 'tool'),
+        arguments: recordValue(item.arguments),
+      } as UI
+    case 'onboard_required':
+      return { ...item, methods: stringArray(item.methods) || [] } as UI
+    case 'onboard_success':
+      return { ...item, level: stringValue(item.level), message: stringValue(item.message) } as UI
+    case 'intent':
+      return { ...item, status: item.status === 'understood' ? 'understood' : 'analyzing' } as UI
+    case 'eval':
+      return { ...item, status: item.status === 'done' ? 'done' : 'evaluating' } as UI
+    case 'compact':
+      return { ...item, status: statusValue(item.status) } as UI
+    case 'tool_blocked':
+      return {
+        ...item,
+        tool: stringValue(item.tool, 'tool'),
+        reason: stringValue(item.reason),
+        message: stringValue(item.message),
+      } as UI
+    case 'ulw_turns_reached':
+      return {
+        ...item,
+        turns_used: typeof item.turns_used === 'number' ? item.turns_used : 0,
+        max_turns: typeof item.max_turns === 'number' ? item.max_turns : 0,
+      } as UI
+    case 'plan_review':
+      return { ...item, plan_content: stringValue(item.plan_content) } as UI
+    case 'files_received':
+      return { ...item, files: Array.isArray(item.files) ? item.files.filter(isRecord) : [] } as UI
+  }
+}
+
+function uniqueImages(images?: string[]): string[] | undefined {
+  if (!images?.length) return images
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const image of images) {
+    if (seen.has(image)) continue
+    seen.add(image)
+    result.push(image)
+  }
+
+  return result
+}
+
+function dedupeKey(item: UI): string | null {
+  if (item.type === 'agent' && item.images?.length) {
+    return `agent-image:${item.images.join('|')}`
+  }
+
+  if (item.id && item.id !== '__optimistic__') {
+    return `id:${item.id}`
+  }
+
+  return null
+}
+
+function mergeItems(previous: UI, next: UI): UI {
+  if (previous.type === 'agent' && next.type === 'agent') {
+    return {
+      ...previous,
+      ...next,
+      content: next.content || previous.content,
+      images: uniqueImages([...(previous.images || []), ...(next.images || [])]),
+    } as AgentUI
+  }
+
+  return { ...previous, ...next } as UI
+}
+
+export function dedupeUI(items: unknown): UI[] {
+  if (!Array.isArray(items)) return []
+
+  const result: UI[] = []
+  const seen = new Map<string, number>()
+
+  for (let index = 0; index < items.length; index++) {
+    const item = normalizeItem(items[index], index)
+    if (!item) continue
+
+    const key = dedupeKey(item)
+
+    if (key && seen.has(key)) {
+      const index = seen.get(key)!
+      result[index] = mergeItems(result[index], item)
+      continue
+    }
+
+    if (key) seen.set(key, result.length)
+    result.push(item)
+  }
+
+  return result
+}

--- a/components/chat/messages/agent.tsx
+++ b/components/chat/messages/agent.tsx
@@ -3,8 +3,10 @@ import remarkGfm from 'remark-gfm'
 import type { AgentUI } from '../types'
 
 export function Agent({ message }: { message: AgentUI }) {
-  const hasImages = message.images && message.images.length > 0
-  const hasText = message.content.trim().length > 0
+  const content = typeof message.content === 'string' ? message.content : ''
+  const images = Array.isArray(message.images) ? message.images : []
+  const hasImages = images.length > 0
+  const hasText = content.trim().length > 0
 
   if (!hasText && !hasImages) return null
 
@@ -31,20 +33,20 @@ export function Agent({ message }: { message: AgentUI }) {
             prose-blockquote:border-l-4 prose-blockquote:border-neutral-200 prose-blockquote:pl-4 prose-blockquote:italic prose-blockquote:text-neutral-600
           ">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {message.content}
+              {content}
             </ReactMarkdown>
           </div>
         )}
 
         {/* Images - displayed below text */}
         {hasImages && (
-          <div className="flex gap-2 flex-wrap">
-            {message.images!.map((img, i) => (
+          <div className="flex w-full flex-col gap-3">
+            {images.map((img, i) => (
               <img
                 key={i}
                 src={img}
                 alt={`Image ${i + 1}`}
-                className="max-h-48 max-w-[200px] rounded-2xl object-contain cursor-pointer hover:opacity-90 transition-opacity shadow-md"
+                className="w-full max-w-3xl max-h-[70vh] rounded-xl border border-neutral-200 object-contain cursor-pointer bg-white shadow-md transition-opacity hover:opacity-90"
                 onClick={() => window.open(img, '_blank')}
               />
             ))}

--- a/components/chat/messages/user.tsx
+++ b/components/chat/messages/user.tsx
@@ -4,16 +4,19 @@ import { HiOutlineDocument } from 'react-icons/hi2'
 import type { UserUI } from '../types'
 
 export function User({ message }: { message: UserUI }) {
-  const hasImages = message.images && message.images.length > 0
-  const hasFiles = message.files && message.files.length > 0
-  const hasText = message.content.trim().length > 0
+  const content = typeof message.content === 'string' ? message.content : ''
+  const images = Array.isArray(message.images) ? message.images : []
+  const files = Array.isArray(message.files) ? message.files : []
+  const hasImages = images.length > 0
+  const hasFiles = files.length > 0
+  const hasText = content.trim().length > 0
 
   return (
     <div className="flex flex-col items-end gap-2 py-3">
       {/* Images - displayed as thumbnails above text */}
       {hasImages && (
         <div className={`flex gap-2 flex-wrap justify-end max-w-[85%]`}>
-          {message.images!.map((img, i) => (
+          {images.map((img, i) => (
             <img
               key={i}
               src={img}
@@ -28,7 +31,7 @@ export function User({ message }: { message: UserUI }) {
       {/* File attachments */}
       {hasFiles && (
         <div className="flex gap-2 flex-wrap justify-end max-w-[85%]">
-          {message.files!.map((file, i) => (
+          {files.map((file, i) => (
             <div key={i} className="flex items-center gap-2 rounded-xl bg-neutral-800 px-3 py-2 shadow-md">
               <HiOutlineDocument className="h-4 w-4 text-neutral-400 shrink-0" />
               <span className="text-sm text-neutral-200 truncate max-w-[150px]">{file.name}</span>
@@ -48,7 +51,7 @@ export function User({ message }: { message: UserUI }) {
             prose-ul:my-1 prose-ol:my-1
           ">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {message.content}
+              {content}
             </ReactMarkdown>
           </div>
         </div>

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -106,6 +106,17 @@ export interface PendingAskUser {
   question: string
   options: string[]
   multi_select: boolean
+  input_type?: string
+  fields?: AskUserField[]
+}
+
+export interface AskUserField {
+  name: string
+  label: string
+  type?: 'text' | 'password'
+  placeholder?: string
+  required?: boolean
+  autocomplete?: string
 }
 
 export interface PendingApproval {
@@ -190,6 +201,12 @@ export interface ToolCallUI extends BaseUI {
 export interface AskUserUI extends BaseUI {
   type: 'ask_user'
   text: string
+  options?: string[]
+  multi_select?: boolean
+  input_type?: string
+  fields?: AskUserField[]
+  answered?: boolean
+  answer?: string
 }
 
 /** Approval needed for dangerous tool */

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useAgentForHuman, type ChatItem, type ApprovalMode, type OutgoingMessage } from 'connectonion/react'
 import type { PendingAskUser, PendingApproval, PendingOnboard, PendingUlwTurnsReached, PendingPlanReview } from './types'
+import { dedupeUI } from './dedupe-ui'
 
 /** Session lifecycle state */
 export type SessionActiveState = 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
@@ -76,12 +77,18 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
     if (item.type === 'tool_call') {
       toolStatuses.set(item.name.toLowerCase(), item.status)
     } else if (item.type === 'ask_user') {
+      if ((item as { answered?: boolean }).answered) {
+        pendingAskUser = null
+        continue
+      }
       const toolStatus = toolStatuses.get('ask_user')
       if (toolStatus === 'running' || toolStatus === undefined) {
         pendingAskUser = {
-          question: item.text,
-          options: item.options,
-          multi_select: item.multi_select,
+          question: typeof item.text === 'string' ? item.text : '',
+          options: Array.isArray(item.options) ? item.options : [],
+          multi_select: item.multi_select === true,
+          input_type: (item as { input_type?: string }).input_type,
+          fields: (item as { fields?: PendingAskUser['fields'] }).fields,
         }
       } else {
         pendingAskUser = null
@@ -151,6 +158,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     setMode: sdkSetMode,
     reconnect: sdkReconnect,
   } = useAgentForHuman(agentAddress, sessionId)
+  const cleanUI = useMemo(() => dedupeUI(ui as import('./types').UI[]) as ChatItem[], [ui])
 
   // Timer effect for elapsed time display
   useEffect(() => {
@@ -213,14 +221,14 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   useEffect(() => {
     if (prevStatusRef.current !== 'idle' && status === 'idle' && !error) {
       // Just completed successfully
-      const lastAgent = ui.filter(e => e.type === 'agent').pop()
+      const lastAgent = cleanUI.filter(e => e.type === 'agent').pop()
       if (lastAgent && 'content' in lastAgent) {
         onComplete?.(lastAgent.content)
       }
     }
 
     prevStatusRef.current = status
-  }, [status, ui, error, onComplete])
+  }, [status, cleanUI, error, onComplete])
 
   // Handle errors
   useEffect(() => {
@@ -231,8 +239,8 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
 
   // Extract pending states from UI
   const { pendingAskUser, pendingApproval, pendingOnboard, pendingUlwTurnsReached, pendingPlanReview } = useMemo(
-    () => extractPendingStates(ui),
-    [ui]
+    () => extractPendingStates(cleanUI),
+    [cleanUI]
   )
 
   // Send message
@@ -282,7 +290,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   }, [reset])
 
   // isConnected: SDK doesn't track this directly, infer from status
-  const isConnected = status !== 'idle' || ui.length > 0
+  const isConnected = status !== 'idle' || cleanUI.length > 0
 
   // Build currentSession for compatibility with page.tsx
   const currentSession: CurrentSession | null = sessionId
@@ -290,7 +298,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     : null
 
   return {
-    ui,
+    ui: cleanUI,
     isConnected,
     isLoading: isProcessing,
     elapsedTime,
@@ -302,7 +310,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     sessionState: connectionState === 'reconnecting' ? 'reconnecting' as const
       : connectionState === 'connected' || isProcessing ? 'active' as const
       : serverSessionAlive ? 'disconnected' as const
-      : ui.length > 0 ? 'connected' as const
+      : cleanUI.length > 0 ? 'connected' as const
       : 'idle' as const,
     currentSession,
     mode: mode || 'safe',

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -1,6 +1,12 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { UI } from '@/components/chat/types'
+import { dedupeUI } from '@/components/chat/dedupe-ui'
+import {
+  isStorageQuotaError,
+  prepareMinimalPersistedChatState,
+  preparePersistedChatState,
+} from './persistence'
 
 export interface Conversation {
   sessionId: string       // Primary key (UUID from SDK/server)
@@ -96,9 +102,10 @@ export const useChatStore = create<ChatStore>()(
       },
 
       updateUI: (sessionId, ui) => {
+        const cleanUI = dedupeUI(ui)
         set(state => ({
           conversations: state.conversations.map(c =>
-            c.sessionId === sessionId ? { ...c, ui } : c
+            c.sessionId === sessionId ? { ...c, ui: cleanUI } : c
           ),
         }))
       },
@@ -156,11 +163,19 @@ export const useChatStore = create<ChatStore>()(
         getItem: (name) => {
           const str = localStorage.getItem(name)
           if (!str) return null
-          const parsed = JSON.parse(str)
+          let parsed
+          try {
+            parsed = preparePersistedChatState(JSON.parse(str))
+          } catch (error) {
+            console.warn('[oo-chat] Dropping unreadable persisted chat state', error)
+            localStorage.removeItem(name)
+            return null
+          }
           // Restore Date objects
           if (parsed.state?.conversations) {
             parsed.state.conversations = parsed.state.conversations.map((c: Conversation) => ({
               ...c,
+              ui: dedupeUI(c.ui),
               createdAt: new Date(c.createdAt),
             }))
           }
@@ -174,7 +189,21 @@ export const useChatStore = create<ChatStore>()(
           return parsed
         },
         setItem: (name, value) => {
-          localStorage.setItem(name, JSON.stringify(value))
+          const prepared = preparePersistedChatState(value)
+          try {
+            localStorage.setItem(name, JSON.stringify(prepared))
+          } catch (error) {
+            if (!isStorageQuotaError(error)) throw error
+
+            const fallback = prepareMinimalPersistedChatState(value)
+            try {
+              localStorage.removeItem(name)
+              localStorage.setItem(name, JSON.stringify(fallback))
+            } catch (retryError) {
+              console.warn('[oo-chat] Unable to persist chat state after quota fallback', retryError)
+              localStorage.removeItem(name)
+            }
+          }
         },
         removeItem: (name) => {
           localStorage.removeItem(name)

--- a/store/persistence.ts
+++ b/store/persistence.ts
@@ -1,0 +1,105 @@
+const MAX_PERSISTED_IMAGE_LENGTH = 8192
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function shouldPersistImage(image: unknown): image is string {
+  return (
+    typeof image === 'string' &&
+    !image.startsWith('data:') &&
+    image.length <= MAX_PERSISTED_IMAGE_LENGTH
+  )
+}
+
+function sanitizeFiles(value: unknown): unknown {
+  if (!Array.isArray(value)) return value
+
+  return value
+    .filter(isRecord)
+    .map(file => {
+      const next = { ...file }
+      if (typeof next.dataUrl === 'string' && next.dataUrl.startsWith('data:')) {
+        delete next.dataUrl
+      }
+      return next
+    })
+}
+
+function sanitizeUIItemForPersistence(item: unknown): unknown {
+  if (!isRecord(item)) return item
+
+  const next = { ...item }
+
+  if (Array.isArray(next.images)) {
+    const images = next.images.filter(shouldPersistImage)
+    if (images.length > 0) {
+      next.images = images
+    } else {
+      delete next.images
+    }
+  }
+
+  if (Array.isArray(next.files)) {
+    next.files = sanitizeFiles(next.files)
+  }
+
+  return next
+}
+
+function sanitizeConversationForPersistence(conversation: unknown, dropUI: boolean): unknown {
+  if (!isRecord(conversation)) return conversation
+
+  return {
+    ...conversation,
+    ui: dropUI
+      ? []
+      : Array.isArray(conversation.ui)
+        ? conversation.ui.map(sanitizeUIItemForPersistence)
+        : [],
+  }
+}
+
+function sanitizeStateForPersistence(state: unknown, dropUI = false): unknown {
+  if (!isRecord(state)) return state
+
+  return {
+    ...state,
+    conversations: Array.isArray(state.conversations)
+      ? state.conversations.map(conversation => sanitizeConversationForPersistence(conversation, dropUI))
+      : state.conversations,
+  }
+}
+
+export function preparePersistedChatState<T>(value: T): T {
+  if (!isRecord(value)) return value
+
+  if (isRecord(value.state)) {
+    return {
+      ...value,
+      state: sanitizeStateForPersistence(value.state),
+    } as T
+  }
+
+  return sanitizeStateForPersistence(value) as T
+}
+
+export function prepareMinimalPersistedChatState<T>(value: T): T {
+  if (!isRecord(value)) return value
+
+  if (isRecord(value.state)) {
+    return {
+      ...value,
+      state: sanitizeStateForPersistence(value.state, true),
+    } as T
+  }
+
+  return sanitizeStateForPersistence(value, true) as T
+}
+
+export function isStorageQuotaError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED')
+  )
+}


### PR DESCRIPTION
## Summary
- render remote-login screenshots as standalone readable chat items
- add structured credential ask-user rendering for account/password prompts
- dedupe and sanitize replayed UI items, and prevent screenshot data URLs from overflowing localStorage

## Validation
- npm run build
- Playwright load of the affected localhost session with zero console errors