### PR TITLE
UI: green-brand design system, redesigned sidebar, per-agent top-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ chromium_automation_profile
 # connectonion
 .co/
 .tmp/
+.gstack/

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -42,7 +42,6 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Chat, useAgentSDK, ModeStatusBar, PlanModeBanner, UlwModeBanner } from '@/components/chat'
 import type { UI, ApprovalMode } from '@/components/chat/types'
 import { dedupeUI } from '@/components/chat/dedupe-ui'
-import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo } from '@/hooks/use-agent-info'
@@ -187,7 +186,7 @@ export default function ChatSessionPage() {
   const isUlwActive = mode === 'ulw'
 
   return (
-    <ChatLayout>
+    <>
       <div className="flex flex-col flex-1 min-h-0 relative">
         {/* Plan mode banner */}
         {mode === 'plan' && (
@@ -235,6 +234,6 @@ export default function ChatSessionPage() {
           skills={skills}
         />
       </div>
-    </ChatLayout>
+    </>
   )
 }

--- a/app/[address]/layout.tsx
+++ b/app/[address]/layout.tsx
@@ -1,0 +1,15 @@
+import { ChatLayout } from '@/components/chat-layout'
+
+/**
+ * Shared layout for one agent. Mounts ChatLayout (the Sidebar) ONCE and keeps it
+ * across child navigation — /[address], /[address]/[sessionId], and new sessions.
+ *
+ * Before this, each page rendered its own <ChatLayout>, so switching or opening a
+ * session unmounted+remounted the whole sidebar: a visible flicker plus a redundant
+ * agent-info refetch, even though no new data was actually loading. As a persistent
+ * layout, the sidebar (and its useAgentInfo poller) survives session navigation;
+ * only the inner page content swaps.
+ */
+export default function AddressLayout({ children }: { children: React.ReactNode }) {
+  return <ChatLayout>{children}</ChatLayout>
+}

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -2,11 +2,9 @@
 
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { HiOutlineStatusOnline, HiOutlineStatusOffline } from 'react-icons/hi'
 import { HiChevronDown, HiChevronUp } from 'react-icons/hi2'
 import { ChatInput, ModeStatusBar } from '@/components/chat'
 import type { ApprovalMode } from '@/components/chat/types'
-import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
@@ -30,6 +28,7 @@ export default function AgentLandingPage() {
     createConversation,
     setPendingMessage,
     clearActive,
+    userProfile,
   } = useChatStore()
 
   useIdentity()
@@ -113,51 +112,72 @@ export default function AgentLandingPage() {
   }, [agentInfo?.accepted_inputs])
 
   return (
-    <ChatLayout>
+    <>
       <div className="flex-1 flex flex-col min-h-0">
-        {/* Scrollable content */}
-        <div className="flex-1 overflow-y-auto min-h-0">
-          <div className="max-w-lg mx-auto px-5 pt-16 sm:pt-24 pb-8">
+        {/* Scrollable content — vertically centered so the page isn't top-heavy */}
+        <div className="flex-1 overflow-y-auto min-h-0 flex flex-col">
+          <div className="m-auto w-full max-w-xl px-5 py-10">
 
             {/* Hero */}
-            <div className="text-center mb-8">
-              <div className="w-14 h-14 rounded-2xl bg-neutral-900 flex items-center justify-center mx-auto mb-3">
-                <span className="text-white font-bold text-xl">
+            <div className="text-center mb-7">
+              <div className="w-16 h-16 rounded-2xl bg-neutral-900 flex items-center justify-center mx-auto mb-4 shadow-sm">
+                <span className="text-white font-semibold text-2xl">
                   {label.charAt(0).toUpperCase()}
                 </span>
               </div>
 
-              <div className="flex items-center justify-center gap-1.5 mb-1">
-                <h1 className="text-lg font-semibold text-neutral-900">{label}</h1>
+              <div className="flex items-center justify-center gap-2 mb-1.5">
+                <h1 className="font-serif text-2xl font-semibold text-neutral-900">{label}</h1>
                 {isOnline !== undefined && (
                   isOnline
-                    ? <HiOutlineStatusOnline className="w-4 h-4 text-green-500" />
-                    : <HiOutlineStatusOffline className="w-4 h-4 text-neutral-400" />
+                    ? <span className="flex items-center gap-1.5 text-[11px] font-mono font-medium text-green-600">
+                        <span className="relative flex h-1.5 w-1.5">
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+                          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-500" />
+                        </span>
+                        LIVE
+                      </span>
+                    : <span className="text-[11px] font-mono font-medium text-neutral-400">OFFLINE</span>
                 )}
               </div>
 
               {metaLine && (
-                <p className="text-[11px] text-neutral-400">{metaLine}</p>
+                <p className="text-[11px] text-neutral-400 font-mono">{metaLine}</p>
+              )}
+
+              {/* Per-agent balance + top-up (one shared account balance) */}
+              {userProfile && (
+                <a
+                  href={`https://o.openonion.ai/purchase?agent=${address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
+                >
+                  <span className="font-mono text-neutral-400 uppercase tracking-wider">Balance</span>
+                  <span className="font-semibold text-neutral-900 tabular-nums">${userProfile.balance_usd.toFixed(2)}</span>
+                  <span className="text-neutral-300">·</span>
+                  <span className="font-medium text-brand-600">Top up →</span>
+                </a>
               )}
             </div>
 
             {/* Skills - slash command palette style */}
             {skills.length > 0 && (
-              <div className="mb-6 rounded-xl border border-neutral-200 bg-white overflow-hidden">
+              <div className="rounded-xl border border-neutral-200 bg-white p-1.5">
                 {visibleSkills.map((skill, i) => (
                   <button
                     key={i}
                     onClick={() => handleSend('/' + skill.name)}
-                    className="flex w-full items-baseline gap-2 px-4 py-2.5 border-b border-neutral-100 last:border-b-0 text-left hover:bg-neutral-50 transition-colors"
+                    className="flex w-full items-baseline gap-2.5 px-3 py-2.5 rounded-lg text-left hover:bg-neutral-50 transition-colors"
                   >
-                    <span className="text-sm font-medium text-neutral-800 shrink-0">/{skill.name}</span>
+                    <span className="text-sm font-medium text-neutral-800 shrink-0 font-mono">/{skill.name}</span>
                     <span className="text-xs text-neutral-400 truncate">{skill.description || 'No description'}</span>
                   </button>
                 ))}
                 {hiddenCount > 0 && (
                   <button
                     onClick={() => setSkillsExpanded(!skillsExpanded)}
-                    className="flex items-center justify-center gap-1 w-full px-4 py-2 text-xs text-neutral-400 hover:text-neutral-600 hover:bg-neutral-50 transition-colors border-t border-neutral-100"
+                    className="flex items-center justify-center gap-1 w-full px-3 py-2 mt-0.5 rounded-lg text-xs text-neutral-400 hover:text-neutral-600 hover:bg-neutral-50 transition-colors"
                   >
                     {skillsExpanded ? (
                       <>Show less <HiChevronUp className="w-3 h-3" /></>
@@ -171,7 +191,7 @@ export default function AgentLandingPage() {
 
             {/* Tools + Accepts */}
             {(toolsLine || acceptsLine) && (
-              <div className="text-center text-[11px] space-y-0.5">
+              <div className="text-center text-[11px] space-y-0.5 mt-5 font-mono">
                 {toolsLine && <p className="text-neutral-400">{toolsLine}</p>}
                 {acceptsLine && <p className="text-neutral-300">{acceptsLine}</p>}
               </div>
@@ -179,15 +199,15 @@ export default function AgentLandingPage() {
           </div>
         </div>
 
-        {/* Bottom: suggestions + input */}
-        <div className="shrink-0 bg-white border-t border-neutral-100 px-4 pb-4 pt-3">
+        {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider) */}
+        <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
           <div className="max-w-3xl mx-auto">
             <div className="flex flex-wrap justify-center gap-2 mb-3">
               {SUGGESTIONS.map((s, i) => (
                 <button
                   key={i}
                   onClick={() => handleSend(s)}
-                  className="rounded-full border border-neutral-200 px-3.5 py-1.5 text-xs text-neutral-500 hover:border-neutral-300 hover:text-neutral-700 hover:bg-neutral-50 transition-all active:scale-[0.97]"
+                  className="rounded-full border border-neutral-200 bg-white/60 px-3.5 py-1.5 text-xs text-neutral-500 hover:border-neutral-300 hover:text-neutral-700 hover:bg-white transition-all active:scale-[0.97]"
                 >
                   {s}
                 </button>
@@ -208,6 +228,6 @@ export default function AgentLandingPage() {
           </div>
         </div>
       </div>
-    </ChatLayout>
+    </>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,17 +1,69 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* ============================================================================
+ * oo-chat design system  —  clean neutral canvas, green brand accent.
+ *
+ * The app is built almost entirely on Tailwind's `neutral-*` scale + white,
+ * so the system lives in theme tokens: a clean (achromatic) neutral canvas
+ * and a single green `brand` accent flow into every existing utility.
+ * Hard-ish edges (pulled-down radii) and near-zero shadows keep it minimal.
+ * ==========================================================================*/
+@theme {
+  /* Neutral ramp = Tailwind defaults (clean gray, no warm cast). */
+
+  /* Brand — the single green accent, used sparingly for emphasis */
+  --color-brand-50:  #f0fdf4;
+  --color-brand-100: #dcfce7;
+  --color-brand-200: #bbf7d0;
+  --color-brand-300: #86efac;
+  --color-brand-400: #4ade80;
+  --color-brand-500: #22c55e;
+  --color-brand-600: #16a34a;
+  --color-brand-700: #15803d;
+  --color-brand-800: #166534;
+  --color-brand-900: #14532d;
+
+  /* Type — grotesque sans for chrome, editorial serif for display, JetBrains mono */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-serif: "Fraunces", ui-serif, "New York", Georgia, "Times New Roman", serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Radius — pulled toward the 4/8px editorial scale (hard-ish edges) */
+  --radius-sm:  0.125rem; /* 2px  */
+  --radius-md:  0.25rem;  /* 4px  */
+  --radius-lg:  0.375rem; /* 6px  */
+  --radius-xl:  0.5rem;   /* 8px  */
+  --radius-2xl: 0.625rem; /* 10px */
+  --radius-3xl: 0.75rem;  /* 12px */
+
+  /* Shadows — near-zero, warm-tinted. Depth comes from borders, not glow. */
+  --shadow-2xs: 0 1px 0 0 rgb(20 20 19 / 0.02);
+  --shadow-xs:  0 1px 1px 0 rgb(20 20 19 / 0.03);
+  --shadow-sm:  0 1px 2px 0 rgb(20 20 19 / 0.04);
+  --shadow-md:  0 1px 3px 0 rgb(20 20 19 / 0.05);
+  --shadow-lg:  0 2px 8px 0 rgb(20 20 19 / 0.06);
+  --shadow-xl:  0 4px 16px 0 rgb(20 20 19 / 0.08);
+  --shadow-2xl: 0 8px 28px 0 rgb(20 20 19 / 0.10);
+}
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: var(--color-neutral-50);
+  --foreground: var(--color-neutral-900);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Brand-tinted text selection */
+::selection {
+  background: var(--color-brand-100);
+  color: var(--color-neutral-900);
 }
 
 /* Smooth animations */
@@ -29,7 +81,7 @@ body {
   animation: fade-in 0.2s ease-out, slide-in-from-bottom-2 0.2s ease-out;
 }
 
-/* Scrollbar styling */
+/* Scrollbar styling — warm stone */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -39,12 +91,21 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #e5e5e5;
+  background: var(--color-neutral-300);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #d4d4d4;
+  background: var(--color-neutral-400);
+}
+
+/* Hide scrollbar but keep scrolling (sidebar lists) */
+.no-scrollbar {
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* legacy Edge/IE */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;                /* WebKit */
 }
 
 /* Thinking dots animation */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
             className="mb-6 rounded-2xl shadow-xl shadow-neutral-200"
           />
 
-          <h1 className="mb-2 text-2xl font-bold tracking-tight text-neutral-900">
+          <h1 className="mb-2 font-serif text-3xl font-semibold tracking-tight text-neutral-900">
             Welcome to oo-chat
           </h1>
           <p className="mb-8 max-w-md text-center text-neutral-500">
@@ -86,7 +86,7 @@ export default function Home() {
           className="mb-6 rounded-2xl shadow-xl shadow-neutral-200"
         />
 
-        <h1 className="mb-2 text-2xl font-bold tracking-tight text-neutral-900">
+        <h1 className="mb-2 font-serif text-3xl font-semibold tracking-tight text-neutral-900">
           Choose an agent
         </h1>
         <p className="mb-8 text-neutral-500">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -89,7 +89,7 @@ export default function SettingsPage() {
               >
                 <HiOutlineArrowLeft className="w-5 h-5" />
               </button>
-              <h1 className="text-xl font-bold text-neutral-900 tracking-tight">Settings</h1>
+              <h1 className="font-serif text-2xl font-semibold text-neutral-900 tracking-tight">Settings</h1>
             </div>
           </div>
         </header>
@@ -98,28 +98,28 @@ export default function SettingsPage() {
           {/* Account Profile Section */}
           <section className="animate-in fade-in slide-in-from-bottom-4 duration-700">
             <div className="flex items-center gap-3 mb-6 px-1">
-              <div className="p-2 bg-indigo-50 rounded-lg">
-                <HiOutlineUserCircle className="w-6 h-6 text-indigo-600" />
+              <div className="p-2 bg-brand-50 rounded-lg">
+                <HiOutlineUserCircle className="w-6 h-6 text-brand-600" />
               </div>
               <div>
-                <h2 className="text-lg font-bold text-neutral-900">Account</h2>
+                <h2 className="font-serif text-xl font-semibold text-neutral-900">Account</h2>
                 <p className="text-xs text-neutral-500 font-medium">Manage your identity and credits</p>
               </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               {/* Balance Card */}
-              <div className="md:col-span-1 bg-neutral-900 rounded-3xl p-8 text-white shadow-2xl shadow-indigo-100 flex flex-col justify-between relative overflow-hidden group">
-                <div className="absolute top-0 right-0 w-32 h-32 bg-indigo-500/10 rounded-full blur-3xl -mr-16 -mt-16 group-hover:bg-indigo-500/20 transition-all duration-700" />
+              <div className="md:col-span-1 bg-neutral-900 rounded-3xl p-8 text-white shadow-2xl shadow-brand-100 flex flex-col justify-between relative overflow-hidden group">
+                <div className="absolute top-0 right-0 w-32 h-32 bg-brand-500/10 rounded-full blur-3xl -mr-16 -mt-16 group-hover:bg-brand-500/20 transition-all duration-700" />
 
                 <div>
                   <div className="flex items-center justify-between mb-8">
-                    <span className="text-xs font-bold text-indigo-300 uppercase tracking-widest flex items-center gap-2">
+                    <span className="text-xs font-bold text-brand-300 uppercase tracking-widest flex items-center gap-2">
                       <HiOutlineCreditCard className="w-4 h-4" />
                       Balance
                     </span>
                     {authLoading && (
-                      <span className="w-2 h-2 bg-indigo-400 rounded-full animate-ping" />
+                      <span className="w-2 h-2 bg-brand-400 rounded-full animate-ping" />
                     )}
                   </div>
 
@@ -132,7 +132,7 @@ export default function SettingsPage() {
                       <div className="text-4xl font-black tracking-tighter">
                         ${userProfile.balance_usd.toFixed(4)}
                       </div>
-                      <div className="text-[10px] text-indigo-300/60 font-medium uppercase tracking-wider">Available Credits</div>
+                      <div className="text-[10px] text-brand-300/60 font-medium uppercase tracking-wider">Available Credits</div>
                     </div>
                   ) : (
                     <div className="text-neutral-500 text-sm font-medium italic">Syncing...</div>
@@ -156,7 +156,7 @@ export default function SettingsPage() {
                     href="https://o.openonion.ai/purchase"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="mt-6 block w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-center text-xs font-bold rounded-xl transition-all active:scale-95 shadow-lg shadow-indigo-900/20"
+                    className="mt-6 block w-full py-3 bg-brand-600 hover:bg-brand-500 text-center text-xs font-bold rounded-xl transition-all active:scale-95 shadow-lg shadow-brand-900/20"
                   >
                     + Add Credits
                   </a>
@@ -178,7 +178,7 @@ export default function SettingsPage() {
                           </div>
                           <button
                             onClick={() => copyToClipboard(identity.address, 'address')}
-                            className="absolute right-2 top-1/2 -translate-y-1/2 p-2.5 text-neutral-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-xl transition-all"
+                            className="absolute right-2 top-1/2 -translate-y-1/2 p-2.5 text-neutral-400 hover:text-brand-600 hover:bg-brand-50 rounded-xl transition-all"
                             title="Copy Address"
                           >
                             {copiedField === 'address' ? <HiOutlineCheck className="w-4 h-4 text-green-600" /> : <HiOutlineClipboardCopy className="w-4 h-4" />}
@@ -197,7 +197,7 @@ export default function SettingsPage() {
                           {openonionApiKey && (
                             <button
                               onClick={() => copyToClipboard(openonionApiKey, 'apikey')}
-                              className="absolute right-2 top-1/2 -translate-y-1/2 p-2.5 text-neutral-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-xl transition-all"
+                              className="absolute right-2 top-1/2 -translate-y-1/2 p-2.5 text-neutral-400 hover:text-brand-600 hover:bg-brand-50 rounded-xl transition-all"
                               title="Copy API Key"
                             >
                               {copiedField === 'apikey' ? <HiOutlineCheck className="w-4 h-4 text-green-600" /> : <HiOutlineClipboardCopy className="w-4 h-4" />}
@@ -212,7 +212,7 @@ export default function SettingsPage() {
                         onClick={exportKey}
                         className="flex items-center gap-2 px-5 py-2.5 bg-neutral-50 hover:bg-white border border-neutral-100 hover:border-neutral-200 text-neutral-700 text-xs font-bold rounded-xl transition-all active:scale-95"
                       >
-                        <HiOutlineShieldCheck className="w-4 h-4 text-indigo-500" />
+                        <HiOutlineShieldCheck className="w-4 h-4 text-brand-500" />
                         Backup Seed
                       </button>
                       <button
@@ -240,7 +240,7 @@ export default function SettingsPage() {
                           value={importKeyInput}
                           onChange={(e) => setImportKeyInput(e.target.value)}
                           placeholder="Paste your 12-word recovery phrase..."
-                          className="w-full px-4 py-3 rounded-xl border border-neutral-200 bg-white text-neutral-900 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/5 outline-none font-mono text-sm min-h-[100px] resize-none transition-all placeholder:text-neutral-400"
+                          className="w-full px-4 py-3 rounded-xl border border-neutral-200 bg-white text-neutral-900 focus:border-brand-500 focus:ring-4 focus:ring-brand-500/5 outline-none font-mono text-sm min-h-[100px] resize-none transition-all placeholder:text-neutral-400"
                         />
                         <div className="flex justify-end gap-3 mt-4">
                           <button
@@ -251,7 +251,7 @@ export default function SettingsPage() {
                           </button>
                           <button
                             onClick={handleImportKey}
-                            className="px-5 py-2 bg-indigo-600 text-white text-xs font-bold rounded-xl hover:bg-indigo-500 shadow-md shadow-indigo-200 transition-all active:scale-95"
+                            className="px-5 py-2 bg-brand-600 text-white text-xs font-bold rounded-xl hover:bg-brand-500 shadow-md shadow-brand-200 transition-all active:scale-95"
                           >
                             Import Now
                           </button>
@@ -261,7 +261,7 @@ export default function SettingsPage() {
                   </>
                 ) : (
                   <div className="py-12 flex flex-col items-center justify-center gap-4">
-                    <div className="w-8 h-8 border-4 border-indigo-100 border-t-indigo-600 rounded-full animate-spin" />
+                    <div className="w-8 h-8 border-4 border-brand-100 border-t-brand-600 rounded-full animate-spin" />
                     <p className="text-sm font-bold text-neutral-400 uppercase tracking-widest">Encrypting Identity...</p>
                   </div>
                 )}
@@ -276,7 +276,7 @@ export default function SettingsPage() {
                 <HiOutlineServer className="w-6 h-6 text-neutral-600" />
               </div>
               <div>
-                <h2 className="text-lg font-bold text-neutral-900">Agents</h2>
+                <h2 className="font-serif text-xl font-semibold text-neutral-900">Agents</h2>
                 <p className="text-xs text-neutral-500 font-medium">Manage your connected agents</p>
               </div>
             </div>
@@ -394,7 +394,7 @@ export default function SettingsPage() {
                   <div className="w-12 h-12 bg-amber-100 rounded-2xl flex items-center justify-center mb-6">
                     <HiOutlineShieldCheck className="w-7 h-7 text-amber-600" />
                   </div>
-                  <h3 className="text-2xl font-black text-amber-950 tracking-tight mb-2">
+                  <h3 className="font-serif text-2xl font-semibold text-amber-950 tracking-tight mb-2">
                     Secure Your Recovery Phrase
                   </h3>
                   <p className="text-sm text-amber-900/60 font-medium leading-relaxed">
@@ -407,7 +407,7 @@ export default function SettingsPage() {
               <div className="p-10">
                 <div className="grid grid-cols-3 gap-3 mb-10">
                   {newMnemonic.split(' ').map((word, i) => (
-                    <div key={i} className="flex flex-col gap-1 p-3 bg-neutral-50 rounded-2xl border border-neutral-100/50 group hover:bg-indigo-50 hover:border-indigo-100 transition-all duration-300">
+                    <div key={i} className="flex flex-col gap-1 p-3 bg-neutral-50 rounded-2xl border border-neutral-100/50 group hover:bg-brand-50 hover:border-brand-100 transition-all duration-300">
                       <span className="text-[10px] text-neutral-400 font-black uppercase tracking-widest">{i + 1}</span>
                       <span className="text-xs font-mono text-neutral-800 font-bold">{word}</span>
                     </div>

--- a/components/agent-header.tsx
+++ b/components/agent-header.tsx
@@ -14,18 +14,22 @@ export function AgentHeader({ address, info, variant = 'full' }: AgentHeaderProp
   const isOnline = info?.online
 
   if (variant === 'compact') {
+    // Rendered in the sidebar — minimal light, live pulse for online.
     return (
       <div className="flex items-center gap-2 min-w-0">
-        <div className="w-6 h-6 rounded-lg bg-neutral-900 flex items-center justify-center shrink-0">
-          <span className="text-white font-bold text-xs">
+        <div className="w-6 h-6 rounded-md bg-neutral-900 flex items-center justify-center shrink-0">
+          <span className="text-white font-semibold text-xs">
             {label.charAt(0).toUpperCase()}
           </span>
         </div>
-        <span className="font-medium text-sm truncate">{label}</span>
+        <span className="font-medium text-sm text-neutral-700 truncate">{label}</span>
         {isOnline !== undefined && (
           isOnline
-            ? <HiOutlineStatusOnline className="w-3 h-3 text-green-500 shrink-0" />
-            : <HiOutlineStatusOffline className="w-3 h-3 text-neutral-400 shrink-0" />
+            ? <span className="relative flex h-1.5 w-1.5 shrink-0" title="Online">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+                <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-500" />
+              </span>
+            : <span className="h-1.5 w-1.5 rounded-full bg-neutral-300 shrink-0" title="Offline" />
         )}
       </div>
     )

--- a/components/chat-layout.tsx
+++ b/components/chat-layout.tsx
@@ -13,15 +13,15 @@ export function ChatLayout({ children }: ChatLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (
-    <div className="flex h-screen bg-white">
+    <div className="flex h-screen bg-neutral-50">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <main className="flex-1 flex flex-col min-w-0">
         {/* Mobile header with logo */}
-        <header className="lg:hidden flex items-center gap-3 px-4 py-3 border-b border-neutral-200 bg-white">
+        <header className="lg:hidden flex items-center gap-3 px-4 py-3 border-b border-neutral-200 bg-neutral-50">
           <button
             onClick={() => setSidebarOpen(true)}
-            className="p-2 -ml-2 rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="p-2 -ml-2 rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
             aria-label="Open menu"
           >
             <HiOutlineMenu className="w-5 h-5 text-neutral-600" />

--- a/components/chat/chat-empty-state.tsx
+++ b/components/chat/chat-empty-state.tsx
@@ -27,7 +27,7 @@ export function ChatEmptyState({
       />
 
       {/* Title */}
-      <h2 className="mb-2 text-2xl font-semibold tracking-tight text-neutral-900">
+      <h2 className="mb-2 font-serif text-2xl font-semibold tracking-tight text-neutral-900">
         {title}
       </h2>
 

--- a/components/chat/messages/agent.tsx
+++ b/components/chat/messages/agent.tsx
@@ -1,6 +1,8 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { HiOutlineArrowDownTray } from 'react-icons/hi2'
 import type { AgentUI } from '../types'
+import { downloadImage, imageFileName } from '../utils'
 
 export function Agent({ message }: { message: AgentUI }) {
   const content = typeof message.content === 'string' ? message.content : ''
@@ -42,13 +44,22 @@ export function Agent({ message }: { message: AgentUI }) {
         {hasImages && (
           <div className="flex w-full flex-col gap-3">
             {images.map((img, i) => (
-              <img
-                key={i}
-                src={img}
-                alt={`Image ${i + 1}`}
-                className="w-full max-w-3xl max-h-[70vh] rounded-xl border border-neutral-200 object-contain cursor-pointer bg-white shadow-md transition-opacity hover:opacity-90"
-                onClick={() => window.open(img, '_blank')}
-              />
+              <div key={i} className="group relative w-fit">
+                <img
+                  src={img}
+                  alt={`Image ${i + 1}`}
+                  className="w-full max-w-3xl max-h-[70vh] rounded-xl border border-neutral-200 object-contain bg-white shadow-md"
+                />
+                <button
+                  type="button"
+                  onClick={() => downloadImage(img, imageFileName(img, i))}
+                  aria-label="Download image"
+                  title="Download image"
+                  className="absolute top-2 right-2 rounded-lg bg-black/60 p-2 text-white opacity-0 shadow-sm transition-opacity hover:bg-black/80 focus:opacity-100 group-hover:opacity-100"
+                >
+                  <HiOutlineArrowDownTray className="h-4 w-4" />
+                </button>
+              </div>
             ))}
           </div>
         )}

--- a/components/chat/messages/thinking.tsx
+++ b/components/chat/messages/thinking.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react'
 import type { ThinkingUI } from '../types'
 
+// Claude-Code-style working indicator: a glyph that grows from a dot to a starburst,
+// plus a rotating gerund. Shown on the running "thinking" line.
+const SPINNER_FRAMES = ['·', '✢', '✳', '∗', '✻', '✽', '✻', '∗', '✳', '✢']
+const GERUNDS = ['Thinking', 'Synthesizing', 'Reasoning', 'Pondering', 'Composing', 'Ruminating', 'Cooking', 'Crunching', 'Percolating', 'Noodling', 'Wrangling', 'Conjuring']
+
 function formatTime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
   const mins = Math.floor(seconds / 60)
@@ -22,44 +27,41 @@ function getActualTokens(usage: ThinkingUI['usage']): number {
 
 export function Thinking({ thinking, isLast = true }: { thinking: ThinkingUI; isLast?: boolean }) {
   const [seconds, setSeconds] = useState(0)
-  const [simulatedTokens, setSimulatedTokens] = useState(0)
+  const [frame, setFrame] = useState(0)
+  const [word, setWord] = useState(0)
   const isRunning = thinking.status === 'running'
 
   useEffect(() => {
     if (!isRunning) return
 
     setSeconds(0)
-    setSimulatedTokens(0)
+    setFrame(0)
+    setWord(0)
 
     const timeInterval = setInterval(() => setSeconds(s => s + 1), 1000)
-    const tokenInterval = setInterval(() => {
-      setSimulatedTokens(prev => Math.min(prev + 11, 1100))
-    }, 100)
+    const spin = setInterval(() => setFrame(f => (f + 1) % SPINNER_FRAMES.length), 120)
+    const cycle = setInterval(() => setWord(w => (w + 1) % GERUNDS.length), 2800)
 
     return () => {
       clearInterval(timeInterval)
-      clearInterval(tokenInterval)
+      clearInterval(spin)
+      clearInterval(cycle)
     }
   }, [isRunning])
 
-  // Running state — only show the last one to avoid flooding
+  // Running state — starburst + rotating gerund + real elapsed time. Only the last
+  // one renders, to avoid flooding. No token count here: there's no real streaming
+  // count mid-run, and a simulated one is misleading — real tokens/cost/duration
+  // show on the done line below.
   if (isRunning) {
     if (!isLast) return null
-    const model = thinking.model || 'thinking'
 
     return (
       <div className="py-1.5">
-        <div className="flex items-center gap-2 text-xs text-neutral-500 font-mono ml-5">
-          <span className="w-2 h-2 rounded-full bg-neutral-400 animate-pulse" />
-          <span>{model}</span>
-          <span className="text-neutral-300">·</span>
-          <span className="tabular-nums">{seconds > 0 ? formatTime(seconds) : '0s'}</span>
-          {simulatedTokens > 0 && (
-            <>
-              <span className="text-neutral-300">·</span>
-              <span className="tabular-nums text-neutral-400">~{formatTokens(simulatedTokens)} tok</span>
-            </>
-          )}
+        <div className="flex items-center gap-1.5 text-xs font-mono ml-5">
+          <span className="inline-block w-3 text-center text-sm leading-none text-orange-400">{SPINNER_FRAMES[frame]}</span>
+          <span className="font-medium text-orange-500">{GERUNDS[word]}…</span>
+          <span className="tabular-nums text-neutral-400">({seconds > 0 ? formatTime(seconds) : '0s'})</span>
         </div>
       </div>
     )

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -108,6 +108,10 @@ function isBlockedError(result: string): boolean {
   return result.includes('Bash file creation blocked')
 }
 
+// The animated "working" starburst lives on the thinking line (see thinking.tsx),
+// not on the bash header. Here the running state is a plain, muted elapsed-time
+// indicator matching the done-state text style.
+
 export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: BashCardProps) {
   const { args, status, result, timing_ms } = toolCall
   const [isExpanded, setIsExpanded] = useState(false)
@@ -189,9 +193,13 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
 
           <HiOutlineTerminal className="w-4 h-4 text-neutral-500 ml-0.5" />
           <span className="text-sm font-bold text-neutral-700 tracking-tight">Bash</span>
-          {description && (
+          {/* Command is collapsed by default, so the header must never be blank: */}
+          {/* show the description if given, otherwise fall back to the command itself. */}
+          {description ? (
             <span className="text-xs text-neutral-400 truncate ml-1">{description}</span>
-          )}
+          ) : command ? (
+            <span className="text-xs text-neutral-400/80 font-mono truncate ml-1">{command}</span>
+          ) : null}
         </div>
 
         <div className="flex items-center gap-2">
@@ -206,14 +214,15 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
           ) : needsApproval && !approvalSent ? (
             <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">Waiting for Permission</span>
           ) : (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest tabular-nums animate-pulse">
-              Running{runningSeconds > 0 && ` ${formatSeconds(runningSeconds)}`}
+            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse tabular-nums">
+              Running{runningSeconds > 0 ? ` (${formatSeconds(runningSeconds)})` : ''}
             </span>
           )}
         </div>
       </div>
 
-      {/* Terminal Block */}
+      {/* Terminal Block — Claude Code style: only rendered when expanded; collapsed = header row only */}
+      {isExpanded && (
       <div className="ml-5">
         <div className="bg-[#1e1e1e] rounded-lg overflow-hidden relative group/terminal">
           <div
@@ -266,6 +275,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
           </button>
         </div>
       </div>
+      )}
 
       {/* Approval Buttons */}
       {needsApproval && status === 'running' && (

--- a/components/chat/messages/tools/file-card.tsx
+++ b/components/chat/messages/tools/file-card.tsx
@@ -57,7 +57,7 @@ export function FileCard({ toolCall, pendingApproval, onApprovalResponse }: any)
         )}
       </div>
 
-      <Modal isOpen={isFullscreen} onClose={() => setIsFullscreen(false)} title={`${name.toUpperCase()}: ${filePath}`}>
+      <Modal isOpen={isFullscreen} onClose={() => setIsFullscreen(false)} title={`${name.charAt(0).toUpperCase() + name.slice(1).toLowerCase()}  ·  ${getFileName(filePath)}`}>
         <FileFullView content={content} filePath={filePath} />
       </Modal>
 

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -1,13 +1,46 @@
 'use client'
 
-import { Highlight } from 'prism-react-renderer'
+import { Highlight, themes } from 'prism-react-renderer'
 import { 
   HiOutlineCheck, 
   HiOutlineX, 
   HiOutlineArrowsExpand
 } from 'react-icons/hi'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { cn } from '../../utils'
 import { getLanguageFromPath, monokaiTheme, formatTime } from './file-utils'
+
+// A file opens as a rendered markdown document when its extension says so, OR when it
+// carries no code extension (.txt / extensionless) but its content clearly reads as
+// markdown — agents often write prompts/reports as .txt. Code files (.py/.js/.json…)
+// stay in the syntax-highlighted view. Diffs never switch (the +/- lines must stay visible).
+const MARKDOWN_EXT_RE = /\.(md|markdown|mdx)$/i
+const PLAIN_TEXT_RE = /\.txt$/i
+const HAS_EXT_RE = /\.[a-z0-9]+$/i
+
+function looksLikeMarkdown(content: string): boolean {
+  // Require ≥2 distinct markdown signals so plain prose with a stray '#'/'*' isn't misread.
+  const signals = [
+    /^#{1,6}\s+\S/m,        // # heading
+    /^\s*[-*+]\s+\S/m,      // - bullet list
+    /^\s*\d+\.\s+\S/m,      // 1. ordered list
+    /\*\*[^*\n]+\*\*/,      // **bold**
+    /^>\s+\S/m,             // > blockquote
+    /```/,                  // ``` fenced code
+    /\[[^\]]+\]\([^)]+\)/,  // [text](url)
+  ]
+  return signals.filter(re => re.test(content)).length >= 2
+}
+
+function shouldRenderMarkdown(filePath: string, content: string, isDiff?: boolean): boolean {
+  if (isDiff || !content) return false
+  if (MARKDOWN_EXT_RE.test(filePath)) return true
+  const name = filePath.split('/').pop() || ''
+  const hasCodeExt = HAS_EXT_RE.test(name) && !PLAIN_TEXT_RE.test(name)
+  if (hasCodeExt) return false
+  return looksLikeMarkdown(content)
+}
 
 interface FileCodePeekProps {
   content: string
@@ -20,15 +53,39 @@ interface FileCodePeekProps {
 export function FileCodePeek({ content, filePath, isDiff, maxLines = 4, onClick }: FileCodePeekProps) {
   if (!content) return null
 
+  // Markdown files: light, rendered document snippet instead of the dark raw-source block.
+  if (shouldRenderMarkdown(filePath, content, isDiff)) {
+    const snippet = content.split('\n').slice(0, 12).join('\n')
+    return (
+      <div
+        className="relative group bg-white border border-neutral-200 rounded-lg overflow-hidden max-h-36 cursor-pointer hover:border-neutral-300 transition-all shadow-sm"
+        onClick={onClick}
+      >
+        <article className="prose prose-sm prose-neutral max-w-none px-4 py-3 pointer-events-none
+          prose-headings:font-semibold prose-headings:mt-2 prose-headings:mb-1
+          prose-h1:text-base prose-h2:text-[15px] prose-h3:text-sm
+          prose-p:my-1 prose-p:text-[13px] prose-p:text-neutral-600 prose-li:my-0.5 prose-li:text-[13px]
+          prose-a:text-blue-600 prose-strong:text-neutral-800
+          prose-code:text-[12px] prose-code:before:content-none prose-code:after:content-none">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{snippet}</ReactMarkdown>
+        </article>
+        <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-white to-transparent" />
+        <div className="absolute right-2 bottom-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <HiOutlineArrowsExpand className="w-3 h-3 text-neutral-400" />
+        </div>
+      </div>
+    )
+  }
+
   const lines = content.split('\n')
   const peekContent = lines.slice(0, maxLines).join('\n')
 
   return (
-    <div 
-      className="relative group bg-[#1e1e1e] rounded-lg overflow-hidden border border-neutral-800/50 hover:border-neutral-700 transition-all cursor-pointer shadow-sm"
+    <div
+      className="relative group bg-neutral-50 rounded-lg overflow-hidden border border-neutral-200 hover:border-neutral-300 transition-all cursor-pointer shadow-sm"
       onClick={onClick}
     >
-      <Highlight theme={monokaiTheme} code={peekContent} language={getLanguageFromPath(filePath)}>
+      <Highlight theme={themes.github} code={peekContent} language={getLanguageFromPath(filePath)}>
         {({ tokens, getLineProps, getTokenProps }) => (
           <pre className="text-[11px] font-mono m-0 p-3 leading-relaxed pointer-events-none">
             {tokens.map((line, i) => {
@@ -53,18 +110,33 @@ export function FileCodePeek({ content, filePath, isDiff, maxLines = 4, onClick 
         )}
       </Highlight>
       
-      <div className="absolute inset-x-0 bottom-0 h-4 bg-gradient-to-t from-[#1e1e1e] to-transparent opacity-80" />
+      <div className="absolute inset-x-0 bottom-0 h-4 bg-gradient-to-t from-neutral-50 to-transparent opacity-90" />
       <div className="absolute right-2 bottom-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-        <HiOutlineArrowsExpand className="w-3 h-3 text-neutral-500" />
+        <HiOutlineArrowsExpand className="w-3 h-3 text-neutral-400" />
       </div>
     </div>
   )
 }
 
 export function FileFullView({ content, filePath, isDiff }: { content: string, filePath: string, isDiff?: boolean }) {
+  // Markdown opens as a rendered document (headings/lists/bold/links), not raw `#`/`**`.
+  // Diffs stay in the line-by-line code view so +/- lines remain visible.
+  if (shouldRenderMarkdown(filePath, content, isDiff)) {
+    return (
+      <div className="h-full overflow-auto bg-white">
+        <article className="prose prose-neutral max-w-3xl mx-auto px-8 py-8
+          prose-headings:font-semibold prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+          prose-p:leading-7 prose-li:my-0.5 prose-a:text-blue-600 prose-a:underline prose-a:underline-offset-2
+          prose-code:text-[13px] prose-code:before:content-none prose-code:after:content-none
+          prose-pre:bg-neutral-100 prose-pre:text-neutral-800 prose-img:rounded-lg">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        </article>
+      </div>
+    )
+  }
   return (
-    <div className="relative group bg-[#1e1e1e] h-full overflow-auto">
-      <Highlight theme={monokaiTheme} code={content} language={getLanguageFromPath(filePath)}>
+    <div className="relative group bg-white h-full overflow-auto">
+      <Highlight theme={themes.github} code={content} language={getLanguageFromPath(filePath)}>
         {({ tokens, getLineProps, getTokenProps }) => (
           <pre className="text-[12px] font-mono m-0 p-6 leading-relaxed min-w-full">
             {tokens.map((line, i) => {

--- a/components/chat/messages/user.tsx
+++ b/components/chat/messages/user.tsx
@@ -1,7 +1,8 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { HiOutlineDocument } from 'react-icons/hi2'
+import { HiOutlineDocument, HiOutlineArrowDownTray } from 'react-icons/hi2'
 import type { UserUI } from '../types'
+import { downloadImage, imageFileName } from '../utils'
 
 export function User({ message }: { message: UserUI }) {
   const content = typeof message.content === 'string' ? message.content : ''
@@ -17,13 +18,22 @@ export function User({ message }: { message: UserUI }) {
       {hasImages && (
         <div className={`flex gap-2 flex-wrap justify-end max-w-[85%]`}>
           {images.map((img, i) => (
-            <img
-              key={i}
-              src={img}
-              alt={`Attachment ${i + 1}`}
-              className="max-h-48 max-w-[200px] rounded-2xl object-contain cursor-pointer hover:opacity-90 transition-opacity shadow-md"
-              onClick={() => window.open(img, '_blank')}
-            />
+            <div key={i} className="group relative w-fit">
+              <img
+                src={img}
+                alt={`Attachment ${i + 1}`}
+                className="max-h-48 max-w-[200px] rounded-2xl object-contain shadow-md"
+              />
+              <button
+                type="button"
+                onClick={() => downloadImage(img, imageFileName(img, i))}
+                aria-label="Download image"
+                title="Download image"
+                className="absolute top-2 right-2 rounded-lg bg-black/60 p-1.5 text-white opacity-0 shadow-sm transition-opacity hover:bg-black/80 focus:opacity-100 group-hover:opacity-100"
+              >
+                <HiOutlineArrowDownTray className="h-4 w-4" />
+              </button>
+            </div>
           ))}
         </div>
       )}

--- a/components/chat/utils.ts
+++ b/components/chat/utils.ts
@@ -32,3 +32,36 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Save an image (data: URI or http(s) URL) to disk. Fetch → blob → <a download>
+// works for data: and same-origin/CORS-enabled URLs; this is the only reliable
+// path for base64 data: images, which Chrome refuses to open via window.open.
+// Cross-origin images without CORS fail the fetch and fall back to a new tab.
+export async function downloadImage(src: string, name: string) {
+  try {
+    const res = await fetch(src)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = name
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  } catch {
+    window.open(src, '_blank')
+  }
+}
+
+// Best-effort extension for the download filename, from a data: mime or URL suffix.
+function imageExt(src: string): string {
+  const mime = src.match(/^data:image\/([a-z0-9.+-]+)/i)?.[1]
+  if (mime) return mime.toLowerCase() === 'jpeg' ? 'jpg' : mime.toLowerCase()
+  const suffix = src.split(/[?#]/)[0].match(/\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i)?.[1]
+  return suffix ? suffix.toLowerCase() : 'png'
+}
+
+export function imageFileName(src: string, index: number): string {
+  return `image-${index + 1}.${imageExt(src)}`
+}

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -110,10 +110,10 @@ export function SessionList({
               key={session.sessionId}
               href={`/${agentAddress}/${session.sessionId}`}
               onClick={onSelect}
-              className={`group relative flex items-center gap-2 px-3 py-2 rounded-xl text-sm transition-all ${
+              className={`group relative flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all ${
                 isActive
                   ? 'bg-neutral-100 text-neutral-900 font-medium'
-                  : 'text-neutral-600 hover:bg-neutral-50'
+                  : 'text-neutral-600 hover:bg-neutral-100/70'
               }`}
             >
               <HiOutlineChat className={`w-3.5 h-3.5 shrink-0 ${
@@ -123,7 +123,7 @@ export function SessionList({
               {onDelete && (
                 <button
                   onClick={(e) => handleDelete(session.sessionId, e)}
-                  className="opacity-0 group-hover:opacity-100 p-1 text-neutral-400 hover:text-neutral-600 rounded transition-opacity"
+                  className="opacity-0 group-hover:opacity-100 p-1 text-neutral-400 hover:text-red-500 rounded transition-opacity"
                 >
                   <HiOutlineTrash className="w-3 h-3" />
                 </button>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -10,6 +10,9 @@ import {
   HiOutlineChevronDown,
   HiOutlineChevronRight,
   HiOutlineSparkles,
+  HiOutlineChatAlt2,
+  HiOutlineLightningBolt,
+  HiOutlineClock,
 } from 'react-icons/hi'
 import { useChatStore } from '@/store/chat-store'
 import { useAgentInfo } from '@/hooks/use-agent-info'
@@ -21,6 +24,14 @@ interface SidebarProps {
   isOpen: boolean
   onClose: () => void
 }
+
+// App-level destinations. `Chats` is live; the rest are reserved for upcoming
+// features (rendered disabled with a SOON badge). Add entries here as they ship.
+const NAV_ITEMS = [
+  { key: 'chats', label: 'Chats', Icon: HiOutlineChatAlt2, soon: false },
+  { key: 'automation', label: 'Automation', Icon: HiOutlineLightningBolt, soon: true },
+  { key: 'schedule', label: 'Schedule', Icon: HiOutlineClock, soon: true },
+] as const
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const router = useRouter()
@@ -59,6 +70,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     return { activeAgent: null, activeSessionId: null }
   }, [pathname, agents])
 
+  const onlineCount = useMemo(
+    () => agents.filter(a => infoMap[a]?.online).length,
+    [agents, infoMap]
+  )
+
   const toggleAgent = (address: string) => {
     setExpandedAgents(prev => {
       const next = new Set(prev)
@@ -82,6 +98,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   }
 
   const isSettingsActive = pathname === '/settings'
+  const isChatsActive = !isSettingsActive
 
   return (
     <>
@@ -96,7 +113,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         fixed lg:relative inset-y-0 left-0 z-50 w-72 bg-white flex flex-col
         transform transition-transform duration-200 ease-out lg:translate-x-0
         ${isOpen ? 'translate-x-0' : '-translate-x-full'}
-        border-r border-neutral-100
+        border-r border-neutral-200
       `}>
         {/* Header with Logo */}
         <div className="px-4 h-14 flex items-center justify-between shrink-0">
@@ -116,7 +133,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               target="_blank"
               rel="noopener noreferrer"
               title={`connectonion v${connectonionVersion} — view on npm`}
-              className="px-1.5 py-0.5 rounded-md text-[10px] font-mono font-medium text-neutral-400 bg-neutral-50 hover:text-neutral-700 hover:bg-neutral-100 transition-colors"
+              className="px-1.5 py-0.5 rounded-md text-[10px] font-mono font-medium text-neutral-400 bg-neutral-100 hover:text-neutral-700 hover:bg-neutral-200 transition-colors"
             >
               v{connectonionVersion}
             </a>
@@ -129,11 +146,76 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           </button>
         </div>
 
+        {/* Live status — quiet mono strip */}
+        <div className="px-4 pb-1 flex items-center gap-2">
+          {onlineCount > 0 ? (
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-500" />
+            </span>
+          ) : (
+            <span className="h-1.5 w-1.5 rounded-full bg-neutral-300" />
+          )}
+          <span className="text-[10px] font-mono tracking-[0.12em] text-neutral-400 uppercase">
+            {onlineCount > 0
+              ? `${onlineCount} agent${onlineCount > 1 ? 's' : ''} online`
+              : 'all agents offline'}
+          </span>
+        </div>
+
+        {/* Nav rail — Chats live, others reserved */}
+        <nav className="px-2 pt-2 pb-1 space-y-0.5">
+          {NAV_ITEMS.map(({ key, label, Icon, soon }) => {
+            const active = key === 'chats' && isChatsActive
+            if (soon) {
+              return (
+                <div
+                  key={key}
+                  className="relative flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-neutral-400 cursor-not-allowed select-none"
+                  title="Coming soon"
+                >
+                  <Icon className="w-4 h-4 shrink-0" />
+                  <span className="flex-1">{label}</span>
+                  <span className="text-[9px] font-mono font-semibold tracking-widest text-neutral-400 border border-neutral-200 rounded px-1 py-0.5">
+                    SOON
+                  </span>
+                </div>
+              )
+            }
+            return (
+              <Link
+                key={key}
+                href="/"
+                onClick={onClose}
+                className={`relative flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
+                  active
+                    ? 'bg-neutral-100 text-neutral-900 font-medium'
+                    : 'text-neutral-600 hover:bg-neutral-100/70'
+                }`}
+              >
+                {active && (
+                  <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-brand-500" />
+                )}
+                <Icon className={`w-4 h-4 shrink-0 ${active ? 'text-brand-500' : 'text-neutral-400'}`} />
+                <span className="flex-1">{label}</span>
+              </Link>
+            )
+          })}
+        </nav>
+
+        {/* Agents section label */}
+        <div className="px-4 pt-3 pb-1 flex items-center justify-between shrink-0">
+          <span className="text-[10px] font-mono tracking-[0.12em] text-neutral-400 uppercase">
+            Agents
+          </span>
+          <span className="text-[10px] font-mono text-neutral-300">{agents.length}</span>
+        </div>
+
         {/* Agent Folders */}
-        <div className="flex-1 overflow-y-auto px-2 pt-2 pb-3">
+        <div className="flex-1 overflow-y-auto no-scrollbar px-2 pb-3">
           {agents.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
-              <div className="w-12 h-12 rounded-xl bg-neutral-50 flex items-center justify-center mb-3">
+            <div className="flex flex-col items-center justify-center py-14 px-6 text-center">
+              <div className="w-12 h-12 rounded-xl bg-neutral-50 border border-neutral-100 flex items-center justify-center mb-3">
                 <HiOutlineSparkles className="w-5 h-5 text-neutral-400" />
               </div>
               <p className="text-neutral-700 text-sm font-medium">No agents yet</p>
@@ -155,9 +237,12 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       className={`group relative flex items-center gap-1 pl-1 pr-1.5 py-1.5 rounded-lg transition-colors ${
                         isAgentActive
                           ? 'bg-neutral-100'
-                          : 'hover:bg-neutral-50'
+                          : 'hover:bg-neutral-100/70'
                       }`}
                     >
+                      {isAgentActive && (
+                        <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-brand-500" />
+                      )}
                       {/* Expand/Collapse */}
                       <button
                         onClick={() => toggleAgent(address)}
@@ -206,7 +291,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
                     {/* Sessions (expanded) */}
                     {expanded && sessions.length > 0 && (
-                      <div className="ml-5 mt-0.5 mb-1 pl-2 border-l border-neutral-100">
+                      <div className="ml-5 mt-0.5 mb-1 pl-2 border-l border-neutral-200">
                         <SessionList
                           sessions={sessions}
                           agentAddress={address}
@@ -225,11 +310,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </div>
 
         {/* Footer */}
-        <div className="border-t border-neutral-100 p-3 space-y-2">
+        <div className="border-t border-neutral-200 p-3 space-y-2">
           <Link
             href="/"
             onClick={onClose}
-            className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-neutral-500 hover:text-neutral-900 hover:bg-neutral-50 border border-dashed border-neutral-200 hover:border-neutral-300 transition-colors"
+            className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100 border border-dashed border-neutral-300 hover:border-neutral-400 transition-colors"
           >
             <HiOutlinePlus className="w-4 h-4" />
             Add Agent
@@ -240,22 +325,22 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               href="https://o.openonion.ai/purchase"
               target="_blank"
               rel="noopener noreferrer"
-              className="group block px-3 py-2.5 rounded-lg bg-neutral-50 hover:bg-neutral-100 transition-colors"
+              className="group block px-3 py-2.5 rounded-lg bg-neutral-50 hover:bg-neutral-100 border border-neutral-200 transition-colors"
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wider">Balance</span>
+                  <span className="text-[10px] font-mono font-medium text-neutral-500 uppercase tracking-widest">Balance</span>
                   <span className="text-sm font-semibold text-neutral-900 tabular-nums">
                     ${userProfile.balance_usd.toFixed(2)}
                   </span>
                 </div>
-                <span className="text-[11px] font-medium text-neutral-400 group-hover:text-neutral-700 transition-colors">
+                <span className="text-[11px] font-medium text-brand-600 group-hover:text-brand-500 transition-colors">
                   Top up →
                 </span>
               </div>
-              <div className="w-full h-1 bg-neutral-200/70 rounded-full mt-2 overflow-hidden">
+              <div className="w-full h-1 bg-neutral-200 rounded-full mt-2 overflow-hidden">
                 <div
-                  className="h-full bg-neutral-900 rounded-full transition-all duration-700"
+                  className="h-full bg-brand-500 rounded-full transition-all duration-700"
                   style={{ width: `${Math.min(100, (userProfile.balance_usd / Math.max(1, userProfile.credits_usd)) * 100)}%` }}
                 />
               </div>
@@ -267,11 +352,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             onClick={onClose}
             className={`group w-full flex items-center gap-2.5 px-3 py-2 rounded-lg font-medium text-sm transition-colors ${
               isSettingsActive
-                ? 'bg-neutral-900 text-white'
-                : 'text-neutral-600 hover:bg-neutral-50 hover:text-neutral-900'
+                ? 'bg-neutral-100 text-neutral-900'
+                : 'text-neutral-600 hover:bg-neutral-100/70 hover:text-neutral-900'
             }`}
           >
-            <HiOutlineCog className={`w-4 h-4 transition-transform duration-500 group-hover:rotate-45 ${isSettingsActive ? 'text-white' : 'text-neutral-400 group-hover:text-neutral-700'}`} />
+            <HiOutlineCog className={`w-4 h-4 transition-transform duration-500 group-hover:rotate-45 ${isSettingsActive ? 'text-brand-500' : 'text-neutral-400 group-hover:text-neutral-700'}`} />
             <span>Settings</span>
           </Link>
         </div>

--- a/hooks/use-agent-info.ts
+++ b/hooks/use-agent-info.ts
@@ -9,7 +9,17 @@ import type { AgentInfo } from 'connectonion/react'
 
 export type { AgentInfo, SkillInfo, AgentAcceptedInputs } from 'connectonion/react'
 
-const POLL_INTERVAL = 30000 // 30 seconds
+const POLL_INTERVAL = 600000 // 10 minutes — info is cache-first + refetched on tab focus/mount; this is just a slow background revalidate for liveness/profile changes, not a tight poll
+
+// Last-known info per address, kept at module scope so it survives component
+// remounts. The Sidebar and agent pages live inside each route's subtree (there
+// is no shared app/[address]/layout.tsx), so navigating between sessions — or
+// creating a new one — remounts them and resets a plain useState({}) back to
+// empty, blanking the online indicator until the next fetch resolves (the
+// "offline flicker"). Seeding from this cache shows the last-known status
+// immediately; the 30s poll still refreshes it. Mirrors the SDK's module-level
+// storeCache, which solves the same survive-remount problem for sessions.
+const infoCache: Record<string, AgentInfo> = {}
 
 /**
  * Hook to fetch info for multiple agent addresses.
@@ -18,7 +28,15 @@ const POLL_INTERVAL = 30000 // 30 seconds
  * Polls every 30 seconds to keep status fresh.
  */
 export function useAgentInfo(addresses: string[]): Record<string, AgentInfo> {
-  const [infoMap, setInfoMap] = useState<Record<string, AgentInfo>>({})
+  // Seed from the module cache so a remount renders last-known status instantly
+  // instead of blanking the indicator until the first fetch returns.
+  const [infoMap, setInfoMap] = useState<Record<string, AgentInfo>>(() => {
+    const seed: Record<string, AgentInfo> = {}
+    for (const addr of addresses) {
+      if (infoCache[addr]) seed[addr] = infoCache[addr]
+    }
+    return seed
+  })
 
   // Stable key so a new array reference on each render doesn't restart polling
   const addressesKey = addresses.join(',')
@@ -28,12 +46,16 @@ export function useAgentInfo(addresses: string[]): Record<string, AgentInfo> {
 
     for (const addr of addresses) {
       fetchAgentInfo(addr).then(info => {
+        infoCache[addr] = info // authoritative result — persist across remounts
         setInfoMap(prev => {
           const existing = prev[addr]
           if (existing && JSON.stringify(existing) === JSON.stringify(info)) return prev
           return { ...prev, [addr]: info }
         })
       }).catch(() => {
+        // Transient fetch error: reflect offline in the live map but DON'T write
+        // it to infoCache — a network blip shouldn't overwrite the last-known
+        // (likely online) status that seeds the next remount.
         setInfoMap(prev => {
           if (prev[addr]?.online === false) return prev
           return { ...prev, [addr]: { address: addr, online: false } }

--- a/hooks/use-identity.ts
+++ b/hooks/use-identity.ts
@@ -140,6 +140,33 @@ export function useIdentity() {
     })
   }, [identity, setApiKey, setUserProfile])
 
+  // Re-fetch balance. The backend (oo-api) deducts as agents consume tokens
+  // through the managed proxy, but the profile is otherwise only fetched at
+  // login — so the balance would look frozen. Keep the last known value on a
+  // transient network failure (don't clear the UI on a background refresh).
+  const refreshProfile = useCallback(async () => {
+    const token = useChatStore.getState().openonionApiKey
+    if (!token) return
+    try {
+      setUserProfile(await getUserProfile(token))
+    } catch {
+      // transient — keep the stale balance rather than blanking it
+    }
+  }, [setUserProfile])
+
+  // Refresh on tab focus and on a slow interval while the tab is visible.
+  useEffect(() => {
+    const refresh = () => { if (!document.hidden) refreshProfile() }
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', refresh)
+    const id = setInterval(refresh, 60000)
+    return () => {
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', refresh)
+      clearInterval(id)
+    }
+  }, [refreshProfile])
+
   const generateNewIdentity = useCallback(() => {
     if (!window.confirm('This will generate a new identity. Make sure you have backed up your current recovery phrase! Continue?')) return
     const { keys: newKeys, mnemonic } = generateWithMnemonic()
@@ -216,5 +243,6 @@ export function useIdentity() {
     importKey,
     exportKey,
     dismissRecoveryPhrase,
+    refreshProfile,
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,12 @@
 
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Move the dev-only Next.js indicator to the bottom-right so it doesn't
+  // overlap the sidebar's Settings link.
+  devIndicators: {
+    position: "bottom-right",
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
End-to-end UI pass on oo-chat. Started from the awesome-design-skills `claude` skill, then re-themed to a **clean neutral canvas + single green brand accent** (dropped the warm/clay tint).

### Design system (`app/globals.css` `@theme`)
- Neutral (achromatic) canvas + `brand-*` green accent tokens
- Serif display headings, pulled-down radii, near-zero shadows, JetBrains mono

### Sidebar — light & minimal
- Live status strip (`N agents online`), reserved **nav rail**: Chats live, `Automation` / `Schedule` marked `SOON`
- Green active-accent bar, hidden scrollbar (`.no-scrollbar`)

### Agent landing
- Vertically centered hero (was top-heavy), de-layered skills list
- **Per-agent balance + top-up link** in the hero

### Billing / UX
- `useIdentity` now refreshes the profile on tab focus + interval, so backend token deductions actually show (previously fetched once at login → balance looked frozen). Note: deduction only happens for agents routed through the oo-api managed proxy; agents on their own provider key aren't charged.
- Tool-card preview modal shows the file **basename**, not the full path

### Config
- Dev indicator moved to `bottom-right` (was overlapping the sidebar Settings link)

## Scope note
This branch (`lab/direct-local`) also had uncommitted UI work (message/thinking/bash/file-card rendering, agent-info polling, the `[address]` layout). Those are folded in because the design work builds on them and the whole state builds & renders together.

## Verified
- `npm run build` passes (all routes)
- Changed files lint clean (pre-existing repo lint noise unchanged)
- Screenshotted: landing, settings, sidebar, green theme, per-agent top-up

## Known follow-up (not in this PR)
- **Mobile horizontal scroll**: the chat-session page (with tool cards) can scroll left/right on narrow viewports. Landing/home don't overflow; the culprit is a wide element in the transcript. Needs a repro with a live message stream to pin down and fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)