### PR TITLE
Fix: slash palette swallows typed args on Enter

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -102,7 +102,9 @@ export function ChatInput({
     setFiles(prev => prev.filter((_, i) => i !== index))
   }, [])
 
-  const slashQuery = value.startsWith('/') ? value.slice(1).split(' ')[0] : null
+  // Only active while typing the command token itself; a space commits the
+  // command and everything after it is arguments (palette dismissed, Enter sends).
+  const slashQuery = value.startsWith('/') && !value.includes(' ') ? value.slice(1) : null
   const filteredSkills = (slashQuery !== null && skills)
     ? skills.filter(s => s.name.startsWith(slashQuery))
     : []


### PR DESCRIPTION
## Problem

After selecting a skill from the `/` palette and typing arguments, pressing Enter did **not** send the message — it re-selected the skill and discarded everything typed after the command, so the input appeared to vanish.

## Root cause

`slashQuery` was computed as the first whitespace-delimited token after `/`:

```ts
const slashQuery = value.startsWith('/') ? value.slice(1).split(' ')[0] : null
```

So `/xiaoman-image-qc ababab` still resolved to `xiaoman-image-qc` and matched a skill. That kept `filteredSkills.length > 0`, which (1) left the palette open and (2) made `handleKeyDown` intercept Enter → `selectSkill` → overwrite the value with `/xiaoman-image-qc `, dropping the typed args.

## Fix

The palette is a command-name completion affordance — relevant only while typing the command token. A space commits the command; the rest is arguments. Gate the query on there being no space yet:

```ts
const slashQuery = value.startsWith('/') && !value.includes(' ') ? value.slice(1) : null
```

Palette dismisses once the command is committed, and Enter sends normally.

## Verification

- `npm run build` passes.
- Manual: `/skill` → select → type args → Enter sends the full message; palette no longer reappears.