### PR TITLE
Show the connected agent's balance in Settings, not the browser identity's

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -62,7 +62,6 @@ export default function AgentLandingPage() {
     createConversation,
     setPendingMessage,
     clearActive,
-    userProfile,
   } = useChatStore()
 
   useIdentity()
@@ -189,21 +188,9 @@ export default function AgentLandingPage() {
                 </p>
               )}
 
-              {/* Secondary actions: balance/top-up (one shared account balance) + share via QR */}
+              {/* Balance lives in Settings now (it's the connected agent's balance,
+                  not this browser identity's) — the header only offers sharing. */}
               <div className="mt-3 flex items-center justify-center gap-2">
-                {userProfile && (
-                  <a
-                    href={`https://o.openonion.ai/purchase?agent=${address}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
-                  >
-                    <span className="font-mono text-neutral-400 uppercase tracking-wider">Balance</span>
-                    <span className="font-semibold text-neutral-900 tabular-nums">${userProfile.balance_usd.toFixed(2)}</span>
-                    <span className="text-neutral-300">·</span>
-                    <span className="font-medium text-neutral-900">Top up →</span>
-                  </a>
-                )}
                 <QrShare address={address} />
               </div>
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,7 +9,6 @@ import {
   HiOutlineClipboardCopy,
   HiOutlineCheck,
   HiOutlineShieldCheck,
-  HiOutlineCreditCard,
   HiOutlineServer,
   HiOutlineUserCircle,
   HiOutlineTrash,
@@ -32,7 +31,6 @@ export default function SettingsPage() {
     addAgent,
     removeAgent,
     openonionApiKey,
-    userProfile,
     conversations,
   } = useChatStore()
 
@@ -40,7 +38,6 @@ export default function SettingsPage() {
 
   const {
     identity,
-    authLoading,
     authError,
     showRecoveryPhrase,
     newMnemonic,
@@ -109,74 +106,32 @@ export default function SettingsPage() {
               </div>
               <div>
                 <h2 className="font-serif text-xl font-semibold text-neutral-900">Account</h2>
-                <p className="text-xs text-neutral-500 font-medium">Manage your identity and credits</p>
+                <p className="text-xs text-neutral-500 font-medium">Your identity and communication key</p>
               </div>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {/* Balance Card */}
-              <div className="md:col-span-1 bg-neutral-900 rounded-3xl p-8 text-white shadow-2xl flex flex-col justify-between relative overflow-hidden group">
-                <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full blur-3xl -mr-16 -mt-16 group-hover:bg-white/10 transition-all duration-700" />
-
-                <div>
-                  <div className="flex items-center justify-between mb-8">
-                    <span className="text-xs font-bold text-neutral-400 uppercase tracking-widest flex items-center gap-2">
-                      <HiOutlineCreditCard className="w-4 h-4" />
-                      Balance
-                    </span>
-                    {authLoading && (
-                      <span className="w-2 h-2 bg-neutral-500 rounded-full animate-ping" />
-                    )}
-                  </div>
-
-                  {authError ? (
-                    <div className="text-red-300 text-xs bg-red-900/30 px-3 py-2 rounded-xl border border-red-800/50">
-                      {authError}
-                    </div>
-                  ) : userProfile ? (
-                    <div className="space-y-1">
-                      <div className="text-4xl font-black tracking-tighter">
-                        ${userProfile.balance_usd.toFixed(2)}
-                      </div>
-                      <div className="text-[10px] text-neutral-400 font-medium uppercase tracking-wider">Available Credits</div>
-                    </div>
-                  ) : (
-                    <div className="text-neutral-500 text-sm font-medium italic">Syncing...</div>
-                  )}
+            <div className="grid grid-cols-1 gap-6">
+              {/* This browser identity is not an agent — it signs you in and carries
+                  the ConnectOnion protocol. Credits belong to the agents you connect
+                  to (shown per agent below), so no balance is featured here. */}
+              {authError && (
+                <div className="text-red-700 text-xs bg-red-50 px-4 py-3 rounded-2xl border border-red-200">
+                  {authError}
                 </div>
-
-                <div className="mt-8">
-                  {userProfile && (
-                    <div className="flex items-center gap-6 py-4 border-t border-white/10 text-[11px] text-white/50 font-bold uppercase tracking-wider">
-                      <div className="flex flex-col gap-1">
-                        <span className="text-white/30">Purchased</span>
-                        <span className="text-white">${userProfile.credits_usd.toFixed(2)}</span>
-                      </div>
-                      <div className="flex flex-col gap-1">
-                        <span className="text-white/30">Spent</span>
-                        <span className="text-white">${userProfile.total_cost_usd.toFixed(2)}</span>
-                      </div>
-                    </div>
-                  )}
-                  <a
-                    href="https://o.openonion.ai/purchase"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-6 block w-full py-3 bg-white hover:bg-neutral-200 text-neutral-900 text-center text-xs font-bold rounded-xl transition-all active:scale-95"
-                  >
-                    + Add Credits
-                  </a>
-                </div>
-              </div>
+              )}
 
               {/* Identity Details Card */}
-              <div className="md:col-span-2 bg-white rounded-3xl p-8 border border-neutral-200/60 shadow-sm space-y-8">
+              <div className="bg-white rounded-3xl p-8 border border-neutral-200/60 shadow-sm space-y-8">
                 {identity ? (
                   <>
+                    <p className="text-xs text-neutral-500 leading-relaxed -mt-1">
+                      This key signs you in and carries the ConnectOnion protocol. It isn&apos;t an
+                      agent and holds no agent credits — each agent&apos;s balance is shown below.
+                    </p>
                     <div className="space-y-6">
                       <div className="space-y-3">
                         <label className="text-[10px] font-bold text-neutral-500 uppercase tracking-widest px-1">
-                          Wallet Address
+                          Identity Address
                         </label>
                         <div className="group relative">
                           <div className="w-full px-4 py-3 bg-neutral-50 border border-neutral-100 rounded-2xl text-xs font-mono text-neutral-600 break-all leading-relaxed pr-12 transition-all hover:bg-white hover:border-neutral-200">
@@ -364,6 +319,25 @@ export default function SettingsPage() {
                             </div>
                           )}
                         </div>
+
+                        {/* Agent balance — the account that actually spends credits.
+                            Only co/* managed-key agents publish it (see AgentInfo). */}
+                        {typeof info?.balance_usd === 'number' && (
+                          <a
+                            href={`https://o.openonion.ai/purchase?agent=${address}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="group/balance shrink-0 flex flex-col items-end gap-0.5 px-3 py-1.5 rounded-xl hover:bg-neutral-50 transition-colors"
+                            title="Top up this agent"
+                          >
+                            <span className="text-sm font-bold text-neutral-900 tabular-nums">
+                              ${info.balance_usd.toFixed(2)}
+                            </span>
+                            <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider group-hover/balance:text-neutral-600 transition-colors">
+                              Top up →
+                            </span>
+                          </a>
+                        )}
 
                         {/* Delete */}
                         <button

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -37,7 +37,7 @@ const NAV_ITEMS = [
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const router = useRouter()
   const pathname = usePathname()
-  const { agents, conversations, deleteConversation, removeAgent, userProfile } = useChatStore()
+  const { agents, conversations, deleteConversation, removeAgent } = useChatStore()
   const infoMap = useAgentInfo(agents)
 
   // Track which agents are expanded (all expanded by default)
@@ -332,27 +332,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             <HiOutlinePlus className="w-4 h-4" />
             Add Agent
           </Link>
-
-          {userProfile && (
-            <a
-              href="https://o.openonion.ai/purchase"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group block px-3 py-2.5 rounded-lg bg-neutral-50 hover:bg-neutral-100 border border-neutral-200 transition-colors"
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-[10px] font-mono font-medium text-neutral-500 uppercase tracking-widest">Balance</span>
-                  <span className="text-sm font-semibold text-neutral-900 tabular-nums">
-                    ${userProfile.balance_usd.toFixed(2)}
-                  </span>
-                </div>
-                <span className="text-[11px] font-medium text-neutral-900 group-hover:text-neutral-600 transition-colors">
-                  Top up →
-                </span>
-              </div>
-            </a>
-          )}
 
           <Link
             href="/settings"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,9 +73,20 @@ SDK. The SDK lives in `../connectonion-ts`; shipping it is in [DEPLOY.md](./DEPL
 
 First load generates a recovery phrase → Ed25519 keypair (your account). The app
 signs a message, posts it to `/api/auth` (a proxy to `oo.openonion.ai`), and gets a
-JWT — used for credits, voice transcription, and the managed `co/` models. Back it up
-from **Settings**. The agent you chat with has its own `0x…` address; don't confuse
-the two.
+JWT — used for voice transcription and login. Back it up from **Settings**. This key
+is a communication/auth identity, **not an agent**: it runs no LLM calls and pays for
+no agent usage. The agent you chat with has its own `0x…` address; don't confuse the two.
+
+## Balance
+
+Credits are spent by the **agent** you connect to (it runs `co/*` on managed keys and
+deducts from *its* OpenOnion account), not by your browser identity. Balance is
+per-address and gated by that address's private key, so the frontend — which only holds
+its own key — can't query an agent's balance directly. Instead the agent reports it:
+the host publishes a `balance_usd` snapshot in its ANNOUNCE profile / `/info`
+(`connectonion`), the SDK surfaces it on `AgentInfo` (`fetchAgentInfo`), and oo-chat
+shows it **per agent in Settings** (a startup snapshot, refreshed when the agent
+restarts — not a live figure). Non-`co/*` agents publish no balance and simply show none.
 
 ## Configuration
 

--- a/hooks/use-identity.ts
+++ b/hooks/use-identity.ts
@@ -140,32 +140,10 @@ export function useIdentity() {
     })
   }, [identity, setApiKey, setUserProfile])
 
