### PR TITLE
Import hooks from @connectonion/react instead of connectonion/react

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 oo-chat is an open-source web chat client for ConnectOnion agents, built with Next.js 16.
 You connect to an agent by its `0x…` address; the live conversation runs over a WebSocket
-through the `connectonion` TypeScript SDK (`../connectonion-ts`). oo-chat is a thin front end —
+through the ConnectOnion TypeScript SDK (`../connectonion-ts`). oo-chat is a thin front end —
 routing, layout, and rendering the SDK's streamed event list — while the SDK owns the agent
 connection, the protocol, and per-session persistence.
+
+The SDK is two npm packages: **`connectonion`** (connection, protocol, types) and
+**`@connectonion/react`** (the hooks oo-chat actually calls, which depend on the first).
+Before 0.2.0 both shipped as one package with the hooks at `connectonion/react`.
 
 There is one connection path: **remote agent over WebSocket via the SDK**. The "modes" in the
 UI (`safe` / `plan` / `accept_edits` / `ulw`) are trust/approval levels, not connection types.
@@ -59,7 +63,7 @@ store/chat-store.ts                 # Sidebar conversation INDEX (not the transc
 ### Key Patterns
 
 **Live chat** (`app/[address]/[sessionId]/page.tsx` → `components/chat/use-agent-sdk.ts`):
-- `useAgentForHuman(address, sessionId)` (from `connectonion/react`) opens a WebSocket
+- `useAgentForHuman(address, sessionId)` (from `@connectonion/react`) opens a WebSocket
   to the relay and returns `ui: ChatItem[]` plus `send`/`sendMessage`/`setMode`/`reconnect`.
 - `use-agent-sdk.ts` derives the `pending*` interaction cards (ask_user, approval, plan,
   onboard, ULW) from the event stream and the connection/session state.
@@ -90,9 +94,13 @@ and are unused.
 
 ## Dependencies
 
-- `connectonion`: the TypeScript SDK — agent connection, WebSocket protocol, session
-  persistence, `useAgentForHuman`, `fetchAgentInfo`, `useVoiceInput`. Pinned by semver
-  (`^0.1.x`) for production; symlinked to `../connectonion-ts` for local dev (see DEPLOY.md).
+- `connectonion`: the core TypeScript SDK — agent connection, WebSocket protocol, session
+  persistence. Pinned by semver (`^0.2.x`) for production; symlinked to `../connectonion-ts`
+  for local dev (see DEPLOY.md).
+- `@connectonion/react`: the SDK's React layer — `useAgentForHuman`, `useVoiceInput`,
+  `fetchAgentInfo`. Split out of `connectonion` at 0.2.0 (it used to be the
+  `connectonion/react` subpath) and released on its own cadence, so both versions move
+  together. Also pinned by semver and symlinked for local dev.
 - `zustand`: state + localStorage persistence (sidebar index, SDK session store).
 - `bip39` + `tweetnacl`: browser BIP39/Ed25519 user identity.
 - `react-icons`: UI icons. `clsx` + `tailwind-merge`: conditional classes.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ oo-chat handles routing, layout, and rendering the SDK's event stream.
 ```
 You paste 0x…  →  /[address] (agent profile)  →  /[address]/[sessionId] (live chat)
                                                           │
-                            useAgentForHuman(address, sessionId)   ← connectonion/react SDK
+                            useAgentForHuman(address, sessionId)   ← @connectonion/react SDK
                                                           │
                             WebSocket → wss://oo.openonion.ai (relay) → the remote agent
 ```

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -7,7 +7,7 @@
 import { useState, useRef, useCallback, useEffect, KeyboardEvent, ChangeEvent } from 'react'
 import { HiOutlineArrowUp, HiOutlineMicrophone, HiOutlineStop, HiX } from 'react-icons/hi'
 import { HiOutlinePlus, HiOutlineDocument } from 'react-icons/hi2'
-import { useVoiceInput } from 'connectonion/react'
+import { useVoiceInput } from '@connectonion/react'
 import { useChatStore } from '@/store/chat-store'
 import { cn } from './utils'
 import type { ChatInputProps, FileAttachment } from './types'

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-import { useAgentForHuman, type ChatItem, type ApprovalMode } from 'connectonion/react'
+import { useAgentForHuman, type ChatItem, type ApprovalMode } from '@connectonion/react'
 import type { PendingAskUser, PendingApproval, PendingOnboard, PendingUlwTurnsReached, PendingPlanReview } from './types'
 import { dedupeUI } from './dedupe-ui'
 
@@ -12,7 +12,7 @@ export type SessionActiveState = 'idle' | 'connected' | 'active' | 'disconnected
 export type UI = ChatItem
 
 // Re-export ApprovalMode
