### PR TITLE
docs: document the oo-chat ↔ connectonion-ts data flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-oo-chat is an open-source chat client for AI agents built with Next.js 16. It supports two connection modes:
-- **Remote Agent**: Connect to deployed ConnectOnion agents via URL
-- **Direct LLM**: Use LLM APIs directly with managed (co/) or provider API keys
+oo-chat is an open-source web chat client for ConnectOnion agents, built with Next.js 16.
+You connect to an agent by its `0x…` address; the live conversation runs over a WebSocket
+through the `connectonion` TypeScript SDK (`../connectonion-ts`). oo-chat is a thin front end —
+routing, layout, and rendering the SDK's streamed event list — while the SDK owns the agent
+connection, the protocol, and per-session persistence.
+
+There is one connection path: **remote agent over WebSocket via the SDK**. The "modes" in the
+UI (`safe` / `plan` / `accept_edits` / `ulw`) are trust/approval levels, not connection types.
+(An older HTTP "Direct LLM" mode was removed; `app/api/chat/route.ts` is dead code.)
 
 Part of the ConnectOnion platform ecosystem.
+
+**Read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full data flow** and
+[`docs/DEPLOY.md`](docs/DEPLOY.md) for the SDK-publish → Vercel pipeline.
 
 ## Development Commands
 
@@ -23,50 +32,71 @@ npm start        # Run production build
 
 ```
 app/
-├── page.tsx           # Main chat UI with conversation management and settings
-├── layout.tsx         # Root layout with Inter font
-├── globals.css        # Tailwind CSS styles
-└── api/chat/route.ts  # API route handling both agent and LLM connections
+├── page.tsx                        # Agent picker / welcome (paste 0x address)
+├── [address]/page.tsx              # Agent landing: profile + first message
+├── [address]/[sessionId]/page.tsx  # Live chat session (the core page)
+├── settings/page.tsx               # Identity, recovery phrase, credits, agents
+├── layout.tsx                      # Root layout
+├── globals.css                     # Tailwind CSS styles
+└── api/
+    ├── auth/route.ts               # CORS proxy → oo.openonion.ai auth (live)
+    └── chat/route.ts               # legacy/unused — see ARCHITECTURE §10
 
-components/chat/       # Reusable chat component library
-├── chat.tsx           # Main Chat component
-├── chat-input.tsx     # Message input with keyboard shortcuts
-├── chat-message.tsx   # Individual message display
-├── chat-messages.tsx  # Message list container
-├── chat-empty-state.tsx # Welcome screen with suggestions
-├── chat-typing.tsx    # Loading indicator
-├── use-chat.ts        # Chat state management hook
-├── types.ts           # TypeScript interfaces
-└── index.ts           # Barrel exports
+components/chat/
+├── use-agent-sdk.ts                # Wraps SDK useAgentForHuman; extracts pending states
+├── chat.tsx                        # Main Chat component
+├── chat-input.tsx                  # Message input (+ SDK useVoiceInput)
+├── chat-messages.tsx               # Switches ChatItem.type → message component
+├── messages/                       # Per-event renderers (agent, tool-call, ask-user, …)
+├── types.ts                        # UI/ChatItem + Pending* type definitions
+└── index.ts                        # Barrel exports
+
+hooks/use-identity.ts               # BIP39→Ed25519 user keypair + auth
+hooks/use-agent-info.ts             # Wraps SDK fetchAgentInfo (30s polling)
+store/chat-store.ts                 # Sidebar conversation INDEX (not the transcript)
 ```
 
 ### Key Patterns
 
-**Connection Modes** (`app/page.tsx`):
-- Agent mode: POST to `{agentUrl}/input` with `{ prompt: message }`
-- LLM mode: Uses `connectonion` SDK's `createLLM()` for chat completions
+**Live chat** (`app/[address]/[sessionId]/page.tsx` → `components/chat/use-agent-sdk.ts`):
+- `useAgentForHuman(address, sessionId)` (from `connectonion/react`) opens a WebSocket
+  to the relay and returns `ui: ChatItem[]` plus `send`/`sendMessage`/`setMode`/`reconnect`.
+- `use-agent-sdk.ts` derives the `pending*` interaction cards (ask_user, approval, plan,
+  onboard, ULW) from the event stream and the connection/session state.
 
-**Chat Hook** (`components/chat/use-chat.ts`):
-- Manages messages state and loading
-- `onSend` callback handles actual API communication
-- Returns `{ messages, isLoading, send, setMessages, clear }`
+**Index vs transcript** (intentional split):
+- `store/chat-store.ts` (zustand `persist`, `localStorage['oo-chat-storage']`) holds only the
+  sidebar index (`{sessionId, title, agentAddress, createdAt}`), `agents[]`, the JWT, and the
+  user profile. **No transcript, no images.**
+- The transcript's single source of truth is the SDK's per-session store
+  (`localStorage['co:agent:{address}:session:{id}']`), capped at 20 sessions and
+  base64-sanitized by the SDK.
 
-**Path Alias**: `@/*` maps to project root
+**Identity** (`hooks/use-identity.ts`): BIP39 mnemonic → Ed25519 keypair (tweetnacl) in
+`localStorage['connectonion_keys']`; signs an auth message → `/api/auth` → JWT.
+
+**Path Alias**: `@/*` maps to project root.
 
 ## Environment Variables
 
 ```bash
-NEXT_PUBLIC_DEFAULT_AGENT_URL  # Pre-configured agent URL (optional)
-OPENAI_API_KEY                  # For direct LLM mode
-ANTHROPIC_API_KEY               # For direct LLM mode
-GEMINI_API_KEY                  # For direct LLM mode
+NEXT_PUBLIC_OPENONION_API_URL   # Auth/profile backend (default https://oo.openonion.ai)
 ```
+
+The relay (`wss://oo.openonion.ai`) is an SDK default (`ConnectOptions.relayUrl`), not an
+oo-chat env var. The `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` /
+`NEXT_PUBLIC_DEFAULT_AGENT_URL` entries in `.env.example` belong to the removed Direct LLM mode
+and are unused.
 
 ## Dependencies
 
-- `connectonion`: Local TypeScript SDK (`file:../connectonion-ts`) for LLM abstraction
-- `react-icons`: UI icons (HiOutline* from Heroicons)
-- `clsx` + `tailwind-merge`: Conditional class utilities
+- `connectonion`: the TypeScript SDK — agent connection, WebSocket protocol, session
+  persistence, `useAgentForHuman`, `fetchAgentInfo`, `useVoiceInput`. Pinned by semver
+  (`^0.1.x`) for production; symlinked to `../connectonion-ts` for local dev (see DEPLOY.md).
+- `zustand`: state + localStorage persistence (sidebar index, SDK session store).
+- `bip39` + `tweetnacl`: browser BIP39/Ed25519 user identity.
+- `react-icons`: UI icons. `clsx` + `tailwind-merge`: conditional classes.
+- `react-markdown` + `remark-gfm` + `react-syntax-highlighter`: message rendering.
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,100 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# oo-chat
 