-  // Re-fetch balance. The backend (oo-api) deducts as agents consume tokens
-  // through the managed proxy, but the profile is otherwise only fetched at
-  // login — so the balance would look frozen. Keep the last known value on a
-  // transient network failure (don't clear the UI on a background refresh).
-  const refreshProfile = useCallback(async () => {
-    const token = useChatStore.getState().openonionApiKey
-    if (!token) return
-    try {
-      setUserProfile(await getUserProfile(token))
-    } catch {
-      // transient — keep the stale balance rather than blanking it
-    }
-  }, [setUserProfile])
-
-  // Refresh on tab focus and on a slow interval while the tab is visible.
-  useEffect(() => {
-    const refresh = () => { if (!document.hidden) refreshProfile() }
-    window.addEventListener('focus', refresh)
-    document.addEventListener('visibilitychange', refresh)
-    const id = setInterval(refresh, 60000)
-    return () => {
-      window.removeEventListener('focus', refresh)
-      document.removeEventListener('visibilitychange', refresh)
-      clearInterval(id)
-    }
-  }, [refreshProfile])
+  // No live profile polling: this browser identity isn't the account that spends
+  // credits (the connected agent is), and its balance is no longer shown. The JWT
+  // above is what's needed for auth / voice transcription; the profile is fetched
+  // once at login. Agent balances are polled per-agent via useAgentInfo.
 
   const generateNewIdentity = useCallback(() => {
     if (!window.confirm('This will generate a new identity. Make sure you have backed up your current recovery phrase! Continue?')) return
@@ -243,6 +221,5 @@ export function useIdentity() {
     importKey,
     exportKey,
     dismissRecoveryPhrase,
-    refreshProfile,
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.1.7",
+    "connectonion": "^0.1.8",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
## Summary
The balance shown across OOCAT was the **browser identity's** (`userProfile.balance_usd` from `/api/v1/auth/me`). But that identity isn't an agent — it runs no LLM calls and spends no credits. The account that actually pays is the backend `co/*` agent you connect to. So the number was the wrong account: it never moved with usage, and "Top up" funded the wrong balance.

This switches the balance to the **connected agent's** balance, sourced from its `AgentInfo`, and reframes the browser identity as an internal communication/auth key. Part 3 of 3 (backend → SDK → **frontend**).

Fixes openonion/oo-chat#31.

## Changes
- **Settings** (`app/settings/page.tsx`): show each agent's balance in the Agents list (`info.balance_usd`) with a per-agent "Top up →" link; removed the browser-identity "Balance" card; the Account section now presents the identity as a communication key ("Identity Address"), with a one-line explanation that it holds no agent credits.
- **Sidebar** (`components/sidebar.tsx`): removed the browser-identity balance footer block.
- **Agent landing** (`app/[address]/page.tsx`): removed the balance/top-up chip from the header (balance is Settings-only now).
- **Docs** (`docs/ARCHITECTURE.md`): new "Balance" section explaining the data flow and the identity-vs-agent distinction.
- **Dependency** (`package.json`): bump `connectonion ^0.1.7 → ^0.1.8` (adds `balance_usd` to `AgentInfo`).

## Design decisions (from openonion/oo-chat#31)
- **Balance is Settings-only**, shown on demand — not live during chat. It's a startup snapshot from the agent's profile.
- **Public profile** for now; a later admin/subscriber gate is deferred.

## Testing / release ordering
⚠️ Depends on **connectonion 0.1.8** (`openonion/connectonion-ts`), which adds `balance_usd` to `AgentInfo`. Per `docs/DEPLOY.md`, the SDK is published first, then `npm install` + `npm run build` here. Because 0.1.8 isn't on npm yet, a production build/typecheck can't run in CI until it publishes — merge order: `connectonion-ts` (tag `v0.1.8`) → this PR. The `connectonion` host PR provides the data.
- Graceful fallback: agents without a published balance (non-`co/*`, offline, older agent/SDK) simply show no balance line.

---
_Generated by [Claude Code](https://claude.ai/code/session_014MCXF2XGjWhvRpiKS4KfcU)_