### PR TITLE
feat(ui): QR share — scan to open an agent on your phone

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -8,6 +8,7 @@ import type { ApprovalMode } from '@/components/chat/types'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { QrShare } from '@/components/qr-share'
 
 const SUGGESTIONS = [
   'What can you do?',
@@ -145,20 +146,23 @@ export default function AgentLandingPage() {
                 <p className="text-[11px] text-neutral-400 font-mono">{metaLine}</p>
               )}
 
-              {/* Per-agent balance + top-up (one shared account balance) */}
-              {userProfile && (
-                <a
-                  href={`https://o.openonion.ai/purchase?agent=${address}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-3 inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
-                >
-                  <span className="font-mono text-neutral-400 uppercase tracking-wider">Balance</span>
-                  <span className="font-semibold text-neutral-900 tabular-nums">${userProfile.balance_usd.toFixed(2)}</span>
-                  <span className="text-neutral-300">·</span>
-                  <span className="font-medium text-brand-600">Top up →</span>
-                </a>
-              )}
+              {/* Secondary actions: balance/top-up (one shared account balance) + share via QR */}
+              <div className="mt-3 flex items-center justify-center gap-2">
+                {userProfile && (
+                  <a
+                    href={`https://o.openonion.ai/purchase?agent=${address}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
+                  >
+                    <span className="font-mono text-neutral-400 uppercase tracking-wider">Balance</span>
+                    <span className="font-semibold text-neutral-900 tabular-nums">${userProfile.balance_usd.toFixed(2)}</span>
+                    <span className="text-neutral-300">·</span>
+                    <span className="font-medium text-brand-600">Top up →</span>
+                  </a>
+                )}
+                <QrShare address={address} />
+              </div>
             </div>
 
             {/* Skills - slash command palette style */}

--- a/components/qr-share.tsx
+++ b/components/qr-share.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { HiOutlineQrcode, HiOutlineX, HiOutlineClipboardCopy, HiOutlineClipboardCheck } from 'react-icons/hi'
+
+/** Production oo-chat frontend. The QR always points here so a scan opens the
+ *  real site, not whatever origin the code is served from (localhost / preview). */
+const OO_CHAT_BASE = 'https://chat.openonion.ai'
+
+/**
+ * A "scan to open on your phone" affordance for an agent.
+ *
+ * The QR encodes this agent's full oo-chat URL (`${OO_CHAT_BASE}/${address}`), not
+ * the bare 0x address — a phone camera only jumps to http(s) URLs, so encoding the
+ * address alone would just surface unactionable text. Generation is fully
+ * client-side (no address leaves the tab).
+ */
+export function QrShare({ address }: { address: string }) {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const onEscape = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
+    window.addEventListener('keydown', onEscape)
+    return () => window.removeEventListener('keydown', onEscape)
+  }, [open])
+
+  const url = `${OO_CHAT_BASE}/${address}`
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        title="Scan to open on your phone"
+        aria-label="Show QR code"
+        className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] font-medium text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
+      >
+        <HiOutlineQrcode className="w-3.5 h-3.5 text-neutral-400" />
+        Share
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+          <div
+            className="absolute inset-0 bg-neutral-900/40 backdrop-blur-sm animate-in fade-in duration-200"
+            onClick={() => setOpen(false)}
+          />
+          <div className="relative w-full max-w-xs rounded-2xl border border-neutral-200 bg-white p-6 shadow-2xl animate-in zoom-in-95 fade-in duration-200">
+            <button
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              className="absolute right-3 top-3 p-1.5 rounded-lg text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 transition-colors"
+            >
+              <HiOutlineX className="w-4 h-4" />
+            </button>
+
+            <p className="text-center text-sm font-medium text-neutral-900">Scan to open on your phone</p>
+            <p className="mt-1 mb-5 text-center text-[11px] text-neutral-400">Point your camera at the code</p>
+
+            <div className="flex justify-center">
+              <div className="rounded-xl border border-neutral-200 bg-white p-3">
+                <QRCodeSVG value={url} size={200} level="M" marginSize={0} />
+              </div>
+            </div>
+
+            <button
+              onClick={handleCopy}
+              className="mt-5 flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2.5 text-xs font-medium text-neutral-600 hover:border-neutral-300 hover:bg-white transition-colors"
+            >
+              {copied ? (
+                <><HiOutlineClipboardCheck className="w-4 h-4 text-green-600" /> Copied</>
+              ) : (
+                <><HiOutlineClipboardCopy className="w-4 h-4" /> Copy link</>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "connectonion": "^0.1.7",
         "next": "16.0.10",
         "prism-react-renderer": "^2.4.1",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "react-icons": "^5.5.0",
@@ -6330,6 +6331,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "connectonion": "^0.1.7",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
## What

A **Share** pill on the agent landing page (`/[address]`) opens a QR code of the agent's oo-chat URL. Scanning it on a phone opens that agent's chat directly.

## Why it encodes a URL, not the bare address

A phone camera only jumps to `http(s)` URLs. Encoding the raw `0x…` address would surface unactionable text, so the QR encodes `https://chat.openonion.ai/<address>`. The base is **fixed to production** so a scan never lands on `localhost` or a preview origin.

## Files

- `components/qr-share.tsx` (new) — Share pill + QR modal + copy-link. Client-side generation (`qrcode.react`), address never leaves the tab.
- `app/[address]/page.tsx` — Share pill placed next to the Balance pill in the hero.
- `package.json` / `package-lock.json` — add `qrcode.react`.

## Verification

- `npm run build` passes (fresh install, published `connectonion`, no SDK symlink).
- Browser-dogfooded: modal renders, no console errors.
- Decoded the rendered QR → `https://chat.openonion.ai/0x2aaf…` (fixed prefix confirmed even when served from localhost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)