### PR TITLE
chore: bump connectonion to 0.1.7 (/api/agents)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
         "clsx": "^2.1.1",
-        "connectonion": "^0.1.6",
+        "connectonion": "^0.1.7",
         "next": "16.0.10",
         "prism-react-renderer": "^2.4.1",
         "react": "19.2.1",
@@ -1414,6 +1414,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -2619,9 +2679,9 @@
       "license": "MIT"
     },
     "node_modules/connectonion": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.1.6.tgz",
-      "integrity": "sha512-cHZ9H2Xv5rLkYBPUUX103t9jACumKd8IPBUC1wzhNzX77TwIRufznQoefU/75nHVaXV8Y1NGfArAxe0pbX450g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.1.7.tgz",
+      "integrity": "sha512-z3aljM4F5nHp5D7a0n0SiMCaPLopp8+G8m1IxzvaRxfHmeAxGDuKRswYwvy8lRfEGJjehMS4GUySnLuMEbORRQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.1.6",
+    "connectonion": "^0.1.7",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.1",


### PR DESCRIPTION
Bumps connectonion 0.1.6 → 0.1.7 (package.json + lockfile). The lockfile pinned 0.1.6 (old /api/relay/agents path), so a redeploy alone would not pick up the new path. 0.1.7 resolves agent discovery via /api/agents, now served by oo-api. Merging triggers the Vercel production deploy.