### PR TITLE
Stop button reacts instantly: optimistic UI stop before agent confirms

### DIFF
--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -133,6 +133,28 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
   return { pendingAskUser, pendingApproval, pendingOnboard, pendingUlwTurnsReached, pendingPlanReview }
 }
 
+/**
+ * Optimistic stop: flip every in-flight status to its finished value so spinners
+ * stop the moment the user clicks Stop, before the agent's closing events arrive.
+ */
+function stopRunningItems(ui: ChatItem[]): ChatItem[] {
+  return ui.map((item) => {
+    switch (item.type) {
+      case 'thinking':
+      case 'tool_call':
+        return item.status === 'running' ? { ...item, status: 'done' as const } : item
+      case 'intent':
+        return item.status === 'analyzing' ? { ...item, status: 'understood' as const } : item
+      case 'eval':
+        return item.status === 'evaluating' ? { ...item, status: 'done' as const } : item
+      case 'compact':
+        return item.status === 'compacting' ? { ...item, status: 'done' as const } : item
+      default:
+        return item
+    }
+  })
+}
+
 function hasActiveRestoredItem(ui: ChatItem[]): boolean {
   return ui.some((item) => {
     switch (item.type) {
@@ -174,19 +196,36 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     setMode: sdkSetMode,
     reconnect: sdkReconnect,
   } = useAgentForHuman(agentAddress, sessionId)
+  // Optimistic stop: set the instant the user clicks Stop, cleared when the run
+  // actually ends (status → idle) or the user sends a new message. While set,
+  // the UI renders as stopped even though the agent is still finishing its
+  // current step server-side.
+  const [stopRequested, setStopRequested] = useState(false)
+
   // Each connect attempt to a non-onboarded agent emits a fresh onboard_required
   // (new UUID, so dedupeUI keeps them all) — keep only the latest card.
   const cleanUI = useMemo(() => {
-    const items = dedupeUI(ui as import('./types').UI[]) as ChatItem[]
+    let items = dedupeUI(ui as import('./types').UI[]) as ChatItem[]
     let lastOnboardIndex = -1
     for (let i = items.length - 1; i >= 0; i--) {
       if (items[i].type === 'onboard_required') { lastOnboardIndex = i; break }
     }
-    if (lastOnboardIndex === -1) return items
-    return items.filter((item, i) => item.type !== 'onboard_required' || i === lastOnboardIndex)
-  }, [ui])
+    if (lastOnboardIndex !== -1) {
+      items = items.filter((item, i) => item.type !== 'onboard_required' || i === lastOnboardIndex)
+    }
+    return stopRequested ? stopRunningItems(items) : items
+  }, [ui, stopRequested])
   const hasActiveUI = useMemo(() => hasActiveRestoredItem(cleanUI), [cleanUI])
-  const isLoading = isProcessing || hasActiveUI
+  const isLoading = (isProcessing || hasActiveUI) && !stopRequested
+
+  // The run ended for real (closing message arrived, or a fresh run started and
+  // finished) — hand the UI back to the SDK's event stream. Adjust-during-render
+  // pattern (not an effect): react.dev/learn/you-might-not-need-an-effect
+  const [prevRunStatus, setPrevRunStatus] = useState(status)
+  if (status !== prevRunStatus) {
+    setPrevRunStatus(status)
+    if (status === 'idle' && stopRequested) setStopRequested(false)
+  }
 
   // Poll server session status only after user was just connected (processing → idle)
   // Don't poll on page load for old sessions — no point checking expired sessions
@@ -253,16 +292,22 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
 
   // Send message
   const send = useCallback((content: string, images?: string[], files?: import('./types').FileAttachment[]) => {
+    setStopRequested(false)
     input(content, { images, files })
   }, [input])
 
-  // Graceful stop: the agent-side poll_interrupt handler drains this at the next
-  // iteration boundary, finishes the current step, and returns a closing message.
-  // No-op when the socket is closed (e.g. a restored session mid-run) — there is
-  // no live agent to signal, and RemoteAgent.send would throw on a null socket.
+  // Stop: the UI stops immediately (optimistic — spinners freeze, the input
+  // returns to send mode), while the agent-side poll_interrupt handler drains
+  // the INTERRUPT at the next iteration boundary, finishes the current step,
+  // and returns a closing message that reconciles the transcript.
+  // The INTERRUPT frame is only sent on a live socket (RemoteAgent.send throws
+  // on a null socket), but the optimistic UI stop applies regardless, so a
+  // restored session stuck showing "running" can also be dismissed.
   const interrupt = useCallback(() => {
-    if (connectionState !== 'connected') return
-    sendMessage({ type: 'INTERRUPT' })
+    setStopRequested(true)
+    if (connectionState === 'connected') {
+      sendMessage({ type: 'INTERRUPT' })
+    }
   }, [sendMessage, connectionState])
 
   const respondToAskUser = useCallback((answer: string | string[]) => {


### PR DESCRIPTION
Clicking Stop previously gave no feedback until the agent finished its
current step and returned a closing message (or gave none at all when the
backend predates INTERRUPT support) — the UI kept showing spinners and the
stop button as if nothing happened.

Now interrupt() sets a local stopRequested flag that immediately:
- flips isLoading off (input returns to send mode, loading indicator hides)
- freezes all in-flight statuses (thinking/tool_call running, intent
  analyzing, eval evaluating, compact compacting) to their finished values

The INTERRUPT frame is still sent on a live socket; when the run truly ends
(status returns to idle) or the user sends a new message, the flag clears
and the SDK event stream becomes the source of truth again. The optimistic
stop also lets users dismiss a restored session stuck showing running.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ToUF8yso9vz3iFtV1Gpav