### PR TITLE
9900 F11C-Bread: add server-backed evidence and disabled chat options

### DIFF
--- a/components/chat/ask-user-options.ts
+++ b/components/chat/ask-user-options.ts
@@ -1,0 +1,11 @@
+export const OOCHAT_DISABLED_OPTION_PREFIX = '__OOCHAT_DISABLED__::'
+
+export function isAskUserOptionDisabled(option: string, disabledOptions: Set<string>): boolean {
+  return disabledOptions.has(option) || option.startsWith(OOCHAT_DISABLED_OPTION_PREFIX)
+}
+
+export function askUserOptionLabel(option: string): string {
+  return option.startsWith(OOCHAT_DISABLED_OPTION_PREFIX)
+    ? option.slice(OOCHAT_DISABLED_OPTION_PREFIX.length)
+    : option
+}

--- a/components/chat/chat-ask-user.tsx
+++ b/components/chat/chat-ask-user.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-icons/hi'
 import { cn } from './utils'
 import { ASK_USER_SKIP_ANSWER, SkipButton } from './ask-user-skip'
+import { askUserOptionLabel, isAskUserOptionDisabled } from './ask-user-options'
 import type { PendingAskUser } from './types'
 
 interface ChatAskUserProps {
@@ -25,6 +26,9 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
   const { multi_select, input_type, fields } = askUser
   const question = typeof askUser.question === 'string' ? askUser.question : ''
   const options = Array.isArray(askUser.options) ? askUser.options : []
+  const disabledOptions = new Set(
+    Array.isArray(askUser.disabled_options) ? askUser.disabled_options : []
+  )
   const [selected, setSelected] = useState<string[]>([])
   const [textInput, setTextInput] = useState('')
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({})
@@ -42,6 +46,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
   const hasMissingRequiredField = formFields.some(field => field.required && !fieldValues[field.name]?.trim())
 
   const handleOptionClick = (option: string) => {
+    if (isAskUserOptionDisabled(option, disabledOptions)) return
     if (multi_select) {
       setSelected(prev =>
         prev.includes(option)
@@ -133,19 +138,26 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
             <div className="grid grid-cols-1 gap-1.5">
               {options.map((option, idx) => {
                 const isSelected = selected.includes(option)
+                const isDisabled = isAskUserOptionDisabled(option, disabledOptions)
                 return (
                   <button
                     key={idx}
                     onClick={() => handleOptionClick(option)}
+                    disabled={isDisabled}
+                    aria-disabled={isDisabled}
                     className={cn(
                       'group flex w-full items-center gap-3 rounded-md border px-3 py-2.5 text-left text-sm transition-all duration-200',
-                      isSelected
+                      isDisabled
+                        ? 'cursor-not-allowed border-neutral-100 bg-neutral-50 text-neutral-400 opacity-70'
+                        : isSelected
                         ? 'border-neutral-300 bg-neutral-50 text-neutral-900'
                         : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:text-neutral-900'
                     )}
                   >
                     <div className="shrink-0">
-                      {multi_select ? (
+                      {isDisabled ? (
+                        <div className="h-5 w-5 rounded-full border-2 border-neutral-200 bg-neutral-100" />
+                      ) : multi_select ? (
                         isSelected ? (
                           <HiOutlineCheckCircle className="w-5 h-5 text-neutral-900" />
                         ) : (
@@ -156,7 +168,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
                       )}
                     </div>
                     <span className={cn(isSelected ? 'font-bold' : 'font-medium')}>
-                      {option}
+                      {askUserOptionLabel(option)}
                     </span>
                   </button>
                 )

--- a/components/chat/dedupe-ui.ts
+++ b/components/chat/dedupe-ui.ts
@@ -97,6 +97,7 @@ function normalizeItem(rawItem: unknown, index: number): UI | null {
         ...item,
         text: stringValue(item.text || item.question),
         options: stringArray(item.options) || [],
+        disabled_options: stringArray(item.disabled_options) || [],
         multi_select: item.multi_select === true,
         input_type: stringValue(item.input_type),
         fields: sanitizeFields(item.fields),

--- a/components/chat/messages/agent.tsx
+++ b/components/chat/messages/agent.tsx
@@ -6,22 +6,25 @@ import remarkGfm from 'remark-gfm'
 import { HiOutlineArrowDownTray } from 'react-icons/hi2'
 import type { AgentUI } from '../types'
 import { downloadImage, imageFileName } from '../utils'
+import { extractLinkedInEmbeds, LinkedInEmbeds } from './linkedin-embed'
 
 export function Agent({ message }: { message: AgentUI }) {
-  const content = typeof message.content === 'string' ? message.content : ''
+  const rawContent = typeof message.content === 'string' ? message.content : ''
+  const { text: content, embeds } = extractLinkedInEmbeds(rawContent)
   // The SDK strips base64 payloads from persisted sessions — items can carry
   // image entries that no longer render. Filter them so no phantom gap remains.
   const images = (Array.isArray(message.images) ? message.images : [])
     .filter(src => src.startsWith('data:') || src.startsWith('http') || src.startsWith('blob:'))
   const hasImages = images.length > 0
   const hasText = content.trim().length > 0
+  const hasEmbeds = embeds.length > 0
 
-  if (!hasText && !hasImages) return null
+  if (!hasText && !hasImages && !hasEmbeds) return null
 
   // Image-only items are tool output (e.g. take_screenshot streams an
   // agent_image event with no text) — render the image plainly, without the
   // avatar bubble that would make it look like the agent "said" something.
-  if (!hasText) {
+  if (!hasText && !hasEmbeds) {
     return (
       <div className="py-2 pl-11">
         <AgentImages images={images} />
@@ -59,6 +62,7 @@ export function Agent({ message }: { message: AgentUI }) {
 
         {/* Images - displayed below text */}
         {hasImages && <AgentImages images={images} />}
+        {hasEmbeds && <LinkedInEmbeds embeds={embeds} />}
       </div>
     </div>
   )

--- a/components/chat/messages/linkedin-embed.tsx
+++ b/components/chat/messages/linkedin-embed.tsx
@@ -1,0 +1,116 @@
+interface LinkedInEmbedData {
+  url: string
+  postUrl?: string
+  title: string
+  width: number
+  height: number
+}
+
+const DIRECTIVE_PATTERN = /\[\[linkedin_embed\]\]([\s\S]*?)\[\[\/linkedin_embed\]\]/g
+const EMBED_PATH = /^\/embed\/feed\/update\/urn:li:(activity|share|ugcPost):\d+\/?$/i
+
+function normalizeLinkedInPostUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  try {
+    const parsed = new URL(value)
+    if (
+      parsed.protocol !== 'https:'
+      || (parsed.hostname !== 'www.linkedin.com' && parsed.hostname !== 'linkedin.com')
+      || parsed.username
+      || parsed.password
+    ) return undefined
+    parsed.hostname = 'www.linkedin.com'
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeEmbed(value: unknown): LinkedInEmbedData | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const data = value as Record<string, unknown>
+  if (data.provider !== 'linkedin' || typeof data.url !== 'string') return null
+
+  try {
+    const parsed = new URL(data.url)
+    if (
+      parsed.protocol !== 'https:'
+      || parsed.hostname !== 'www.linkedin.com'
+      || parsed.username
+      || parsed.password
+      || !EMBED_PATH.test(parsed.pathname)
+    ) return null
+    for (const key of parsed.searchParams.keys()) {
+      if (key !== 'collapsed') return null
+    }
+    const collapsed = parsed.searchParams.get('collapsed')
+    if (collapsed !== null && collapsed !== '0' && collapsed !== '1') return null
+    parsed.hash = ''
+
+    return {
+      url: parsed.toString(),
+      postUrl: normalizeLinkedInPostUrl(data.post_url),
+      title: typeof data.title === 'string' && data.title.trim()
+        ? data.title.trim().slice(0, 160)
+        : 'LinkedIn post',
+      width: Math.max(280, Math.min(Number(data.width) || 504, 1200)),
+      height: Math.max(320, Math.min(Number(data.height) || 900, 1800)),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function extractLinkedInEmbeds(content: string): {
+  text: string
+  embeds: LinkedInEmbedData[]
+} {
+  const embeds: LinkedInEmbedData[] = []
+  const text = content.replace(DIRECTIVE_PATTERN, (_directive, raw: string) => {
+    try {
+      const embed = normalizeEmbed(JSON.parse(raw))
+      if (embed) embeds.push(embed)
+    } catch {
+      // Invalid or untrusted directives are omitted instead of rendered as HTML.
+    }
+    return ''
+  }).trim()
+  return { text, embeds }
+}
+
+export function LinkedInEmbeds({ embeds }: { embeds: LinkedInEmbedData[] }) {
+  if (!embeds.length) return null
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {embeds.map((embed) => (
+        <div
+          key={embed.url}
+          className="w-full max-w-[504px] overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
+        >
+          <iframe
+            src={embed.url}
+            title={embed.title}
+            width={embed.width}
+            height={embed.height}
+            loading="lazy"
+            referrerPolicy="strict-origin-when-cross-origin"
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            allowFullScreen
+            className="block min-h-[420px] w-full border-0"
+          />
+          {embed.postUrl && (
+            <a
+              href={embed.postUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="block border-t border-neutral-100 px-4 py-3 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+            >
+              Open this post on LinkedIn
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/chat/messages/tools/ask-user-card.tsx
+++ b/components/chat/messages/tools/ask-user-card.tsx
@@ -19,6 +19,7 @@ import {
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import { ASK_USER_SKIP_ANSWER, SkipButton } from '../../ask-user-skip'
+import { askUserOptionLabel, isAskUserOptionDisabled } from '../../ask-user-options'
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -46,11 +47,12 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
   const question = (args?.question as string) || ''
   const isPending = !!pendingAskUser && !!onAskUserResponse && status === 'running' && !responded
   const options = pendingAskUser?.options
+  const disabledOptions = new Set(pendingAskUser?.disabled_options || [])
   const multiSelect = pendingAskUser?.multi_select
   const isQr = !!qrImage && !!(options && options.length) && /scan|qr|二维码|扫码/i.test(`${question} ${(options || []).join(' ')}`)
 
   const handleOptionClick = (option: string) => {
-    if (!isPending) return
+    if (!isPending || isAskUserOptionDisabled(option, disabledOptions)) return
     if (multiSelect) {
       setSelected(prev =>
         prev.includes(option)
@@ -179,9 +181,11 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                           <button
                             key={idx}
                             onClick={() => handleOptionClick(option)}
-                            className="w-full bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-bold py-2.5 rounded-xl transition-all active:scale-[0.99]"
+                            disabled={isAskUserOptionDisabled(option, disabledOptions)}
+                            aria-disabled={isAskUserOptionDisabled(option, disabledOptions)}
+                            className="w-full bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-bold py-2.5 rounded-xl transition-all active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-400"
                           >
-                            {option}
+                            {askUserOptionLabel(option)}
                           </button>
                         ))}
                         <SkipButton onSkip={handleSkip} />
@@ -206,19 +210,26 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                 <div className="grid grid-cols-1 gap-1.5">
                   {options.map((option, idx) => {
                     const isSelected = selected.includes(option)
+                    const isDisabled = isAskUserOptionDisabled(option, disabledOptions)
                     return (
                       <button
                         key={idx}
                         onClick={() => handleOptionClick(option)}
+                        disabled={isDisabled}
+                        aria-disabled={isDisabled}
                         className={cn(
                           "w-full flex items-center gap-3 px-4 py-3 text-left rounded-xl transition-all duration-200 border group/item",
-                          isSelected
+                          isDisabled
+                            ? "cursor-not-allowed bg-neutral-50 text-neutral-400 border-neutral-100 opacity-70"
+                            : isSelected
                             ? "bg-neutral-100 text-neutral-900 border-neutral-400 shadow-sm"
                             : "bg-white text-neutral-700 border-neutral-200 hover:border-neutral-400 hover:bg-neutral-50"
                         )}
                       >
                         <div className="shrink-0">
-                          {multiSelect ? (
+                          {isDisabled ? (
+                            <div className="w-5 h-5 rounded-full border-2 border-neutral-200 bg-neutral-100" />
+                          ) : multiSelect ? (
                             isSelected ? (
                               <HiOutlineCheckCircle className="w-5 h-5 text-neutral-900" />
                             ) : (
@@ -232,7 +243,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                           "text-sm",
                           isSelected ? "font-semibold" : "font-medium text-neutral-600"
                         )}>
-                          {option}
+                          {askUserOptionLabel(option)}
                         </span>
                       </button>
                     )

--- a/components/chat/migrate-agent-session.ts
+++ b/components/chat/migrate-agent-session.ts
@@ -1,0 +1,79 @@
+const migratedKeys = new Set<string>()
+const OMITTED_DATA_URL = '[legacy image removed; use server evidence reference]'
+
+function shouldKeepImage(value: unknown): value is string {
+  return (
+    typeof value === 'string'
+    && !value.startsWith('data:')
+    && value.length <= 8192
+  )
+}
+
+function sanitize(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(
+      /data:[^;,\s]+;base64,[A-Za-z0-9+/=]+/g,
+      OMITTED_DATA_URL,
+    )
+  }
+  if (Array.isArray(value)) return value.map(sanitize)
+  if (!value || typeof value !== 'object') return value
+
+  const next: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'images' && Array.isArray(item)) {
+      const images = item.filter(shouldKeepImage)
+      if (images.length) next[key] = images
+      continue
+    }
+    if (key === 'dataUrl' && typeof item === 'string' && item.startsWith('data:')) {
+      continue
+    }
+    next[key] = sanitize(item)
+  }
+  return next
+}
+
+function sanitizeStoredSession(key: string): void {
+  const original = window.localStorage.getItem(key)
+  if (!original || !original.includes('data:')) return
+  try {
+    const sanitized = JSON.stringify(sanitize(JSON.parse(original)))
+    if (sanitized.length >= original.length) return
+    window.localStorage.removeItem(key)
+    try {
+      window.localStorage.setItem(key, sanitized)
+    } catch (error) {
+      window.localStorage.setItem(key, original)
+      throw error
+    }
+  } catch {
+    // A malformed SDK cache is left untouched; server replay remains authoritative.
+  }
+}
+
+/**
+ * Remove legacy base64 payloads before SDK hydration.
+ *
+ * The transcript remains owned by the SDK's bounded local cache; screenshots do
+ * not. New screenshots are server assets referenced from replayable tool results.
+ * We intentionally do not move sessions into IndexedDB: doing so creates a second
+ * client-side transcript owner and makes delete/restore semantics inconsistent.
+ */
+export function prepareAgentSessionStorage(
+  agentAddress: string,
+  sessionId: string,
+): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve()
+  const currentKey = `co:agent:${agentAddress}:session:${sessionId}`
+  if (migratedKeys.has(currentKey)) return Promise.resolve()
+  migratedKeys.add(currentKey)
+
+  const sessionKeys: string[] = []
+  for (let index = 0; index < window.localStorage.length; index++) {
+    const storedKey = window.localStorage.key(index)
+    if (storedKey?.startsWith('co:agent:')) sessionKeys.push(storedKey)
+  }
+  for (const storedKey of sessionKeys) sanitizeStoredSession(storedKey)
+  return Promise.resolve()
+}

--- a/components/chat/server-evidence.ts
+++ b/components/chat/server-evidence.ts
@@ -1,0 +1,104 @@
+import type { ChatItem } from 'connectonion/react'
+
+interface ServerEvidenceImage {
+  id: string
+  groupId: string
+  content: string
+  url: string
+  ordinal: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isEvidenceUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  try {
+    const parsed = new URL(value)
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+      && parsed.pathname.startsWith('/evidence/v1/')
+      && Boolean(parsed.searchParams.get('token'))
+    )
+  } catch {
+    return false
+  }
+}
+
+function collectImages(value: unknown, images: ServerEvidenceImage[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectImages(item, images)
+    return
+  }
+  if (!isRecord(value)) return
+
+  const serverImages = value.server_images
+  if (Array.isArray(serverImages)) {
+    for (const raw of serverImages) {
+      if (!isRecord(raw) || !isEvidenceUrl(raw.url)) continue
+      const id = typeof raw.id === 'string' ? raw.id : ''
+      const groupId = typeof raw.group_id === 'string' ? raw.group_id : ''
+      if (!id || !groupId) continue
+      images.push({
+        id,
+        groupId,
+        content: typeof raw.content === 'string' ? raw.content : 'Verification evidence.',
+        url: raw.url,
+        ordinal: typeof raw.ordinal === 'number' ? raw.ordinal : 0,
+      })
+    }
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key !== 'server_images') collectImages(child, images)
+  }
+}
+
+function resultImages(result: unknown): ServerEvidenceImage[] {
+  if (typeof result !== 'string' || !result.trim()) return []
+  try {
+    const parsed: unknown = JSON.parse(result)
+    const images: ServerEvidenceImage[] = []
+    collectImages(parsed, images)
+    return images
+  } catch {
+    return []
+  }
+}
+
+/** Rebuild server-backed evidence bubbles from replayed tool results. */
+export function mergeServerEvidence(ui: ChatItem[]): ChatItem[] {
+  const existingUrls = new Set(
+    ui.flatMap(item => item.type === 'agent' ? (item.images || []) : []),
+  )
+  const seenGroups = new Set<string>()
+  const merged: ChatItem[] = []
+
+  for (const item of ui) {
+    merged.push(item)
+    if (item.type !== 'tool_call') continue
+
+    const groups = new Map<string, ServerEvidenceImage[]>()
+    for (const image of resultImages(item.result)) {
+      if (existingUrls.has(image.url)) continue
+      const group = groups.get(image.groupId) || []
+      group.push(image)
+      groups.set(image.groupId, group)
+    }
+
+    for (const [groupId, images] of groups) {
+      if (seenGroups.has(groupId)) continue
+      seenGroups.add(groupId)
+      images.sort((left, right) => left.ordinal - right.ordinal)
+      merged.push({
+        id: `server-evidence-${groupId}`,
+        type: 'agent',
+        content: images[0]?.content || 'Verification evidence.',
+        images: images.map(image => image.url),
+      })
+    }
+  }
+
+  return merged
+}

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -70,6 +70,7 @@ export interface AskUserEvent {
   type: 'ask_user'
   question: string
   options?: string[]
+  disabled_options?: string[]
   multi_select?: boolean
 }
 
@@ -92,6 +93,7 @@ export interface StreamEvent {
   // ask_user fields
   question?: string
   options?: string[]
+  disabled_options?: string[]
   multi_select?: boolean
 }
 
@@ -105,6 +107,7 @@ export interface Activity {
 export interface PendingAskUser {
   question: string
   options: string[]
+  disabled_options: string[]
   multi_select: boolean
   input_type?: string
   fields?: AskUserField[]
@@ -202,6 +205,7 @@ export interface AskUserUI extends BaseUI {
   type: 'ask_user'
   text: string
   options?: string[]
+  disabled_options?: string[]
   multi_select?: boolean
   input_type?: string
   fields?: AskUserField[]

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -4,6 +4,8 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useAgentForHuman, type ChatItem, type ApprovalMode } from 'connectonion/react'
 import type { PendingAskUser, PendingApproval, PendingOnboard, PendingUlwTurnsReached, PendingPlanReview } from './types'
 import { dedupeUI } from './dedupe-ui'
+import { mergeServerEvidence } from './server-evidence'
+import { prepareAgentSessionStorage } from './migrate-agent-session'
 
 /** Session lifecycle state */
 export type SessionActiveState = 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
@@ -175,6 +177,9 @@ function hasActiveRestoredItem(ui: ChatItem[]): boolean {
 
 export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   const { agentAddress, sessionId, onComplete, onError } = options
+  const [storageReady] = useState(
+    () => prepareAgentSessionStorage(agentAddress, sessionId),
+  )
 
   const prevStatusRef = useRef<'idle' | 'working' | 'waiting'>('idle')
 
@@ -202,10 +207,44 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   // current step server-side.
   const [stopRequested, setStopRequested] = useState(false)
 
-  // Each connect attempt to a non-onboarded agent emits a fresh onboard_required
-  // (new UUID, so dedupeUI keeps them all) — keep only the latest card.
+  // A URL session may outlive the SDK's sanitized local UI cache. Give normal
+  // hydration a moment, then ask the server for the canonical transcript when
+  // this page is still idle, empty, and disconnected.
+  const reconnectFallbackRef = useRef({
+    connectionState,
+    status,
+    uiLength: ui.length,
+    reconnect: sdkReconnect,
+  })
+  useEffect(() => {
+    reconnectFallbackRef.current = {
+      connectionState,
+      status,
+      uiLength: ui.length,
+      reconnect: sdkReconnect,
+    }
+  }, [connectionState, status, ui.length, sdkReconnect])
+  useEffect(() => {
+    const timer = window.setTimeout(async () => {
+      await storageReady.catch(() => undefined)
+      const latest = reconnectFallbackRef.current
+      if (
+        latest.connectionState !== 'connected'
+        && latest.status === 'idle'
+        && latest.uiLength === 0
+      ) {
+        latest.reconnect()
+      }
+    }, 1200)
+    return () => window.clearTimeout(timer)
+  }, [agentAddress, sessionId, storageReady])
+
+  // Server evidence references are replayed inside tool results. Rebuild those
+  // image rows before normal UI deduplication, then apply upstream's onboarding
+  // and optimistic-stop policies without discarding either behavior.
   const cleanUI = useMemo(() => {
-    let items = dedupeUI(ui as import('./types').UI[]) as ChatItem[]
+    const serverBackedUI = mergeServerEvidence(ui)
+    let items = dedupeUI(serverBackedUI as import('./types').UI[]) as ChatItem[]
     let lastOnboardIndex = -1
     for (let i = items.length - 1; i >= 0; i--) {
       if (items[i].type === 'onboard_required') { lastOnboardIndex = i; break }

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -86,9 +86,13 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
       }
       const toolStatus = toolStatuses.get('ask_user')
       if (toolStatus === 'running' || toolStatus === undefined) {
+        const disabledOptions = (item as ChatItem & { disabled_options?: unknown }).disabled_options
         pendingAskUser = {
           question: typeof item.text === 'string' ? item.text : '',
           options: Array.isArray(item.options) ? item.options : [],
+          disabled_options: Array.isArray(disabledOptions)
+            ? disabledOptions.filter((option): option is string => typeof option === 'string')
+            : [],
           multi_select: item.multi_select === true,
           input_type: (item as { input_type?: string }).input_type,
           fields: (item as { fields?: PendingAskUser['fields'] }).fields,


### PR DESCRIPTION
## Summary

- Render validated LinkedIn post embeds in agent messages.
- Rebuild server-backed evidence images from replayed tool results.
- Remove legacy Base64 image payloads from local session caches.
- Restore empty URL sessions from the server when local hydration is unavailable.
- Support disabled ask-user options in both chat interfaces.
- Preserve upstream onboarding deduplication and optimistic Stop behavior.

## Validation

- `npm run build` passes.
- TypeScript compilation passes.
- `git diff --check origin/main...HEAD` passes.
