### PR TITLE
Show the authenticated agent profile, not just the public one

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -73,9 +73,6 @@ export default function ChatSessionPage() {
   useIdentity()
 
   const agentInfoMap = useAgentInfo([address])
-  // Default to empty, not undefined: the dashboard's skill allowlist fails closed, so
-  // an absent list must mean "nothing is invocable yet", never "anything goes".
-  const skills = agentInfoMap[address]?.skills || []
 
   // Add agent if not in list
   useEffect(() => {
@@ -118,11 +115,20 @@ export default function ChatSessionPage() {
     reconnect,
     interrupt,
     dashboardHtml,
+    profile,
   } = useAgentSDK({
     agentAddress: address,
     sessionId,
     onError: (error) => setConnectionError(error),
   })
+
+  // Skills come from the authenticated socket once it is up, and from the public relay
+  // directory before that — this session is connected, so it is entitled to the full list
+  // and the dashboard's buttons should work for every skill the agent actually has.
+  //
+  // Default to empty, not undefined: the dashboard's skill allowlist fails closed, so
+  // an absent list must mean "nothing is invocable yet", never "anything goes".
+  const skills = profile?.skills ?? agentInfoMap[address]?.skills ?? []
 
   // Consume pending message and apply initial mode from URL
   const consumedRef = useRef<string | null>(null)

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -92,13 +92,27 @@ export default function AgentLandingPage() {
   }, [clearActive])
 
   const infoMap = useAgentInfo([address])
-  const agentInfo = infoMap[address]
+  const directoryInfo = infoMap[address]
 
   // A draft session: warmed on the landing page so the Dashboard paints before the
   // first message, and reused as the real session once the user sends, so the
   // already-open connection carries over. Not added to the sidebar until send.
   const draftSessionId = useMemo(() => crypto.randomUUID(), [])
-  const { dashboardHtml, connect, clear } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
+  const { dashboardHtml, profile, connect, clear } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
+
+  // Two answers to "what is this agent", and the difference is the point: the relay
+  // directory is public and lists the published skill subset, while `profile` arrives over
+  // the authenticated socket and holds everything. Layer, don't replace — the frame is
+  // authoritative only for the fields it sends (name, model, tools, skills, balance), and
+  // trust / version / accepted_inputs come from the directory alone. Replacing here would
+  // silently drop accepted_inputs and disable image upload.
+  //
+  // Before the frame lands — and for a visitor who never passes the trust gate — the public
+  // view is not a placeholder for the real list, it IS the answer they are entitled to.
+  const agentInfo = useMemo(
+    () => (profile ? { ...directoryInfo, ...profile } : directoryInfo),
+    [directoryInfo, profile]
+  )
 
   // Set when the draft becomes a real conversation, so unmount-on-navigate keeps the
   // warmed connection the session page is about to re-acquire.

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-import { useAgentForHuman, type ChatItem, type ApprovalMode } from 'connectonion/react'
+import { useAgentForHuman, type AgentInfo, type ChatItem, type ApprovalMode } from 'connectonion/react'
 import type { PendingAskUser, PendingApproval, PendingOnboard, PendingUlwTurnsReached, PendingPlanReview } from './types'
 import { dedupeUI } from './dedupe-ui'
 
@@ -63,6 +63,12 @@ interface UseAgentSDKReturn {
   connect: () => void
   /** Latest agent-authored dashboard.html snapshot, or null until the first arrives. */
   dashboardHtml: string | null
+  /**
+   * The agent's own account of itself over the authenticated socket — every skill,
+   * not the subset the public directory lists. `null` until the connection passes
+   * the trust gate, which is exactly when a visitor should not see the full list.
+   */
+  profile: AgentInfo | null
   clear: () => void
 }
 
@@ -200,6 +206,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     setMode: sdkSetMode,
     reconnect: sdkReconnect,
     dashboardHtml,
+    profile,
     connect,
   } = useAgentForHuman(agentAddress, sessionId)
   // Optimistic stop: set the instant the user clicks Stop, cleared when the run
@@ -393,6 +400,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     reconnect: sdkReconnect,
     connect,
     dashboardHtml,
+    profile,
     clear,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
         "clsx": "^2.1.1",
-        "connectonion": "^0.1.9",
+        "connectonion": "^0.1.10",
         "next": "16.0.10",
         "prism-react-renderer": "^2.4.1",
         "qrcode.react": "^4.2.0",
@@ -3655,9 +3655,9 @@
       "license": "MIT"
     },
     "node_modules/connectonion": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.1.9.tgz",
-      "integrity": "sha512-JFCGq9afYNqI9pqi4QFBO4i6ZseHXCBN8DuDQluh/kC48AU06T+DNIh7joG7yklKwS5FDsv5P7Ox9h8ALvx3IA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.1.10.tgz",
+      "integrity": "sha512-k38L+5wQ8qlmaRDbh087odifAwU4mW+os+Y9fkHMd9PmOOG3YZSvFqwySgrIN7b1Dubh5fFegEsEQHehg1y2/Q==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.1.9",
+    "connectonion": "^0.1.10",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
Third and last layer of openonion/connectonion#323 → openonion/connectonion-ts#22.

## The problem this closes

The Host answers "what can this agent do" twice, on purpose:

| source | authenticated | skills |
|---|---|---|
| relay `/api/agents/{addr}` | no | published subset |
| agent `/info` | no | published subset |
| agent WS `AGENT_PROFILE` | signature + trust gate | **everything** |

oo-chat only ever read the public answer. So a session that had already entered the invite code still saw the visitor's list — and the dashboard's skill allowlist, which correctly **fails closed**, refused buttons for skills the agent genuinely has.

## Change

`useAgentSDK` passes the SDK's new `profile` through, and both pages layer it over the directory record:

```ts
const agentInfo = profile ? { ...directoryInfo, ...profile } : directoryInfo   // landing
const skills = profile?.skills ?? agentInfoMap[address]?.skills ?? []          // session
```

**Layer, don't replace.** The frame is authoritative only for what it sends — name, model, tools, skills, balance. `trust`, `version` and `accepted_inputs` come from the directory alone, and `accepted_inputs` gates image/file upload, so a plain `profile ?? directoryInfo` would have silently disabled attachments the moment the profile arrived. That is the one non-obvious thing in this diff.

Before the frame lands, and for a visitor who never passes the trust gate, the public view stays — it is not a placeholder for the real list, it is the answer they are entitled to.

## Ordering — this one is a hard dependency

`profile` does not exist on `useAgentForHuman` in the published SDK (0.1.9). **Merge only after connectonion-ts#22 ships to npm and the dependency here is bumped**, or the Vercel build fails on exactly the type error I hit locally:

```
Type error: Property 'profile' does not exist on type 'UseAgentForHumanReturn'.
```

Verified green against a symlinked local SDK build: `npm run build` ✓, `npm test` → 30 passed.

Once #323 is deployed, `profile` fills in and the connected view gets richer; unconnected views correctly get less than they used to, which is the security fix.