### PR TITLE
Stop button: gracefully interrupt a running agent

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -113,6 +113,7 @@ export default function ChatSessionPage() {
     respondToPlanReview,
     setMode,
     reconnect,
+    interrupt,
   } = useAgentSDK({
     agentAddress: address,
     sessionId,
@@ -202,6 +203,7 @@ export default function ChatSessionPage() {
         <Chat
           ui={displayUI}
           onSend={handleSend}
+          onStop={interrupt}
           isLoading={isLoading}
           elapsedTime={elapsedTime}
           suggestions={[]}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -17,6 +17,8 @@ const MAX_FILES = 10
 
 export function ChatInput({
   onSend,
+  onStop,
+  isLoading = false,
   placeholder = 'Message...',
   statusBar,
   className,
@@ -352,22 +354,37 @@ export function ChatInput({
               )}
             </button>
 
-            {/* Send button */}
-            <button
-              onClick={handleSubmit}
-              disabled={
-                isVoiceActive ||
-                (!value.trim() && images.length === 0 && files.length === 0)
-              }
-              aria-label="Send message"
-              title="Send message"
-              className={cn(
-                'flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white transition-all duration-200 active:scale-95 shadow-sm',
-                'bg-neutral-900 hover:bg-neutral-800 disabled:bg-neutral-100 disabled:text-neutral-300'
-              )}
-            >
-              <HiOutlineArrowUp className="h-5 w-5 stroke-2" />
-            </button>
+            {/* Send / Stop button — becomes a stop button while the agent is running */}
+            {isLoading && onStop ? (
+              <button
+                onClick={onStop}
+                disabled={isVoiceActive}
+                aria-label="Stop agent"
+                title="Stop"
+                className={cn(
+                  'flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white transition-all duration-200 active:scale-95 shadow-sm',
+                  'bg-neutral-900 hover:bg-neutral-800 disabled:opacity-50'
+                )}
+              >
+                <span className="h-3 w-3 rounded-[3px] bg-white" />
+              </button>
+            ) : (
+              <button
+                onClick={handleSubmit}
+                disabled={
+                  isVoiceActive ||
+                  (!value.trim() && images.length === 0 && files.length === 0)
+                }
+                aria-label="Send message"
+                title="Send message"
+                className={cn(
+                  'flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white transition-all duration-200 active:scale-95 shadow-sm',
+                  'bg-neutral-900 hover:bg-neutral-800 disabled:bg-neutral-100 disabled:text-neutral-300'
+                )}
+              >
+                <HiOutlineArrowUp className="h-5 w-5 stroke-2" />
+              </button>
+            )}
           </div>
 
           {/* Mode bar - inside container */}

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -14,6 +14,7 @@ import type { ChatProps, ThinkingUI, UserUI } from './types'
 export function Chat({
   ui = [],
   onSend,
+  onStop,
   isLoading = false,
   placeholder = 'Send a message...',
   elapsedTime = 0,
@@ -111,6 +112,7 @@ export function Chat({
     return (
       <ChatInput
         onSend={handleSend}
+        onStop={onStop}
         isLoading={isLoading}
         placeholder={inputPlaceholder}
         statusBar={statusBar}

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -305,6 +305,8 @@ export interface SkillInfo {
 export interface ChatProps {
   ui?: UI[]
   onSend: (message: string, images?: string[], files?: FileAttachment[]) => void
+  /** Gracefully stop the running agent (shown as a stop button while isLoading) */
+  onStop?: () => void
   isLoading?: boolean
   placeholder?: string
   className?: string
@@ -354,6 +356,8 @@ export interface ChatMessageProps {
 
 export interface ChatInputProps {
   onSend: (message: string, images?: string[], files?: FileAttachment[]) => void
+  /** Gracefully stop the running agent; when provided, the send button becomes a stop button while isLoading */
+  onStop?: () => void
   isLoading?: boolean
   placeholder?: string
   className?: string

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -47,6 +47,8 @@ interface UseAgentSDKReturn {
   /** ULW mode: turns remaining (max - used) */
   ulwTurnsRemaining: number | null
   send: (content: string, images?: string[], files?: import('./types').FileAttachment[]) => void
+  /** Gracefully stop a running agent: it finishes the current step and returns a closing message */
+  interrupt: () => void
   respondToAskUser: (answer: string | string[]) => void
   respondToApproval: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
   respondToUlwTurnsReached: (action: 'continue' | 'switch_mode', options?: { turns?: number; mode?: ApprovalMode }) => void
@@ -271,6 +273,15 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     input(content, { images, files })
   }, [input])
 
+  // Graceful stop: the agent-side poll_interrupt handler drains this at the next
+  // iteration boundary, finishes the current step, and returns a closing message.
+  // No-op when the socket is closed (e.g. a restored session mid-run) — there is
+  // no live agent to signal, and RemoteAgent.send would throw on a null socket.
+  const interrupt = useCallback(() => {
+    if (connectionState !== 'connected') return
+    sendMessage({ type: 'INTERRUPT' })
+  }, [sendMessage, connectionState])
+
   const respondToAskUser = useCallback((answer: string | string[]) => {
     sendMessage({ type: 'ASK_USER_RESPONSE', answer: Array.isArray(answer) ? answer.join(', ') : answer })
   }, [sendMessage])
@@ -340,6 +351,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     ulwTurnsUsed: ulwTurnsUsed ?? null,
     ulwTurnsRemaining: ulwTurns != null && ulwTurnsUsed != null ? ulwTurns - ulwTurnsUsed : null,
     send,
+    interrupt,
     respondToAskUser,
     respondToApproval,
     respondToUlwTurnsReached,


### PR DESCRIPTION
## What

While the agent is running (`isLoading`), the send button becomes a **stop button**. Clicking it sends `{type:'INTERRUPT'}` over the existing WebSocket via `sendMessage` — the relay forwards the frame verbatim, so **no SDK change** is needed. `onStop` threads `page → Chat → ChatInput`. `interrupt()` no-ops when the socket is closed (e.g. a restored session mid-run) so a stray click can't throw.

## Graceful

The agent's `poll_interrupt` handler (openonion/connectonion#188) drains the INTERRUPT at the next iteration boundary, finishes the current step, and returns a closing message — a proper agent turn, not a silent cutoff. It does not abort an in-flight LLM call or a running tool.

## ⚠️ Merge order (coordination)

This is the frontend half. **Merging this deploys the button to chat.openonion.ai immediately** (Vercel), but the button only actually stops once a deployed agent runs a connectonion build that includes `poll_interrupt`. Until then it's a live-but-dead button (click does nothing; no error).

**Land order:** merge connectonion#188 → redeploy the agent on that connectonion → then merge this. Verified end-to-end: the agent-side stop was tested against #188's real code (a would-loop-forever agent stopped at iteration 4 when an INTERRUPT was injected through the relay's `send_to_agent` path).

## Verification

`npm run build` passes (at branch creation). Only the 5 stop files change; the #22 slash-palette fix and #23 storage cleanup are untouched.