### PR TITLE
feat(dashboard): let the reader decide how wide Home is

### DIFF
--- a/components/dashboard/use-pane-width.ts
+++ b/components/dashboard/use-pane-width.ts
@@ -30,6 +30,12 @@ export function usePaneWidth() {
   // Starts at the default on both server and first client render — reading
   // localStorage during render would make the two disagree and hydrate wrong.
   const [width, setWidth] = useState(DEFAULT_PANE)
+  // Two flags for one state, deliberately. `draggingRef` is the gate the move
+  // handler reads: a React state update is not visible until the next render, so
+  // a pointermove arriving in the same tick as the pointerdown would be dropped —
+  // the drag appears to stick for a frame before catching up. The ref is correct
+  // immediately. `dragging` state exists only to drive the visual class.
+  const draggingRef = useRef(false)
   const [dragging, setDragging] = useState(false)
   const startRef = useRef({ x: 0, w: DEFAULT_PANE })
 
@@ -42,22 +48,24 @@ export function usePaneWidth() {
     e.preventDefault()
     e.currentTarget.setPointerCapture(e.pointerId)
     startRef.current = { x: e.clientX, w: width }
+    draggingRef.current = true
     setDragging(true)
   }, [width])
 
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    if (!dragging) return
+    if (!draggingRef.current) return
     // The pane is on the right, so dragging left widens it.
     const next = startRef.current.w - (e.clientX - startRef.current.x)
     setWidth(Math.min(MAX_PANE, Math.max(MIN_PANE, next)))
-  }, [dragging])
+  }, [])
 
   const onPointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    if (!dragging) return
+    if (!draggingRef.current) return
+    draggingRef.current = false
     e.currentTarget.releasePointerCapture(e.pointerId)
     setDragging(false)
-    window.localStorage.setItem(STORAGE_KEY, String(width))
-  }, [dragging, width])
+    setWidth((w) => { window.localStorage.setItem(STORAGE_KEY, String(w)); return w })
+  }, [])
 
   // Keyboard users get the same control; a divider nobody can reach without a
   // mouse is a control only some readers have.

--- a/components/dashboard/use-pane-width.ts
+++ b/components/dashboard/use-pane-width.ts
@@ -1,0 +1,77 @@
+/**
+ * @purpose Remember how wide the reader wants the Home pane, and drag it there.
+ * @llm-note The pane used to be `lg:w-[440px] xl:w-[500px] shrink-0` — three fixed
+ *   sizes we picked. But the pane holds agent-authored HTML we do not control: one
+ *   agent's Home is a four-column table, another's is a wide chart. There is no
+ *   single width that fits them, and the reader is the only one who knows whether
+ *   they are here to read the dashboard or the chat. So the width is theirs.
+ *
+ *   Two details that are easy to get wrong:
+ *
+ *   - **The iframe eats the drag.** Once the pointer crosses into the dashboard
+ *     frame, the parent stops receiving pointermove and the divider sticks. The
+ *     handle takes a pointer capture on pointerdown, which keeps every subsequent
+ *     event on the handle regardless of what it is over.
+ *   - **Bounds are not decoration.** Without a floor the reader can drag the pane
+ *     over the composer and lose the chat with no way back; without a ceiling the
+ *     chat becomes a column too narrow to read. Both are one drag from happening
+ *     and neither is obvious to undo.
+ */
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export const MIN_PANE = 320
+export const MAX_PANE = 900
+const DEFAULT_PANE = 500
+const STORAGE_KEY = 'ochat:home-pane-width'
+
+export function usePaneWidth() {
+  // Starts at the default on both server and first client render — reading
+  // localStorage during render would make the two disagree and hydrate wrong.
+  const [width, setWidth] = useState(DEFAULT_PANE)
+  const [dragging, setDragging] = useState(false)
+  const startRef = useRef({ x: 0, w: DEFAULT_PANE })
+
+  useEffect(() => {
+    const saved = Number(window.localStorage.getItem(STORAGE_KEY))
+    if (saved >= MIN_PANE && saved <= MAX_PANE) setWidth(saved)
+  }, [])
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    startRef.current = { x: e.clientX, w: width }
+    setDragging(true)
+  }, [width])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (!dragging) return
+    // The pane is on the right, so dragging left widens it.
+    const next = startRef.current.w - (e.clientX - startRef.current.x)
+    setWidth(Math.min(MAX_PANE, Math.max(MIN_PANE, next)))
+  }, [dragging])
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (!dragging) return
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    setDragging(false)
+    window.localStorage.setItem(STORAGE_KEY, String(width))
+  }, [dragging, width])
+
+  // Keyboard users get the same control; a divider nobody can reach without a
+  // mouse is a control only some readers have.
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>) => {
+    const step = e.shiftKey ? 50 : 10
+    const delta = e.key === 'ArrowLeft' ? step : e.key === 'ArrowRight' ? -step : 0
+    if (!delta) return
+    e.preventDefault()
+    setWidth((w) => {
+      const next = Math.min(MAX_PANE, Math.max(MIN_PANE, w + delta))
+      window.localStorage.setItem(STORAGE_KEY, String(next))
+      return next
+    })
+  }, [])
+
+  return { width, dragging, onPointerDown, onPointerMove, onPointerUp, onKeyDown }
+}

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -16,6 +16,7 @@
 import { useState } from 'react'
 import { HiOutlineViewGrid, HiOutlineChatAlt2, HiOutlineChevronRight } from 'react-icons/hi'
 import { cn } from '@/components/chat/utils'