-## Getting Started
+An open-source web chat client for [ConnectOnion](https://docs.connectonion.com)
+agents, built with Next.js 16. Paste an agent's `0x…` address and chat with it —
+streamed tool calls, approvals, plan reviews, and autonomous "ultra-long work" runs
+included.
 
-First, run the development server:
+oo-chat is a thin front end: the heavy lifting (connecting to an agent, the
+WebSocket protocol, streaming, and per-session persistence) lives in the
+`connectonion` TypeScript SDK ([`../connectonion-ts`](https://github.com/openonion/connectonion-ts)).
+oo-chat handles routing, layout, and rendering the SDK's event stream.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## How it works (30-second version)
+
+```
+You paste 0x…  →  /[address] (agent profile)  →  /[address]/[sessionId] (live chat)
+                                                          │
+                            useAgentForHuman(address, sessionId)   ← connectonion/react SDK
+                                                          │
+                            WebSocket → wss://oo.openonion.ai (relay) → the remote agent
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+- **User identity** is a BIP39 mnemonic → Ed25519 keypair generated in your browser
+  (`localStorage['connectonion_keys']`), authenticated against `oo.openonion.ai`.
+- **Agents** are addressed by their `0x…` public key; profile + online status come
+  from the relay (`fetchAgentInfo`).
+- **Transcripts** are persisted by the SDK per session
+  (`localStorage['co:agent:{address}:session:{id}']`); the sidebar store only keeps a
+  lightweight conversation index.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+📖 **Full data-flow walkthrough: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).**
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Getting started
 
-## Learn More
+```bash
+npm install
+npm run dev          # http://localhost:3000
+```
 
-To learn more about Next.js, take a look at the following resources:
+Open the app, paste an agent address, and start chatting. A user identity (recovery
+phrase) is generated automatically on first load — back it up from **Settings**.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+### Environment
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+The app reads a single env var (optional):
 
-## Deploy on Vercel
+```bash
+NEXT_PUBLIC_OPENONION_API_URL=https://oo.openonion.ai   # auth/profile backend (default)
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The relay (`wss://oo.openonion.ai`) is an SDK default and not configured here. See
+`.env.example`.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Scripts
+
+```bash
+npm run dev      # dev server (localhost:3000)
+npm run build    # production build (what Vercel runs)
+npm run lint     # ESLint
+npm start        # serve the production build
+```
+
+## Project layout
+
+```
+app/
+├── page.tsx                       # agent picker / welcome
+├── [address]/page.tsx             # agent landing (profile + first message)
+├── [address]/[sessionId]/page.tsx # live chat session
+├── settings/page.tsx              # identity, credits, agents
+└── api/
+    ├── auth/route.ts              # CORS proxy → oo.openonion.ai auth
+    └── chat/route.ts              # legacy/unused (see ARCHITECTURE §10)
+
+components/chat/                   # chat UI: use-agent-sdk.ts + message renderers
+hooks/                            # use-identity, use-agent-info
+store/chat-store.ts               # sidebar conversation index (zustand + persist)
+docs/                             # ARCHITECTURE.md, DEPLOY.md
+```
+
+## The SDK
+
+`connectonion` is a separate package. For local development `node_modules/connectonion`
+is symlinked to `../connectonion-ts`; production builds use the published npm version
+pinned in `package.json`. Publishing the SDK and shipping oo-chat is documented in
+[`docs/DEPLOY.md`](docs/DEPLOY.md).
+
+## Related projects
+
+- [`../connectonion-ts`](https://github.com/openonion/connectonion-ts) — the
+  TypeScript SDK (`connectonion` on npm): `useAgentForHuman`, `RemoteAgent`, the
+  WebSocket protocol, session persistence.
+- `../chat-ui` (`@connectonion/chat-ui`) — source registry for the chat components.
+  When fixing design issues in `components/chat/`, mirror the change into
+  `../chat-ui/registry/` to keep them in sync.
+
+## Deploy
+
+Hosted on Vercel (project `oo-chat`). Push a branch for a preview deploy; merge to
+`main` for production. See [`docs/DEPLOY.md`](docs/DEPLOY.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,428 @@
+# oo-chat Architecture & Data Flow
+
+How oo-chat talks to ConnectOnion agents, end to end. This is the map for "where
+does this data come from and where does it go."
+
+oo-chat is a thin, stateless-on-the-server Next.js front end. **Almost all of the
+real work — connecting to an agent, streaming the conversation, persisting the
+transcript — lives in the `connectonion` TypeScript SDK** (`connectonion-ts`).
+oo-chat is mostly routing, layout, and rendering the SDK's event stream.
+
+---
+
+## 1. The big picture
+
+```
+┌──────────────────────────── Browser (oo-chat, Next.js client) ───────────────────────────┐
+│                                                                                            │
+│   app/page.tsx ──▶ app/[address]/page.tsx ──▶ app/[address]/[sessionId]/page.tsx           │
+│   (pick agent)      (agent profile)            (live chat)                                  │
+│                                                     │                                       │
+│                                                     ▼                                       │
+│                                          components/chat/use-agent-sdk.ts                   │
+│                                          (thin wrapper / pending-state extractor)           │
+│                                                     │                                       │
+│                                                     ▼                                       │
+│   ┌──────────────────────── connectonion/react (the SDK) ─────────────────────────────┐    │
+│   │  useAgentForHuman(address, sessionId)                                              │    │
+│   │    • zustand session store  ──────────▶ localStorage: co:agent:{addr}:session:{id} │    │
+│   │    • agent-cache (≤6 live sockets)                                                  │    │
+│   │    • RemoteAgent ── WebSocket ───────────────────────────────┐                     │    │
+│   └──────────────────────────────────────────────────────────────┼─────────────────────┘  │
+│                                                                    │                        │
+│   hooks/use-identity.ts ── /api/auth (proxy) ──┐                   │                        │
+│   hooks/use-agent-info.ts ── fetchAgentInfo ───┼──── HTTPS ────────┼─────┐                  │
+│   store/chat-store.ts ──▶ localStorage: oo-chat-storage            │     │                  │
+│   use-identity ─────────▶ localStorage: connectonion_keys          │     │                  │
+└────────────────────────────────────────────────────────────────────┼─────┼──────────────────┘
+                                                                       │     │
+                          wss://oo.openonion.ai (relay)  ◀─────────────┘     │ https://oo.openonion.ai
+                                     │                                       │  • /api/v1/auth, /auth/me
+                                     │                                       │  • /api/relay/agents/{addr}
+                                     ▼                                       ▼
+                          ┌──────────────────────┐                 ┌──────────────────┐
+                          │  ConnectOnion Relay   │                 │   oo-api backend │
+                          │  (oo.openonion.ai)    │                 │  (auth, profile, │
+                          │  routes WS to agent   │                 │   credits, LLM)  │
+                          └───────────┬──────────┘                 └──────────────────┘
+                                      │  (or direct: https://{name}-{addr}.agents.openonion.ai)
+                                      ▼
+                          ┌──────────────────────┐
+                          │   Remote Agent        │  (a deployed ConnectOnion agent)
+                          │   streams the run     │
+                          └──────────────────────┘
+```
+
+The only "modes" today are about *trust/approval* (`safe` / `plan` / `accept_edits`
+/ `ulw`), not about *connection type*. **There is exactly one connection path:
+remote agent over WebSocket via the SDK.** (The old "Direct LLM" mode is gone — see
+[§10](#10-legacy--dead-code).)
+
+---
+
+## 2. The moving parts
+
+| Piece | Where | Role |
+|-------|-------|------|
+| **oo-chat client** | this repo (`app/`, `components/`, `hooks/`, `store/`) | UI, routing, rendering the SDK event stream |
+| **`connectonion` SDK** | `../connectonion-ts` (npm `connectonion`, symlinked for dev) | The actual agent connection, WebSocket protocol, session persistence |
+| **Next.js API routes** | `app/api/auth`, `app/api/chat` | `/api/auth` is a CORS proxy to oo-api; `/api/chat` is legacy/unused |
+| **Relay** | `wss://oo.openonion.ai` | Routes WebSocket traffic between the browser and a (possibly NAT'd) agent |
+| **oo-api backend** | `https://oo.openonion.ai` | Auth (JWT), agent registry/profile, credits, managed `co/` LLM gateway |
+| **Remote agent** | `https://{name}-{addr}.agents.openonion.ai` or relay-routed | The deployed ConnectOnion agent that actually runs the task |
+
+Two identities are in play; don't confuse them:
+
+- **User identity** — the human using oo-chat. A BIP39 mnemonic → Ed25519 keypair
+  generated in the browser (`hooks/use-identity.ts`), stored in
+  `localStorage['connectonion_keys']`. Its `0x…` public key is the user's account
+  with oo-api (credits, auth).
+- **Agent address** — the `0x…` public key of the agent you're chatting with. This
+  is what you paste into oo-chat and what appears in the URL (`/[address]`).
+
+---
+
+## 3. Identity & auth
+
+`hooks/use-identity.ts` runs on every page (`useIdentity()`), and owns the user's
+keypair + session token.
+
+```
+mount
+  └─ loadBrowser()  → localStorage['connectonion_keys']
+        │ found?  ── yes ──▶ use it
+        └─ no  ──▶ bip39.generateMnemonic() ──▶ Ed25519 keypair (tweetnacl)
+                    └─ saveBrowser() + show recovery phrase modal
+  └─ authenticate(keys):
+        sign "ConnectOnion-Auth-{address}-{ts}"
+          └─ POST /api/auth  ──proxy──▶  POST oo.openonion.ai/api/v1/auth
+                └─ { token }                     (JWT)
+                     └─ chat-store.setApiKey(token)        // persisted
+        GET /api/auth (Bearer token)
+          └──proxy──▶ GET oo.openonion.ai/api/v1/auth/me
+                └─ { public_key, credits_usd, balance_usd, … }
+                     └─ chat-store.setUserProfile(profile)  // persisted
+```
+
+`app/api/auth/route.ts` exists only to dodge browser CORS — it forwards to
+`NEXT_PUBLIC_OPENONION_API_URL` (default `https://oo.openonion.ai`) and returns the
+response verbatim. The JWT (`openonionApiKey`) is later used for credit-metered
+features like voice transcription and the managed `co/` LLM gateway.
+
+Identity can be exported/imported/regenerated from `app/settings/page.tsx`
+(12/24-word mnemonic, or a 128-hex private key).
+
+---
+
+## 4. Routing & navigation
+
+Three client routes, all wrapped in `ChatLayout` (sidebar + main pane):
+
+```
+/                          app/page.tsx
+  • No agents → welcome + "paste 0x address" form
+  • Has agents → picker grid (name + online dot from useAgentInfo)
+  • Pick/add agent ──▶ router.push(`/${address}`)
+
+/[address]                 app/[address]/page.tsx
+  • Agent landing: profile from useAgentInfo (name, model, trust, version,
+    skills as /slash-commands, tools, accepted inputs)
+  • Send first message:
+        sessionId = crypto.randomUUID()
+        chat-store.createConversation(sessionId, address)
+        chat-store.setPendingMessage(content)
+        router.push(`/${address}/${sessionId}?mode=…&turns=…`)
+
+/[address]/[sessionId]     app/[address]/[sessionId]/page.tsx
+  • The live chat. useAgentSDK({ agentAddress, sessionId }).
+  • On mount: apply ?mode from URL, then consumePendingMessage() and send().
+  • Streams ChatItem[] → <Chat> renders them.
+  • Syncs sidebar title to the first user message.
+  • If store hydrated and no conversation + no transcript → redirect to /[address].
+```
+
+The first message is deliberately handed off through `pendingMessage` in the store:
+the landing page mints the session and navigates, and the session page actually
+opens the socket and sends. This keeps the URL shareable (one URL = one session).
+
+---
+
+## 5. Agent discovery & profile
+
+`hooks/use-agent-info.ts` wraps the SDK's `fetchAgentInfo(address)` and polls every
+30s (and on tab focus), deduping by value so unchanged data doesn't re-render.
+
+`fetchAgentInfo` (SDK, `src/connect/endpoint.ts`):
+
+```
+GET https://oo.openonion.ai/api/relay/agents/{address}
+  └─ { endpoints[], relay, last_seen, profile{ name|alias, model, trust,
+                                                version, tools[], skills[],
+                                                accepted_inputs } }
+  • online = Boolean(relay)        // true only while the agent holds a live
+                                    //   announce connection to the relay
+  • for each endpoint (localhost > private > public):
+        GET {endpoint}/info  → if info.address === address, merge as fresher profile
+```
+
+Result (`AgentInfo`): `{ address, name?, model?, trust?, version?, tools?, skills?,
+accepted_inputs?, online }`. This drives the picker dots, the landing hero, the
+skill palette, and the "accepts text/images/files" line.
+
+---
+
+## 6. The live chat connection (the core)
+
+This is the heart of the data flow. oo-chat's `use-agent-sdk.ts` is a thin wrapper;
+the SDK's `useAgentForHuman(address, sessionId)` does the work.
+
+### 6.1 Layers
+
+```
+app/[address]/[sessionId]/page.tsx
+   │  send(text, images?, files?) / respondToAskUser / respondToApproval / setMode / reconnect
+   ▼
+components/chat/use-agent-sdk.ts            ← oo-chat
+   • dedupeUI(ui)                            (collapses duplicate stream items)
+   • extractPendingStates(ui)                (derives the "waiting" cards, see §6.5)
+   • derives sessionState, isLoading, elapsedTime
+   ▼
+connectonion/react · useAgentForHuman        ← SDK
+   • zustand store per (address, sessionId)  → localStorage co:agent:{addr}:session:{id}
+   • agent-cache: reuse a live RemoteAgent (≤6, LRU) across session switches
+   ▼
+connectonion · RemoteAgent                   ← SDK
+   • opens/keeps the WebSocket, signs CONNECT, maps frames → ChatItem[]
+   ▼
+WebSocket  wss://oo.openonion.ai  (relay)  →  remote agent
+```
+
+### 6.2 Connection lifecycle
+
+```
+input(prompt)                       // fire-and-forget; UI updates via callbacks
+  │ append user ChatItem, status = 'working'
+  ▼
+_ensureConnected()
+  │ open WebSocket, send CONNECT { payload, from, signature, session_id?, to }   (Ed25519, 30s deadline)
+  │
+  ├── CONNECTED { session_id, status, session?, chat_items? }
+  │       status='connected' → idle (ready)      status='running' → keep waiting for live events
+  │
+  └── ONBOARD_REQUIRED { methods, paymentAmount? }      // trust gate for a stranger
+          → user submits invite code / payment → ONBOARD_SUBMIT (signed) → ONBOARD_SUCCESS → CONNECTED
+  ▼
+send INPUT { input_id, prompt, images?, files? }
+  ▼
+… stream of frames (thinking / tool_call / tool_result / ask_user / …) → ChatItem[] …
+  ▼
+OUTPUT { result, session?, chat_items? }   → status = 'idle'; conversation settled
+```
+
+### 6.3 Inbound frames (server → client) → ChatItem
+
+The SDK maps each WebSocket frame to a `ChatItem` (the discriminated union the UI
+renders). The important ones:
+
+| Frame | Becomes / does | Status |
+|-------|----------------|--------|
+| `CONNECTED` | resolve connect; sync session/transcript | →idle or waiting |
+| `llm_call` / `llm_result` | `thinking` item (running → done, with tokens/cost) | →working |
+| `thinking` | `thinking` item (done) | — |
+| `assistant` / `agent_image` | `agent` item (markdown / images) | — |
+| `tool_call` / `tool_result` | `tool_call` item (running → done, with result) | →working |
+| `tool_blocked` | `tool_blocked` item | — |
+| `intent` / `eval` / `compact` | `intent` / `eval` / `compact` items | — |
+| `files_received` | `files_received` item | — |
+| `ask_user` | `ask_user` item | **→waiting** |
+| `approval_needed` | `approval_needed` item | **→waiting** |
+| `plan_review` | `plan_review` item | **→waiting** |
+| `onboard_required` | `onboard_required` item | **→waiting** |
+| `ulw_turns_reached` | `ulw_turns_reached` item | **→waiting** |
+| `OUTPUT` | settle the turn | **→idle** |
+| `ERROR` | set error, close socket | →idle / disconnected |
+| `PING` | reply `PONG` (keepalive) | — |
+| `session_sync` / `mode_changed` / `SESSION_STATUS` | update session/mode/status | — |
+
+### 6.4 Outbound messages (client → server)
+
+`send()` → `input()`; everything else goes through `sendMessage(...)`:
+
+| Message | Sent when | Shape (key fields) |
+|---------|-----------|--------------------|
+| `CONNECT` | first connect | `{ payload, from, signature, session_id?, to }` (Ed25519) |
+| `INPUT` | user sends a prompt | `{ input_id, prompt, images?, files? }` |
+| `ASK_USER_RESPONSE` | answer an `ask_user` | `{ answer }` |
+| `APPROVAL_RESPONSE` | approve/reject a tool | `{ approved, scope: 'once'\|'session', mode?, feedback? }` |
+| `PLAN_REVIEW_RESPONSE` | respond to a plan | `{ message }` |
+| `ULW_RESPONSE` | continue at a ULW checkpoint | `{ action: 'continue'\|'switch_mode', turns?, mode? }` |
+| `ONBOARD_SUBMIT` | submit onboarding | signed `{ payload, from, signature, … }` |
+| `mode_change` | switch approval mode | `{ mode, turns? }` |
+| `SESSION_STATUS` | poll if a session is alive | `{ session: { session_id } }` |
+| `PONG` | answer a `PING` | `{ }` |
+
+### 6.5 Approval modes & interactive gates
+
+**Approval mode** (`ApprovalMode = 'safe' | 'plan' | 'accept_edits' | 'ulw'`) is the
+trust level for the run. It's seeded from the URL (`?mode=…&turns=N`, set on the
+landing page) and can be changed live via `ModeStatusBar` → `setMode()` → the SDK
+(which optimistically updates local state and sends `mode_change`).
+
+- `safe` — ask before edits/commands (default)
+- `plan` — research first, present a plan for approval
+- `accept_edits` — edit without asking
+- `ulw` — "ultra-long work": run autonomously for `N` turns, then pause at a checkpoint
+
+**Interactive gates** are frames that put the run into `status = 'waiting'`. The SDK
+emits a ChatItem; oo-chat's `extractPendingStates()` turns the *latest unanswered*
+one into a `pending*` object that `[sessionId]/page.tsx` passes to `<Chat>`, which
+renders the matching card. The user's answer goes back out as the matching message
+above:
+
+| Gate (ChatItem) | oo-chat pending state | Response message |
+|-----------------|-----------------------|------------------|
+| `ask_user` | `pendingAskUser` | `ASK_USER_RESPONSE` |
+| `approval_needed` | `pendingApproval` | `APPROVAL_RESPONSE` |
+| `plan_review` | `pendingPlanReview` | `PLAN_REVIEW_RESPONSE` |
+| `onboard_required` | `pendingOnboard` | `ONBOARD_SUBMIT` |
+| `ulw_turns_reached` | `pendingUlwTurnsReached` | `ULW_RESPONSE` |
+
+---
+
+## 7. The event/UI model: ChatItem → component
+
+The SDK's `ui: ChatItem[]` is the single ordered stream the UI renders. `ChatItem`
+is a discriminated union on `type` (mirrored in `components/chat/types.ts` as `UI`):
+
+```
+user · agent · thinking · tool_call · ask_user · approval_needed ·
+onboard_required · onboard_success · intent · eval · compact ·
+tool_blocked · ulw_turns_reached · plan_review · files_received
+```
+
+`components/chat/chat-messages.tsx` switches on `item.type` and renders the matching
+component from `components/chat/messages/`:
+
+```
+user            → messages/user.tsx          (markdown + images + files)
+agent           → messages/agent.tsx         (markdown + images)
+thinking        → messages/thinking.tsx      (collapsible)
+tool_call       → messages/tool-call.tsx     ──┐ dispatches by tool name:
+                                                ├ bash/shell/run  → BashCard
+                                                ├ write/read      → FileCard
+                                                ├ edit            → FileDiffCard
+                                                ├ grep/glob/find  → GrepCard
+                                                ├ ask_user        → LoginCard (fields) / AskUserCard
+                                                ├ exit_plan_…     → PlanCard
+                                                └ default         → GenericCard
+intent/eval/compact/tool_blocked/files_received/onboard_*  → their messages/*.tsx
+ulw_turns_reached → chat-ulw-checkpoint.tsx  (interactive)
+```
+
+`approval_needed` and `plan_review` are rendered *inline* on the related `tool_call`
+card rather than as standalone rows.
+
+---
+
+## 8. State & persistence
+
+Three independent `localStorage` namespaces. The split is deliberate — the
+**transcript has exactly one owner (the SDK)**, and the sidebar only keeps an index.
+
+| localStorage key | Owner | Holds | Notes |
+|------------------|-------|-------|-------|
+| `connectonion_keys` | `hooks/use-identity.ts` | user keypair + mnemonic | the user's identity |
+| `oo-chat-storage` | `store/chat-store.ts` (zustand `persist`) | conversation **index**, `agents[]`, JWT, user profile, `activeSessionId` | **no transcript, no images** |
+| `co:agent:{address}:session:{id}` | SDK `useAgentForHuman` (zustand) | the **transcript** (`ui`/`messages`/`session`) | one key per session |
+
+### 8.1 Index vs transcript
+
+`chat-store.ts` stores a `Conversation` as `{ sessionId, title, agentAddress,
+createdAt }` — just enough to render the sidebar. The actual messages live only in
+the SDK's per-session store. On reload, the SDK store hydrates synchronously from
+localStorage, so the transcript is already present when `[sessionId]/page.tsx`
+mounts — no refetch needed for display. (Older builds kept a second `ui` copy inside
+`chat-store`; that's now stripped on read as a migration.)
+
+### 8.2 SDK-side persistence (in `connectonion-ts`)
+
+- **`sanitizeForPersistence`** — before writing, strips base64 data URLs (inline
+  images, file `dataUrl`s) so a single conversation can't blow the ~5MB origin quota.
+  http(s) image URLs are kept.
+- **Session cap** — `MAX_PERSISTED_SESSIONS = 20`. On store open, `pruneOldSessions`
+  keeps the 20 most-recently-updated `co:agent:*:session:*` keys and drops the rest.
+  The server is the source of truth, so a pruned session re-fetches when reopened.
+- **Agent cache** — `MAX_LIVE_AGENTS = 6`. Live `RemoteAgent` WebSocket connections
+  are kept in an LRU cache so switching between recent sessions doesn't tear down and
+  re-handshake the socket.
+
+---
+
+## 9. What oo-chat actually imports from the SDK
+
+| oo-chat file | Imports | Purpose |
+|--------------|---------|---------|
+| `components/chat/use-agent-sdk.ts` | `useAgentForHuman`, `ChatItem`, `ApprovalMode` (from `connectonion/react`) | the live chat hook |
+| `hooks/use-agent-info.ts` | `fetchAgentInfo`, `AgentInfo`, `SkillInfo`, `AgentAcceptedInputs` | agent profile/online polling |
+| `components/chat/chat-input.tsx` | `useVoiceInput` | voice record + transcription (uses the JWT) |
+| `components/sidebar.tsx` | `version` (from `connectonion/package.json`) | shows the SDK version |
+| `app/api/chat/route.ts` | `createLLM`, `connect`, `address` | **legacy route**, see §10 |
+
+oo-chat pins `connectonion` by semver (`^0.1.x`) for production/Vercel builds, and
+symlinks `node_modules/connectonion → ../connectonion-ts` for local development. See
+[DEPLOY.md](./DEPLOY.md) for how a change to the SDK reaches production.
+
+---
+
+## 10. Legacy / dead code
+
+- **`app/api/chat/route.ts`** — an older HTTP-POST chat route (agent-`/input`
+  signing + a `createLLM()` "Direct LLM" fallback). **Nothing calls it.** The current
+  UI talks to agents only through the SDK's WebSocket. Its file header still
+  references a removed `use-chat.ts` and a `connectionMode='llm'` `page.tsx`; treat
+  the header as historical. Kept (not deleted) to avoid churn; safe to remove if you
+  confirm no external caller.
+- **`.env.example` LLM keys** — `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
+  `GEMINI_API_KEY` and `NEXT_PUBLIC_DEFAULT_AGENT_URL` were for that removed mode and
+  are unused by the running app. The only env var the app reads is
+  `NEXT_PUBLIC_OPENONION_API_URL`.
+
+---
+
+## 11. Configuration & environment
+
+| Var | Default | Used by |
+|-----|---------|---------|
+| `NEXT_PUBLIC_OPENONION_API_URL` | `https://oo.openonion.ai` | `app/api/auth/route.ts` (auth proxy target) |
+
+Relay (`wss://oo.openonion.ai`) and the relay HTTP API
+(`https://oo.openonion.ai/api/relay/...`) are SDK defaults (`ConnectOptions.relayUrl`),
+not oo-chat env vars. `next.config.ts` is empty (Next.js 16 defaults; builds use
+Turbopack). `vercel.json` only sets `installCommand: npm install`.
+
+---
+
+## 12. One full round trip (worked example)
+
+1. User pastes `0x3d40…` on `/` → `/0x3d40…`. `useAgentInfo` shows the profile.
+2. User types "List the files here" → landing mints `sessionId`, stores the message,
+   navigates to `/0x3d40…/{sessionId}?mode=safe`.
+3. `[sessionId]` mounts → `useAgentForHuman` opens (or reuses) a WebSocket to
+   `wss://oo.openonion.ai`, sends a signed `CONNECT`, gets `CONNECTED`, then `INPUT`.
+4. Agent streams `intent` → `thinking` → `tool_call(bash: ls)` → `tool_result` →
+   `assistant`. Each frame becomes a `ChatItem`; the SDK persists to
+   `co:agent:0x3d40…:session:{id}`; oo-chat renders each row.
+5. The bash tool needs approval (mode `safe`): `approval_needed` → `status=waiting` →
+   oo-chat shows the approval card → user clicks Allow → `APPROVAL_RESPONSE` → run
+   resumes.
+6. `OUTPUT` settles the turn (`status=idle`). The sidebar title is set from the first
+   user message. Reloading the page rehydrates the transcript from localStorage; the
+   socket reconnects only if you send again or hit reconnect.
+
+---
+
+## See also
+
+- [`DEPLOY.md`](./DEPLOY.md) — publishing the SDK to npm and shipping oo-chat to Vercel.
+- `../connectonion-ts/src/connect/` — `RemoteAgent`, the WebSocket protocol, types.
+- `../connectonion-ts/src/react/` — `useAgentForHuman`, the session store, voice input.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,428 +1,115 @@
-# oo-chat Architecture & Data Flow
+# oo-chat — Architecture & Data Flow
 
-How oo-chat talks to ConnectOnion agents, end to end. This is the map for "where
-does this data come from and where does it go."
+oo-chat is a thin Next.js front end. The `connectonion` TypeScript SDK
+(`../connectonion-ts`) does the real work: connecting to an agent, the WebSocket
+protocol, and saving the transcript. oo-chat just routes, lays out, and renders the
+SDK's stream of events.
 
-oo-chat is a thin, stateless-on-the-server Next.js front end. **Almost all of the
-real work — connecting to an agent, streaming the conversation, persisting the
-transcript — lives in the `connectonion` TypeScript SDK** (`connectonion-ts`).
-oo-chat is mostly routing, layout, and rendering the SDK's event stream.
+## One picture
+
+```
+   Browser (oo-chat)                                   ConnectOnion
+ ┌───────────────────────────────┐
+ │  /            pick an agent    │
+ │  /[address]   agent profile    │      fetchAgentInfo
+ │  /[address]/[sessionId] ◀──────┼──── HTTPS ───▶  oo.openonion.ai
+ │        │  live chat            │                 (auth · profile · credits)
+ │        ▼                       │
+ │  useAgentForHuman()  ← the SDK │      WebSocket
+ │        │                       │ ───  wss://oo.openonion.ai ──▶  relay ──▶  the agent
+ └────────┼──────────────────────┘
+          ▼  localStorage
+   keypair · sidebar index · transcript
+```
+
+## The flow, start to finish
+
+1. You paste an agent's `0x…` address → the app shows its profile
+   (`fetchAgentInfo`, from the relay).
+2. You send a message → the app mints a `sessionId` and opens `/[address]/[sessionId]`.
+3. That page calls the SDK's `useAgentForHuman(address, sessionId)`, which opens a
+   WebSocket to the relay (`wss://oo.openonion.ai`) and sends your message.
+4. The agent streams back events — thinking, tool calls, results, questions. The SDK
+   turns each into a `ChatItem`; oo-chat renders each as a row.
+5. If the agent needs you (approve a command, answer a question, review a plan), the
+   run pauses and a card appears; your reply goes back over the same socket.
+6. When the turn ends, the SDK has already saved the transcript to localStorage.
+   Reload restores it instantly; the socket reconnects only when you send again.
+
+## Two ideas that explain the rest
+
+**1 · One connection path.** Everything is agent ↔ browser over a single WebSocket
+through the SDK. The "modes" (`safe` / `plan` / `accept_edits` / `ulw`) are *trust
+levels*, not connection types. (An old HTTP "Direct LLM" mode is gone —
+`app/api/chat/route.ts` is dead code.)
+
+**2 · Index vs transcript.** Two stores, on purpose — the transcript has exactly one
+owner (the SDK); the sidebar store just lists conversations:
+
+| localStorage key | Owner | Holds |
+|---|---|---|
+| `connectonion_keys` | `use-identity` | your keypair (BIP39 → Ed25519) |
+| `oo-chat-storage` | `chat-store` | sidebar index + agents + token — **no messages** |
+| `co:agent:{addr}:session:{id}` | the SDK | the actual transcript (capped at 20 sessions) |
+
+## Where things live
+
+| Path | Role |
+|---|---|
+| `app/page.tsx` | pick / add an agent |
+| `app/[address]/page.tsx` | agent profile + first message |
+| `app/[address]/[sessionId]/page.tsx` | the live chat |
+| `components/chat/use-agent-sdk.ts` | wraps the SDK hook; derives the "waiting" cards |
+| `components/chat/chat-messages.tsx` | `ChatItem.type` → message component |
+| `hooks/use-identity.ts` | your keypair + login |
+| `hooks/use-agent-info.ts` | agent profile + online status (polls every 30s) |
+| `store/chat-store.ts` | the sidebar index |
+| `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
+
+oo-chat imports `useAgentForHuman`, `fetchAgentInfo`, and `useVoiceInput` from the
+SDK. The SDK lives in `../connectonion-ts`; shipping it is in [DEPLOY.md](./DEPLOY.md).
+
+## Identity & login
+
+First load generates a recovery phrase → Ed25519 keypair (your account). The app
+signs a message, posts it to `/api/auth` (a proxy to `oo.openonion.ai`), and gets a
+JWT — used for credits, voice transcription, and the managed `co/` models. Back it up
+from **Settings**. The agent you chat with has its own `0x…` address; don't confuse
+the two.
+
+## Configuration
+
+One optional env var: `NEXT_PUBLIC_OPENONION_API_URL` (default `https://oo.openonion.ai`,
+the auth/profile backend). The relay URL is an SDK default. `next.config.ts` is empty.
 
 ---
 
-## 1. The big picture
-
-```
-┌──────────────────────────── Browser (oo-chat, Next.js client) ───────────────────────────┐
-│                                                                                            │
-│   app/page.tsx ──▶ app/[address]/page.tsx ──▶ app/[address]/[sessionId]/page.tsx           │
-│   (pick agent)      (agent profile)            (live chat)                                  │
-│                                                     │                                       │
-│                                                     ▼                                       │
-│                                          components/chat/use-agent-sdk.ts                   │
-│                                          (thin wrapper / pending-state extractor)           │
-│                                                     │                                       │
-│                                                     ▼                                       │
-│   ┌──────────────────────── connectonion/react (the SDK) ─────────────────────────────┐    │
-│   │  useAgentForHuman(address, sessionId)                                              │    │
-│   │    • zustand session store  ──────────▶ localStorage: co:agent:{addr}:session:{id} │    │
-│   │    • agent-cache (≤6 live sockets)                                                  │    │
-│   │    • RemoteAgent ── WebSocket ───────────────────────────────┐                     │    │
-│   └──────────────────────────────────────────────────────────────┼─────────────────────┘  │
-│                                                                    │                        │
-│   hooks/use-identity.ts ── /api/auth (proxy) ──┐                   │                        │
-│   hooks/use-agent-info.ts ── fetchAgentInfo ───┼──── HTTPS ────────┼─────┐                  │
-│   store/chat-store.ts ──▶ localStorage: oo-chat-storage            │     │                  │
-│   use-identity ─────────▶ localStorage: connectonion_keys          │     │                  │
-└────────────────────────────────────────────────────────────────────┼─────┼──────────────────┘
-                                                                       │     │
-                          wss://oo.openonion.ai (relay)  ◀─────────────┘     │ https://oo.openonion.ai
-                                     │                                       │  • /api/v1/auth, /auth/me
-                                     │                                       │  • /api/relay/agents/{addr}
-                                     ▼                                       ▼
-                          ┌──────────────────────┐                 ┌──────────────────┐
-                          │  ConnectOnion Relay   │                 │   oo-api backend │
-                          │  (oo.openonion.ai)    │                 │  (auth, profile, │
-                          │  routes WS to agent   │                 │   credits, LLM)  │
-                          └───────────┬──────────┘                 └──────────────────┘
-                                      │  (or direct: https://{name}-{addr}.agents.openonion.ai)
-                                      ▼
-                          ┌──────────────────────┐
-                          │   Remote Agent        │  (a deployed ConnectOnion agent)
-                          │   streams the run     │
-                          └──────────────────────┘
-```
-
-The only "modes" today are about *trust/approval* (`safe` / `plan` / `accept_edits`
-/ `ulw`), not about *connection type*. **There is exactly one connection path:
-remote agent over WebSocket via the SDK.** (The old "Direct LLM" mode is gone — see
-[§10](#10-legacy--dead-code).)
-
----
-
-## 2. The moving parts
-
-| Piece | Where | Role |
-|-------|-------|------|
-| **oo-chat client** | this repo (`app/`, `components/`, `hooks/`, `store/`) | UI, routing, rendering the SDK event stream |
-| **`connectonion` SDK** | `../connectonion-ts` (npm `connectonion`, symlinked for dev) | The actual agent connection, WebSocket protocol, session persistence |
-| **Next.js API routes** | `app/api/auth`, `app/api/chat` | `/api/auth` is a CORS proxy to oo-api; `/api/chat` is legacy/unused |
-| **Relay** | `wss://oo.openonion.ai` | Routes WebSocket traffic between the browser and a (possibly NAT'd) agent |
-| **oo-api backend** | `https://oo.openonion.ai` | Auth (JWT), agent registry/profile, credits, managed `co/` LLM gateway |
-| **Remote agent** | `https://{name}-{addr}.agents.openonion.ai` or relay-routed | The deployed ConnectOnion agent that actually runs the task |
-
-Two identities are in play; don't confuse them:
-
-- **User identity** — the human using oo-chat. A BIP39 mnemonic → Ed25519 keypair
-  generated in the browser (`hooks/use-identity.ts`), stored in
-  `localStorage['connectonion_keys']`. Its `0x…` public key is the user's account
-  with oo-api (credits, auth).
-- **Agent address** — the `0x…` public key of the agent you're chatting with. This
-  is what you paste into oo-chat and what appears in the URL (`/[address]`).
-
----
-
-## 3. Identity & auth
-
-`hooks/use-identity.ts` runs on every page (`useIdentity()`), and owns the user's
-keypair + session token.
-
-```
-mount
-  └─ loadBrowser()  → localStorage['connectonion_keys']
-        │ found?  ── yes ──▶ use it
-        └─ no  ──▶ bip39.generateMnemonic() ──▶ Ed25519 keypair (tweetnacl)
-                    └─ saveBrowser() + show recovery phrase modal
-  └─ authenticate(keys):
-        sign "ConnectOnion-Auth-{address}-{ts}"
-          └─ POST /api/auth  ──proxy──▶  POST oo.openonion.ai/api/v1/auth
-                └─ { token }                     (JWT)
-                     └─ chat-store.setApiKey(token)        // persisted
-        GET /api/auth (Bearer token)
-          └──proxy──▶ GET oo.openonion.ai/api/v1/auth/me
-                └─ { public_key, credits_usd, balance_usd, … }
-                     └─ chat-store.setUserProfile(profile)  // persisted
-```
-
-`app/api/auth/route.ts` exists only to dodge browser CORS — it forwards to
-`NEXT_PUBLIC_OPENONION_API_URL` (default `https://oo.openonion.ai`) and returns the
-response verbatim. The JWT (`openonionApiKey`) is later used for credit-metered
-features like voice transcription and the managed `co/` LLM gateway.
-
-Identity can be exported/imported/regenerated from `app/settings/page.tsx`
-(12/24-word mnemonic, or a 128-hex private key).
-
----
-
-## 4. Routing & navigation
-
-Three client routes, all wrapped in `ChatLayout` (sidebar + main pane):
-
-```
-/                          app/page.tsx
-  • No agents → welcome + "paste 0x address" form
-  • Has agents → picker grid (name + online dot from useAgentInfo)
-  • Pick/add agent ──▶ router.push(`/${address}`)
-
-/[address]                 app/[address]/page.tsx
-  • Agent landing: profile from useAgentInfo (name, model, trust, version,
-    skills as /slash-commands, tools, accepted inputs)
-  • Send first message:
-        sessionId = crypto.randomUUID()
-        chat-store.createConversation(sessionId, address)
-        chat-store.setPendingMessage(content)
-        router.push(`/${address}/${sessionId}?mode=…&turns=…`)
-
-/[address]/[sessionId]     app/[address]/[sessionId]/page.tsx
-  • The live chat. useAgentSDK({ agentAddress, sessionId }).
-  • On mount: apply ?mode from URL, then consumePendingMessage() and send().
-  • Streams ChatItem[] → <Chat> renders them.
-  • Syncs sidebar title to the first user message.
-  • If store hydrated and no conversation + no transcript → redirect to /[address].
-```
-
-The first message is deliberately handed off through `pendingMessage` in the store:
-the landing page mints the session and navigates, and the session page actually
-opens the socket and sends. This keeps the URL shareable (one URL = one session).
-
----
-
-## 5. Agent discovery & profile
-
-`hooks/use-agent-info.ts` wraps the SDK's `fetchAgentInfo(address)` and polls every
-30s (and on tab focus), deduping by value so unchanged data doesn't re-render.
-
-`fetchAgentInfo` (SDK, `src/connect/endpoint.ts`):
-
-```
-GET https://oo.openonion.ai/api/relay/agents/{address}
-  └─ { endpoints[], relay, last_seen, profile{ name|alias, model, trust,
-                                                version, tools[], skills[],
-                                                accepted_inputs } }
-  • online = Boolean(relay)        // true only while the agent holds a live
-                                    //   announce connection to the relay
-  • for each endpoint (localhost > private > public):
-        GET {endpoint}/info  → if info.address === address, merge as fresher profile
-```
-
-Result (`AgentInfo`): `{ address, name?, model?, trust?, version?, tools?, skills?,
-accepted_inputs?, online }`. This drives the picker dots, the landing hero, the
-skill palette, and the "accepts text/images/files" line.
-
----
-
-## 6. The live chat connection (the core)
-
-This is the heart of the data flow. oo-chat's `use-agent-sdk.ts` is a thin wrapper;
-the SDK's `useAgentForHuman(address, sessionId)` does the work.
-
-### 6.1 Layers
-
-```
-app/[address]/[sessionId]/page.tsx
-   │  send(text, images?, files?) / respondToAskUser / respondToApproval / setMode / reconnect
-   ▼
-components/chat/use-agent-sdk.ts            ← oo-chat
-   • dedupeUI(ui)                            (collapses duplicate stream items)
-   • extractPendingStates(ui)                (derives the "waiting" cards, see §6.5)
-   • derives sessionState, isLoading, elapsedTime
-   ▼
-connectonion/react · useAgentForHuman        ← SDK
-   • zustand store per (address, sessionId)  → localStorage co:agent:{addr}:session:{id}
-   • agent-cache: reuse a live RemoteAgent (≤6, LRU) across session switches
-   ▼
-connectonion · RemoteAgent                   ← SDK
-   • opens/keeps the WebSocket, signs CONNECT, maps frames → ChatItem[]
-   ▼
-WebSocket  wss://oo.openonion.ai  (relay)  →  remote agent
-```
-
-### 6.2 Connection lifecycle
-
-```
-input(prompt)                       // fire-and-forget; UI updates via callbacks
-  │ append user ChatItem, status = 'working'
-  ▼
-_ensureConnected()
-  │ open WebSocket, send CONNECT { payload, from, signature, session_id?, to }   (Ed25519, 30s deadline)
-  │
-  ├── CONNECTED { session_id, status, session?, chat_items? }
-  │       status='connected' → idle (ready)      status='running' → keep waiting for live events
-  │
-  └── ONBOARD_REQUIRED { methods, paymentAmount? }      // trust gate for a stranger
-          → user submits invite code / payment → ONBOARD_SUBMIT (signed) → ONBOARD_SUCCESS → CONNECTED
-  ▼
-send INPUT { input_id, prompt, images?, files? }
-  ▼
-… stream of frames (thinking / tool_call / tool_result / ask_user / …) → ChatItem[] …
-  ▼
-OUTPUT { result, session?, chat_items? }   → status = 'idle'; conversation settled
-```
-
-### 6.3 Inbound frames (server → client) → ChatItem
-
-The SDK maps each WebSocket frame to a `ChatItem` (the discriminated union the UI
-renders). The important ones:
-
-| Frame | Becomes / does | Status |
-|-------|----------------|--------|
-| `CONNECTED` | resolve connect; sync session/transcript | →idle or waiting |
-| `llm_call` / `llm_result` | `thinking` item (running → done, with tokens/cost) | →working |
-| `thinking` | `thinking` item (done) | — |
-| `assistant` / `agent_image` | `agent` item (markdown / images) | — |
-| `tool_call` / `tool_result` | `tool_call` item (running → done, with result) | →working |
-| `tool_blocked` | `tool_blocked` item | — |
-| `intent` / `eval` / `compact` | `intent` / `eval` / `compact` items | — |
-| `files_received` | `files_received` item | — |
-| `ask_user` | `ask_user` item | **→waiting** |
-| `approval_needed` | `approval_needed` item | **→waiting** |
-| `plan_review` | `plan_review` item | **→waiting** |
-| `onboard_required` | `onboard_required` item | **→waiting** |
-| `ulw_turns_reached` | `ulw_turns_reached` item | **→waiting** |
-| `OUTPUT` | settle the turn | **→idle** |
-| `ERROR` | set error, close socket | →idle / disconnected |
-| `PING` | reply `PONG` (keepalive) | — |
-| `session_sync` / `mode_changed` / `SESSION_STATUS` | update session/mode/status | — |
-
-### 6.4 Outbound messages (client → server)
-
-`send()` → `input()`; everything else goes through `sendMessage(...)`:
-
-| Message | Sent when | Shape (key fields) |
-|---------|-----------|--------------------|
-| `CONNECT` | first connect | `{ payload, from, signature, session_id?, to }` (Ed25519) |
-| `INPUT` | user sends a prompt | `{ input_id, prompt, images?, files? }` |
-| `ASK_USER_RESPONSE` | answer an `ask_user` | `{ answer }` |
-| `APPROVAL_RESPONSE` | approve/reject a tool | `{ approved, scope: 'once'\|'session', mode?, feedback? }` |
-| `PLAN_REVIEW_RESPONSE` | respond to a plan | `{ message }` |
-| `ULW_RESPONSE` | continue at a ULW checkpoint | `{ action: 'continue'\|'switch_mode', turns?, mode? }` |
-| `ONBOARD_SUBMIT` | submit onboarding | signed `{ payload, from, signature, … }` |
-| `mode_change` | switch approval mode | `{ mode, turns? }` |
-| `SESSION_STATUS` | poll if a session is alive | `{ session: { session_id } }` |
-| `PONG` | answer a `PING` | `{ }` |
-
-### 6.5 Approval modes & interactive gates
-
-**Approval mode** (`ApprovalMode = 'safe' | 'plan' | 'accept_edits' | 'ulw'`) is the
-trust level for the run. It's seeded from the URL (`?mode=…&turns=N`, set on the
-landing page) and can be changed live via `ModeStatusBar` → `setMode()` → the SDK
-(which optimistically updates local state and sends `mode_change`).
-
-- `safe` — ask before edits/commands (default)
-- `plan` — research first, present a plan for approval
-- `accept_edits` — edit without asking
-- `ulw` — "ultra-long work": run autonomously for `N` turns, then pause at a checkpoint
-
-**Interactive gates** are frames that put the run into `status = 'waiting'`. The SDK
-emits a ChatItem; oo-chat's `extractPendingStates()` turns the *latest unanswered*
-one into a `pending*` object that `[sessionId]/page.tsx` passes to `<Chat>`, which
-renders the matching card. The user's answer goes back out as the matching message
-above:
-
-| Gate (ChatItem) | oo-chat pending state | Response message |
-|-----------------|-----------------------|------------------|
-| `ask_user` | `pendingAskUser` | `ASK_USER_RESPONSE` |
-| `approval_needed` | `pendingApproval` | `APPROVAL_RESPONSE` |
-| `plan_review` | `pendingPlanReview` | `PLAN_REVIEW_RESPONSE` |
-| `onboard_required` | `pendingOnboard` | `ONBOARD_SUBMIT` |
-| `ulw_turns_reached` | `pendingUlwTurnsReached` | `ULW_RESPONSE` |
-
----
-
-## 7. The event/UI model: ChatItem → component
-
-The SDK's `ui: ChatItem[]` is the single ordered stream the UI renders. `ChatItem`
-is a discriminated union on `type` (mirrored in `components/chat/types.ts` as `UI`):
-
-```
-user · agent · thinking · tool_call · ask_user · approval_needed ·
-onboard_required · onboard_success · intent · eval · compact ·
-tool_blocked · ulw_turns_reached · plan_review · files_received
-```
-
-`components/chat/chat-messages.tsx` switches on `item.type` and renders the matching
-component from `components/chat/messages/`:
-
-```
-user            → messages/user.tsx          (markdown + images + files)
-agent           → messages/agent.tsx         (markdown + images)
-thinking        → messages/thinking.tsx      (collapsible)
-tool_call       → messages/tool-call.tsx     ──┐ dispatches by tool name:
-                                                ├ bash/shell/run  → BashCard
-                                                ├ write/read      → FileCard
-                                                ├ edit            → FileDiffCard
-                                                ├ grep/glob/find  → GrepCard
-                                                ├ ask_user        → LoginCard (fields) / AskUserCard
-                                                ├ exit_plan_…     → PlanCard
-                                                └ default         → GenericCard
-intent/eval/compact/tool_blocked/files_received/onboard_*  → their messages/*.tsx
-ulw_turns_reached → chat-ulw-checkpoint.tsx  (interactive)
-```
-
-`approval_needed` and `plan_review` are rendered *inline* on the related `tool_call`
-card rather than as standalone rows.
-
----
-
-## 8. State & persistence
-
-Three independent `localStorage` namespaces. The split is deliberate — the
-**transcript has exactly one owner (the SDK)**, and the sidebar only keeps an index.
-
-| localStorage key | Owner | Holds | Notes |
-|------------------|-------|-------|-------|
-| `connectonion_keys` | `hooks/use-identity.ts` | user keypair + mnemonic | the user's identity |
-| `oo-chat-storage` | `store/chat-store.ts` (zustand `persist`) | conversation **index**, `agents[]`, JWT, user profile, `activeSessionId` | **no transcript, no images** |
-| `co:agent:{address}:session:{id}` | SDK `useAgentForHuman` (zustand) | the **transcript** (`ui`/`messages`/`session`) | one key per session |
-
-### 8.1 Index vs transcript
-
-`chat-store.ts` stores a `Conversation` as `{ sessionId, title, agentAddress,
-createdAt }` — just enough to render the sidebar. The actual messages live only in
-the SDK's per-session store. On reload, the SDK store hydrates synchronously from
-localStorage, so the transcript is already present when `[sessionId]/page.tsx`
-mounts — no refetch needed for display. (Older builds kept a second `ui` copy inside
-`chat-store`; that's now stripped on read as a migration.)
-
-### 8.2 SDK-side persistence (in `connectonion-ts`)
-
-- **`sanitizeForPersistence`** — before writing, strips base64 data URLs (inline
-  images, file `dataUrl`s) so a single conversation can't blow the ~5MB origin quota.
-  http(s) image URLs are kept.
-- **Session cap** — `MAX_PERSISTED_SESSIONS = 20`. On store open, `pruneOldSessions`
-  keeps the 20 most-recently-updated `co:agent:*:session:*` keys and drops the rest.
-  The server is the source of truth, so a pruned session re-fetches when reopened.
-- **Agent cache** — `MAX_LIVE_AGENTS = 6`. Live `RemoteAgent` WebSocket connections
-  are kept in an LRU cache so switching between recent sessions doesn't tear down and
-  re-handshake the socket.
-
----
-
-## 9. What oo-chat actually imports from the SDK
-
-| oo-chat file | Imports | Purpose |
-|--------------|---------|---------|
-| `components/chat/use-agent-sdk.ts` | `useAgentForHuman`, `ChatItem`, `ApprovalMode` (from `connectonion/react`) | the live chat hook |
-| `hooks/use-agent-info.ts` | `fetchAgentInfo`, `AgentInfo`, `SkillInfo`, `AgentAcceptedInputs` | agent profile/online polling |
-| `components/chat/chat-input.tsx` | `useVoiceInput` | voice record + transcription (uses the JWT) |
-| `components/sidebar.tsx` | `version` (from `connectonion/package.json`) | shows the SDK version |
-| `app/api/chat/route.ts` | `createLLM`, `connect`, `address` | **legacy route**, see §10 |
-
-oo-chat pins `connectonion` by semver (`^0.1.x`) for production/Vercel builds, and
-symlinks `node_modules/connectonion → ../connectonion-ts` for local development. See
-[DEPLOY.md](./DEPLOY.md) for how a change to the SDK reaches production.
-
----
-
-## 10. Legacy / dead code
-
-- **`app/api/chat/route.ts`** — an older HTTP-POST chat route (agent-`/input`
-  signing + a `createLLM()` "Direct LLM" fallback). **Nothing calls it.** The current
-  UI talks to agents only through the SDK's WebSocket. Its file header still
-  references a removed `use-chat.ts` and a `connectionMode='llm'` `page.tsx`; treat
-  the header as historical. Kept (not deleted) to avoid churn; safe to remove if you
-  confirm no external caller.
-- **`.env.example` LLM keys** — `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
-  `GEMINI_API_KEY` and `NEXT_PUBLIC_DEFAULT_AGENT_URL` were for that removed mode and
-  are unused by the running app. The only env var the app reads is
-  `NEXT_PUBLIC_OPENONION_API_URL`.
-
----
-
-## 11. Configuration & environment
-
-| Var | Default | Used by |
-|-----|---------|---------|
-| `NEXT_PUBLIC_OPENONION_API_URL` | `https://oo.openonion.ai` | `app/api/auth/route.ts` (auth proxy target) |
-
-Relay (`wss://oo.openonion.ai`) and the relay HTTP API
-(`https://oo.openonion.ai/api/relay/...`) are SDK defaults (`ConnectOptions.relayUrl`),
-not oo-chat env vars. `next.config.ts` is empty (Next.js 16 defaults; builds use
-Turbopack). `vercel.json` only sets `installCommand: npm install`.
-
----
-
-## 12. One full round trip (worked example)
-
-1. User pastes `0x3d40…` on `/` → `/0x3d40…`. `useAgentInfo` shows the profile.
-2. User types "List the files here" → landing mints `sessionId`, stores the message,
-   navigates to `/0x3d40…/{sessionId}?mode=safe`.
-3. `[sessionId]` mounts → `useAgentForHuman` opens (or reuses) a WebSocket to
-   `wss://oo.openonion.ai`, sends a signed `CONNECT`, gets `CONNECTED`, then `INPUT`.
-4. Agent streams `intent` → `thinking` → `tool_call(bash: ls)` → `tool_result` →
-   `assistant`. Each frame becomes a `ChatItem`; the SDK persists to
-   `co:agent:0x3d40…:session:{id}`; oo-chat renders each row.
-5. The bash tool needs approval (mode `safe`): `approval_needed` → `status=waiting` →
-   oo-chat shows the approval card → user clicks Allow → `APPROVAL_RESPONSE` → run
-   resumes.
-6. `OUTPUT` settles the turn (`status=idle`). The sidebar title is set from the first
-   user message. Reloading the page rehydrates the transcript from localStorage; the
-   socket reconnects only if you send again or hit reconnect.
-
----
-
-## See also
-
-- [`DEPLOY.md`](./DEPLOY.md) — publishing the SDK to npm and shipping oo-chat to Vercel.
-- `../connectonion-ts/src/connect/` — `RemoteAgent`, the WebSocket protocol, types.
-- `../connectonion-ts/src/react/` — `useAgentForHuman`, the session store, voice input.
+## Reference — the WebSocket protocol
+
+*Skip this unless you're working on the agent connection itself.* The SDK
+(`connectonion-ts/src/connect/`) owns it; here's the shape.
+
+**Connect → run → settle:** the SDK sends a signed `CONNECT` (a stranger may first
+hit an `ONBOARD_REQUIRED` trust gate), then `INPUT { prompt }`. The agent streams
+events until `OUTPUT` settles the turn. `PING`/`PONG` keep the socket alive.
+
+**Streamed events → `ChatItem`** (rendered by `chat-messages.tsx`):
+`thinking` (llm_call/result), `agent` (assistant/image), `tool_call` (+`tool_result`),
+`tool_blocked`, `intent`, `eval`, `compact`, `files_received`.
+
+**Interactive gates** pause the run (`status = 'waiting'`) until you respond:
+
+| Gate (from agent) | Card shown | Your reply (to agent) |
+|---|---|---|
+| `ask_user` | question / form | `ASK_USER_RESPONSE` |
+| `approval_needed` | allow/deny a tool | `APPROVAL_RESPONSE` |
+| `plan_review` | approve a plan | `PLAN_REVIEW_RESPONSE` |
+| `onboard_required` | invite code / payment | `ONBOARD_SUBMIT` |
+| `ulw_turns_reached` | continue autonomous run | `ULW_RESPONSE` |
+
+Switching mode mid-run sends `mode_change`. `SESSION_STATUS` checks whether a session
+is still alive on the relay.
+
+**SDK persistence details:** before writing, the SDK strips base64 data URLs (images)
+so a conversation can't blow the ~5MB quota; it keeps the 20 most-recent sessions and
+caches up to 6 live sockets so switching sessions doesn't re-handshake.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,109 @@
+# Deploy: SDK → npm → oo-chat → Vercel
+
+oo-chat depends on the `connectonion` TypeScript SDK, which lives in a **separate
+repo** (`../connectonion-ts`, GitHub `openonion/connectonion-ts`). A change to the
+SDK only reaches production once it's published to npm and oo-chat is bumped to that
+version. This is the full chain.
+
+## The dependency, two ways
+
+`oo-chat/package.json` declares `"connectonion": "^0.1.x"` — a **published npm
+version** (this is what Vercel installs and builds against).
+
+For local development, `node_modules/connectonion` is symlinked to
+`../connectonion-ts` so SDK edits show up immediately:
+
+```
+node_modules/connectonion -> ../../connectonion-ts
+```
+
+> ⚠️ **Local builds can pass while Vercel fails.** The symlink points at your
+> *working* SDK, which may contain unpublished changes. Vercel installs the
+> *published* semver. If oo-chat uses an SDK symbol that isn't in the published
+> version yet, `npm run build` is green locally but Vercel errors with a TypeScript
+> "no overlap" / missing-export error. The fix is always: publish the SDK first,
+> then bump oo-chat. (This is exactly what bit `RemoteSessionStatus = 'running'` —
+> it existed only in the local SDK until `connectonion@0.1.6` shipped.)
+
+## Versioning
+
+Increment the patch by 1; when a segment would hit two digits, roll up:
+
+```
+0.1.5 → 0.1.6    0.1.9 → 0.2.0    0.9.9 → 1.0.0
+```
+
+## Steps
+
+### 1. Publish the SDK (`../connectonion-ts`)
+
+```bash
+cd ../connectonion-ts
+./node_modules/.bin/tsc                       # type-check
+npx jest tests/connect.test.ts --forceExit    # tests must pass
+
+# bump version in package.json (e.g. 0.1.5 → 0.1.6), then:
+git add -A && git commit -m "v0.1.6"
+git tag v0.1.6
+git push origin main && git push origin v0.1.6
+```
+
+Pushing the **`v*` tag** triggers `.github/workflows/publish.yml`, which builds and
+publishes `connectonion` to npm. Watch it:
+
+```bash
+gh run watch --repo openonion/connectonion-ts --exit-status
+npm view connectonion version          # should show the new version
+```
+
+### 2. Point oo-chat at the published version
+
+```bash
+cd ../oo-chat
+npm pkg set dependencies.connectonion="^0.1.6"
+npm install                            # updates package-lock.json to the registry tarball
+npm run build                          # MUST pass — this is what Vercel will run
+```
+
+### 3. Ship oo-chat
+
+```bash
+git add package.json package-lock.json
+git commit -m "Update connectonion to v0.1.6"
+git push                               # push the branch; merge the PR to main
+```
+
+Vercel auto-deploys: a branch push builds a **preview**; a merge to `main` builds
+**production**. Confirm the deploy is green before calling it done.
+
+### 4. Restore the local dev symlink (don't commit)
+
+Production `package.json` keeps the semver (`^0.1.6`). For local SDK work, restore
+the symlink in `node_modules` only:
+
+```bash
+rm -rf node_modules/connectonion
+ln -s ../../connectonion-ts node_modules/connectonion
+```
+
+`package.json` stays at `^0.1.6` (committed); only `node_modules` points at the local
+SDK. Don't commit a `file:../connectonion-ts` dependency.
+
+## Automation
+
+The skill `connectonion:deploy-oo-chat` automates steps 1–4. The `meta` is: publish
+`connectonion-ts` to npm via GitHub Actions, update the oo-chat dependency, commit,
+push, and verify the Vercel deploy.
+
+## Map
+
+| Thing | Value |
+|-------|-------|
+| SDK repo | `openonion/connectonion-ts` |
+| oo-chat repo | `openonion/oo-chat` |
+| npm package | `connectonion` |
+| Vercel project | `oo-chat` |
+| Publish trigger | git tag `v*` → GitHub Actions → npm |
+| Deploy trigger | push to `main` → Vercel production; branch push → preview |
+| Dev dependency | symlink `node_modules/connectonion → ../connectonion-ts` |
+| Prod dependency | `"connectonion": "^X.Y.Z"` in `package.json` |


### PR DESCRIPTION
Replaces the stale architecture docs (which still described the removed HTTP Agent-URL / Direct-LLM modes and a `use-chat.ts` that no longer exists) with an accurate, end-to-end map of how the current app connects to agents through the `connectonion` TypeScript SDK.

## What's in here

- **`docs/ARCHITECTURE.md`** (new) — the whole data flow:
  - the big-picture diagram (browser → SDK → relay/oo-api → agent)
  - user identity vs agent address; the BIP39→Ed25519 auth flow
  - routing (`/` → `/[address]` → `/[address]/[sessionId]`)
  - agent discovery (`fetchAgentInfo`, `online = Boolean(relay)`)
  - the live connection: `useAgentForHuman` → `RemoteAgent` → WebSocket relay, with the **inbound/outbound frame tables** and connection lifecycle
  - approval modes (`safe`/`plan`/`accept_edits`/`ulw`) + interactive gates (ask_user, approval, plan_review, onboard, ULW)
  - `ChatItem` → React component dispatch
  - the **three localStorage stores** (conversation index vs SDK transcript) + session cap + sanitization
  - legacy/dead code (`/api/chat`, stale `.env.example` keys)
- **`docs/DEPLOY.md`** (new) — SDK publish → npm → oo-chat bump → Vercel, including the symlink-vs-semver gotcha that makes local builds pass while Vercel fails.
- **`README.md`** — rewritten from create-next-app boilerplate into a real project overview.
- **`CLAUDE.md`** — refreshed Architecture / Key Patterns / Environment / Dependencies sections.

Docs only — no code changes.