-export type { ApprovalMode } from 'connectonion/react'
+export type { ApprovalMode } from '@connectonion/react'
 
 interface UseAgentSDKOptions {
   agentAddress: string

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,12 @@
 # oo-chat — Architecture & Data Flow
 
-oo-chat is a thin Next.js front end. The `connectonion` TypeScript SDK
-(`../connectonion-ts`) does the real work: connecting to an agent, the WebSocket
-protocol, and saving the transcript. oo-chat just routes, lays out, and renders the
-SDK's stream of events.
+oo-chat is a thin Next.js front end. The ConnectOnion TypeScript SDK does the real
+work: connecting to an agent, the WebSocket protocol, and saving the transcript.
+oo-chat just routes, lays out, and renders the SDK's stream of events.
+
+The SDK is two packages: `connectonion` (`../connectonion-ts`) holds the connection
+and protocol, and `@connectonion/react` holds the hooks oo-chat calls. Everything
+below that says "the SDK" applies to both.
 
 ## One picture
 
@@ -66,8 +69,9 @@ owner (the SDK); the sidebar store just lists conversations:
 | `store/chat-store.ts` | the sidebar index |
 | `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
 
-oo-chat imports `useAgentForHuman`, `fetchAgentInfo`, and `useVoiceInput` from the
-SDK. The SDK lives in `../connectonion-ts`; shipping it is in [DEPLOY.md](./DEPLOY.md).
+oo-chat imports `useAgentForHuman`, `fetchAgentInfo`, and `useVoiceInput` from
+`@connectonion/react`, which sits on top of `connectonion` (`../connectonion-ts`).
+Shipping both is in [DEPLOY.md](./DEPLOY.md).
 
 ## Identity & login
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,20 +1,38 @@
 # Deploy: SDK → npm → oo-chat → Vercel
 
-oo-chat depends on the `connectonion` TypeScript SDK, which lives in a **separate
-repo** (`../connectonion-ts`, GitHub `openonion/connectonion-ts`). A change to the
-SDK only reaches production once it's published to npm and oo-chat is bumped to that
-version. This is the full chain.
+oo-chat depends on the ConnectOnion TypeScript SDK, which lives in **separate repos**.
+A change to the SDK only reaches production once it's published to npm and oo-chat is
+bumped to that version. This is the full chain.
+
+## Two packages
+
+Since SDK 0.2.0 the SDK is two npm packages, and oo-chat depends on both:
+
+| Package | Repo | What oo-chat uses it for |
+|---------|------|--------------------------|
+| `connectonion` | `openonion/connectonion-ts` | Connection, WebSocket protocol, types. Also a peer dependency of the package below. |
+| `@connectonion/react` | `openonion/connectonion-react` | `useAgentForHuman`, `useVoiceInput`, `fetchAgentInfo` — what the components import. |
+
+> Until `connectonion-react` exists, `@connectonion/react` is staged inside
+> `connectonion-ts` at `packages/react/`, so "publish the React package" means
+> tagging from that directory. Everything below is written for the split repos;
+> substitute the path while it's still staged.
+
+`@connectonion/react` declares `connectonion` as a **peer** dependency, so the two
+versions must be compatible — bump them together and keep the majors/minors aligned
+unless you have a reason not to.
 
 ## The dependency, two ways
 
-`oo-chat/package.json` declares `"connectonion": "^0.1.x"` — a **published npm
-version** (this is what Vercel installs and builds against).
+`oo-chat/package.json` declares `"connectonion": "^0.2.x"` and
+`"@connectonion/react": "^0.2.x"` — **published npm versions** (this is what Vercel
+installs and builds against).
 
-For local development, `node_modules/connectonion` is symlinked to
-`../connectonion-ts` so SDK edits show up immediately:
+For local development, both are symlinked so SDK edits show up immediately:
 
 ```
-node_modules/connectonion -> ../../connectonion-ts
+node_modules/connectonion       -> ../../connectonion-ts
+node_modules/@connectonion/react -> ../../connectonion-react
 ```
 
 > ⚠️ **Local builds can pass while Vercel fails.** The symlink points at your
@@ -35,17 +53,19 @@ Increment the patch by 1; when a segment would hit two digits, roll up:
 
 ## Steps
 
-### 1. Publish the SDK (`../connectonion-ts`)
+### 1. Publish the core SDK (`../connectonion-ts`)
+
+Core goes first — `@connectonion/react` builds against it.
 
 ```bash
 cd ../connectonion-ts
 ./node_modules/.bin/tsc                       # type-check
 npx jest tests/connect.test.ts --forceExit    # tests must pass
 
-# bump version in package.json (e.g. 0.1.5 → 0.1.6), then:
-git add -A && git commit -m "v0.1.6"
-git tag v0.1.6
-git push origin main && git push origin v0.1.6
+# bump version in package.json (e.g. 0.2.0 → 0.2.1), then:
+git add -A && git commit -m "v0.2.1"
+git tag v0.2.1
+git push origin main && git push origin v0.2.1
 ```
 
 Pushing the **`v*` tag** triggers `.github/workflows/publish.yml`, which builds and
@@ -56,54 +76,87 @@ gh run watch --repo openonion/connectonion-ts --exit-status
 npm view connectonion version          # should show the new version
 ```
 
-### 2. Point oo-chat at the published version
+### 2. Publish the React package (`../connectonion-react`)
+
+Skip this step if the change was core-only and the hooks are untouched — just leave
+`@connectonion/react` at its current version.
+
+```bash
+cd ../connectonion-react
+npm pkg set peerDependencies.connectonion="^0.2.1"   # only if core's range moved
+npx tsc --noEmit
+npx jest
+
+# bump version in package.json, then:
+git add -A && git commit -m "v0.2.1"
+git tag v0.2.1
+git push origin main && git push origin v0.2.1
+
+gh run watch --repo openonion/connectonion-react --exit-status
+npm view @connectonion/react version
+```
+
+### 3. Point oo-chat at the published versions
 
 ```bash
 cd ../oo-chat
-npm pkg set dependencies.connectonion="^0.1.6"
-npm install                            # updates package-lock.json to the registry tarball
+npm pkg set dependencies.connectonion="^0.2.1"
+npm pkg set 'dependencies.@connectonion/react'="^0.2.1"
+npm install                            # updates package-lock.json to the registry tarballs
 npm run build                          # MUST pass — this is what Vercel will run
 ```
 
-### 3. Ship oo-chat
+`npm install` will fail loudly if the two versions violate the peer range — that check
+is the point of the peer dependency, so fix the versions rather than forcing past it.
+
+### 4. Ship oo-chat
 
 ```bash
 git add package.json package-lock.json
-git commit -m "Update connectonion to v0.1.6"
+git commit -m "Update connectonion + @connectonion/react to v0.2.1"
 git push                               # push the branch; merge the PR to main
 ```
 
 Vercel auto-deploys: a branch push builds a **preview**; a merge to `main` builds
 **production**. Confirm the deploy is green before calling it done.
 
-### 4. Restore the local dev symlink (don't commit)
+### 5. Restore the local dev symlinks (don't commit)
 
-Production `package.json` keeps the semver (`^0.1.6`). For local SDK work, restore
-the symlink in `node_modules` only:
+Production `package.json` keeps the semvers (`^0.2.1`). For local SDK work, restore
+the symlinks in `node_modules` only:
 
 ```bash
 rm -rf node_modules/connectonion
 ln -s ../../connectonion-ts node_modules/connectonion
+
+rm -rf node_modules/@connectonion/react
+mkdir -p node_modules/@connectonion
+ln -s ../../../connectonion-react node_modules/@connectonion/react
 ```
 
-`package.json` stays at `^0.1.6` (committed); only `node_modules` points at the local
-SDK. Don't commit a `file:../connectonion-ts` dependency.
+`package.json` stays at `^0.2.1` (committed); only `node_modules` points at the local
+SDK. Don't commit `file:../connectonion-ts` dependencies.
+
+> A symlinked `@connectonion/react` resolves `connectonion` through oo-chat's
+> `node_modules` — which is itself symlinked to your working core. So local builds see
+> your working copy of *both*, which is exactly the trap in the warning above, doubled.
 
 ## Automation
 
-The skill `connectonion:deploy-oo-chat` automates steps 1–4. The `meta` is: publish
-`connectonion-ts` to npm via GitHub Actions, update the oo-chat dependency, commit,
-push, and verify the Vercel deploy.
+The skill `connectonion:deploy-oo-chat` automates steps 1–5. The `meta` is: publish
+`connectonion-ts` (and `connectonion-react` when the hooks changed) to npm via GitHub
+Actions, update the oo-chat dependencies, commit, push, and verify the Vercel deploy.
 
 ## Map
 
 | Thing | Value |
 |-------|-------|
-| SDK repo | `openonion/connectonion-ts` |
+| Core SDK repo | `openonion/connectonion-ts` |
+| React SDK repo | `openonion/connectonion-react` (staged at `connectonion-ts/packages/react` until it exists) |
 | oo-chat repo | `openonion/oo-chat` |
-| npm package | `connectonion` |
+| npm packages | `connectonion`, `@connectonion/react` |
 | Vercel project | `oo-chat` |
-| Publish trigger | git tag `v*` → GitHub Actions → npm |
+| Publish trigger | git tag `v*` in either SDK repo → GitHub Actions → npm |
 | Deploy trigger | push to `main` → Vercel production; branch push → preview |
-| Dev dependency | symlink `node_modules/connectonion → ../connectonion-ts` |
-| Prod dependency | `"connectonion": "^X.Y.Z"` in `package.json` |
+| Dev dependency | symlinks `node_modules/connectonion → ../connectonion-ts`, `node_modules/@connectonion/react → ../connectonion-react` |
+| Prod dependency | `"connectonion": "^X.Y.Z"` + `"@connectonion/react": "^X.Y.Z"` in `package.json` |

--- a/hooks/use-agent-info.ts
+++ b/hooks/use-agent-info.ts
@@ -4,10 +4,10 @@
 // on tab focus. All field mapping (relay profile, direct /info merge, online
 // detection) lives in the SDK — this file must not duplicate it.
 import { useState, useEffect, useCallback } from 'react'
-import { fetchAgentInfo } from 'connectonion/react'
-import type { AgentInfo } from 'connectonion/react'
+import { fetchAgentInfo } from '@connectonion/react'
+import type { AgentInfo } from '@connectonion/react'
 
-export type { AgentInfo, SkillInfo, AgentAcceptedInputs } from 'connectonion/react'
+export type { AgentInfo, SkillInfo, AgentAcceptedInputs } from '@connectonion/react'
 
 const POLL_INTERVAL = 600000 // 10 minutes — info is cache-first + refetched on tab focus/mount; this is just a slow background revalidate for liveness/profile changes, not a tight poll
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@connectonion/react": "^0.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.1.8",
+    "connectonion": "^0.2.0",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
Downstream half of openonion/connectonion-ts#20 — depends on openonion/connectonion-ts#21.

The SDK's React layer is now its own package. `connectonion@0.2.0` drops the `connectonion/react`
subpath, so oo-chat imports `useAgentForHuman`, `useVoiceInput`, and `fetchAgentInfo` from
`@connectonion/react` and takes both packages as dependencies.

`connectonion` stays a direct dependency for two reasons: it's a peer of `@connectonion/react`,
and `components/sidebar.tsx` reads its version off `connectonion/package.json` for the npm link
in the footer.

## Changes

- `components/chat/chat-input.tsx`, `components/chat/use-agent-sdk.ts`, `hooks/use-agent-info.ts`
  — import from `@connectonion/react`
- `package.json` — `connectonion: ^0.2.0`, `@connectonion/react: ^0.2.0`
- `docs/DEPLOY.md` — the publish pipeline is now two packages: core first (React builds against
  it), React second, then bump oo-chat. Their peer range has to stay compatible; `npm install`
  fails loudly if it doesn't. Step 5 restores two dev symlinks instead of one, with a note that a
  symlinked `@connectonion/react` resolves `connectonion` through oo-chat's own `node_modules`
  — so a local build sees your working copy of *both* packages, which is the "local passes,
  Vercel fails" trap doubled.
- `docs/ARCHITECTURE.md`, `CLAUDE.md`, `README.md` — name which package each import comes from

No behaviour change. Same hooks, same signatures, same
`localStorage['co:agent:{address}:session:{id}']` keys, so sessions in the wild carry over
untouched.

## ⚠️ Do not merge before the packages are published

`connectonion@0.2.0` and `@connectonion/react@0.2.0` are not on npm yet, so **`package-lock.json`
is deliberately unchanged** — it can only be regenerated by DEPLOY.md step 3 once they exist.
Merging this before then gives Vercel a `package.json` it cannot install.

(This repo already commits the dependency bump ahead of the lockfile — `main` currently has
`^0.1.8` in `package.json` against `^0.1.7` in the lock.)

## Testing

`npm run build` passes against both packages built from source — all 8 routes compile:

```
┌ ○ /                        ├ ƒ /api/auth
├ ○ /_not-found              ├ ƒ /api/chat
├ ƒ /[address]               ├ ○ /apple-icon.png
├ ƒ /[address]/[sessionId]   ├ ○ /icon.png
                             └ ○ /settings
```

`npm run lint` reports nothing new on the three changed files — the only finding in them is a
pre-existing `<img>`/LCP warning at `chat-input.tsx:234`, unrelated to the changed import on
line 10.

Verifying this locally needs the two SDK packages present as real directories rather than
symlinks: Turbopack fails to resolve a package symlinked outside the project root, which is why
the build was run against copies of the built packages instead of the `node_modules` symlinks
DEPLOY.md describes for `next dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm4bF94RsS7QKC8GVtymDm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hm4bF94RsS7QKC8GVtymDm)_