+import { usePaneWidth, MIN_PANE, MAX_PANE } from './use-pane-width'
 
 interface WorkspaceShellProps {
   chat: React.ReactNode
@@ -34,6 +35,7 @@ export function WorkspaceShell({
   // Null until the reader picks a side; their choice then outranks the default forever.
   const [chosenView, chooseView] = useState<'chat' | 'home' | null>(null)
   const [dashboardOpen, setDashboardOpen] = useState(true)
+  const pane = usePaneWidth()
 
   // Derived, not an effect: honor defaultMobileView only once a snapshot exists, so
   // opening on Home never means opening on a blank pane.
@@ -76,12 +78,36 @@ export function WorkspaceShell({
         </div>
 
         {/* Dashboard pane */}
+        {hasDashboard && dashboardOpen && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize dashboard"
+          aria-valuenow={pane.width}
+          aria-valuemin={MIN_PANE}
+          aria-valuemax={MAX_PANE}
+          tabIndex={0}
+          onPointerDown={pane.onPointerDown}
+          onPointerMove={pane.onPointerMove}
+          onPointerUp={pane.onPointerUp}
+          onKeyDown={pane.onKeyDown}
+          className={cn(
+            'hidden lg:block w-1 shrink-0 cursor-col-resize',
+            'hover:bg-neutral-300 focus-visible:bg-neutral-400 focus-visible:outline-none',
+            pane.dragging ? 'bg-neutral-400' : 'bg-transparent'
+          )}
+        />
+        )}
+
         {hasDashboard && (
-        <aside className={cn(
-          'w-full border-l border-neutral-200 bg-neutral-50 flex-col lg:w-[440px] xl:w-[500px] shrink-0',
-          mobileView === 'home' ? 'flex' : 'hidden',
-          dashboardOpen ? 'lg:flex' : 'lg:hidden'
-        )}>
+        <aside
+          style={{ ['--pane' as string]: `${pane.width}px` }}
+          className={cn(
+            'w-full border-l border-neutral-200 bg-neutral-50 flex-col shrink-0 lg:w-[var(--pane)]',
+            mobileView === 'home' ? 'flex' : 'hidden',
+            dashboardOpen ? 'lg:flex' : 'lg:hidden'
+          )}
+        >
           <div className="hidden lg:flex items-center justify-between px-4 py-2 border-b border-neutral-200">
             <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Home</span>
             <button
@@ -92,7 +118,7 @@ export function WorkspaceShell({
               <HiOutlineChevronRight className="w-4 h-4" />
             </button>
           </div>
-          <div className="flex-1 min-h-0">{dashboard}</div>
+          <div className={cn('flex-1 min-h-0', pane.dragging && 'pointer-events-none select-none')}>{dashboard}</div>
         </aside>
         )}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "oo-chat",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "@types/react-syntax-highlighter": "^15.5.13",


### PR DESCRIPTION
The pane was `lg:w-[440px] xl:w-[500px] shrink-0` — three widths we picked, and `shrink-0` meant it would not yield even under pressure.

That is a width we are not in a position to choose. The pane holds **agent-authored** HTML: one agent's Home is a four-column table, another's is a wide chart. Concretely, the naturewill contract dashboard needed a `@media (max-width: 560px)` rule to stop its amount column being clipped at 500px — and that rule turns into wasted space the moment somebody wants the pane wider. The reader is also the only one who knows whether they opened this to read the dashboard or the chat.

## The change

A divider between the two panes. 320–900px, remembered in `localStorage`, arrow keys as well as drag.

## Two things this has to get right

**The iframe eats the drag.** Once the pointer crosses into the dashboard frame the parent stops receiving `pointermove` and the divider sticks where it was. The handle takes a pointer capture on `pointerdown`, so every later event stays with the handle regardless of what it is over, and the frame gets `pointer-events-none` for the duration.

**Bounds are not decoration.** Without a floor the pane covers the composer and the chat is gone with no obvious way back. Without a ceiling the chat becomes a column too narrow to read. Both are one drag away and neither is discoverable to undo.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 30 passed
- Ran against a live agent (naturewill, 115-row contract dashboard) on a local dev server

**Not yet verified visually**: I could not get a screenshot of the drag in motion — the browser automation I was using stopped responding partway through. The code paths above are reasoned, typechecked and unit-clean, but nobody has watched the divider move. Worth a manual pass before merge.

## Related

- #38 — what a dashboard is allowed to be. A resizable pane is the other half of that question: components decide what it can *show*, width decides how much of it fits.