### PR TITLE
fix(onboard): ask for the code before the message, not after

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { HiChevronDown, HiChevronUp } from 'react-icons/hi2'
 import { ChatInput, ModeStatusBar, useAgentSDK } from '@/components/chat'
+import { OnboardGate } from '@/components/chat/onboard-gate'
 import { WorkspaceShell } from '@/components/dashboard/workspace-shell'
 import { DashboardPane } from '@/components/dashboard/dashboard-pane'
 import type { ApprovalMode } from '@/components/chat/types'
@@ -98,7 +99,7 @@ export default function AgentLandingPage() {
   // first message, and reused as the real session once the user sends, so the
   // already-open connection carries over. Not added to the sidebar until send.
   const draftSessionId = useMemo(() => crypto.randomUUID(), [])
-  const { dashboardHtml, profile, connect, clear } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
+  const { dashboardHtml, profile, connect, clear, submitOnboard } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
 
   // Two answers to "what is this agent", and the difference is the point: the relay
   // directory is public and lists the published skill subset, while `profile` arrives over
@@ -112,6 +113,18 @@ export default function AgentLandingPage() {
   const agentInfo = useMemo(
     () => (profile ? { ...directoryInfo, ...profile } : directoryInfo),
     [directoryInfo, profile]
+  )
+
+  // Whether to ask for a code instead of offering a composer the reader may not use.
+  //
+  // `onboard` states the agent's policy, not this reader's standing — it says a code
+  // is accepted, never that you already gave one. `profile` is the per-reader half:
+  // it arrives over the authenticated socket, so having it *is* proof of access.
+  // Gated policy and no profile is the one combination where a composer would invite
+  // someone to type a message the agent is going to refuse.
+  const gate = agentInfo?.onboard
+  const needsOnboard = Boolean(
+    gate && (gate.invite_code || typeof gate.payment === 'number') && !profile
   )
 
   // Set when the draft becomes a real conversation, so unmount-on-navigate keeps the
@@ -313,18 +326,26 @@ export default function AgentLandingPage() {
         {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider) */}
         <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
           <div className="max-w-3xl mx-auto">
-            <ChatInput
-              onSend={handleSend}
-              placeholder="Message this agent..."
-              skills={skills}
-              statusBar={
-                <ModeStatusBar
-                  mode={mode}
-                  onModeChange={handleModeChange}
-                  ulwTurnsRemaining={pendingUlwTurns}
-                />
-              }
-            />
+            {needsOnboard ? (
+              <OnboardGate
+                onboard={gate!}
+                agentName={label}
+                onSubmit={(options: { inviteCode?: string; payment?: number }) => { connect(); submitOnboard(options) }}
+              />
+            ) : (
+              <ChatInput
+                onSend={handleSend}
+                placeholder="Message this agent..."
+                skills={skills}
+                statusBar={
+                  <ModeStatusBar
+                    mode={mode}
+                    onModeChange={handleModeChange}
+                    ulwTurnsRemaining={pendingUlwTurns}
+                  />
+                }
+              />
+            )}
           </div>
         </div>
       </div>

--- a/components/chat/onboard-gate.tsx
+++ b/components/chat/onboard-gate.tsx
@@ -1,0 +1,97 @@
+/**
+ * @purpose Say up front that an agent is gated, in place of a composer the reader
+ *   is not yet allowed to use.
+ * @llm-note The old order was: composer → reader types → connect → agent refuses →
+ *   an onboard card appears in the transcript → the message they wrote is gone
+ *   (#27). Every part of that is avoidable, because `/info` has said
+ *   `onboard: {invite_code: true}` the whole time — the client just could not see
+ *   it until AgentInfo started carrying the field (connectonion-ts v0.2.0).
+ *
+ *   Deliberately *not* a wall in front of the landing page. Name, model, skills and
+ *   example prompts are what convince someone to go and ask for a code; hiding them
+ *   behind the code is asking for the ticket before showing the film. What changes
+ *   is only the composer: an input the reader may use, instead of one that will
+ *   reject them.
+ *
+ *   The in-transcript OnboardRequired card stays as-is. It is still correct for the
+ *   case this cannot cover — an agent that starts open and gates mid-session, where
+ *   there is no landing page left to render.
+ */
+'use client'
+
+import { useState } from 'react'
+import { HiOutlineTicket, HiOutlineArrowRight, HiOutlineCreditCard } from 'react-icons/hi'
+import type { AgentOnboard } from 'connectonion/react'
+
+interface OnboardGateProps {
+  onboard: AgentOnboard
+  agentName: string
+  onSubmit: (options: { inviteCode?: string; payment?: number }) => void
+  isSubmitting?: boolean
+  error?: string | null
+}
+
+export function OnboardGate({
+  onboard, agentName, onSubmit, isSubmitting = false, error = null,
+}: OnboardGateProps) {
+  const [code, setCode] = useState('')
+  const takesCode = onboard.invite_code === true
+  const price = typeof onboard.payment === 'number' ? onboard.payment : null
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center gap-2 mb-1">
+        <HiOutlineTicket className="w-4 h-4 text-neutral-400" />
+        <p className="text-sm font-medium text-neutral-800">
+          {agentName} is invite-only
+        </p>
+      </div>
+      <p className="text-xs text-neutral-500 mb-3">
+        Enter a code to start talking. Nothing you write is sent until you are in.
+      </p>
+
+      {takesCode && (
+        <form
+          className="flex gap-2"
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (code.trim() && !isSubmitting) onSubmit({ inviteCode: code.trim() })
+          }}
+        >
+          <input
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="Invite code"
+            autoFocus
+            disabled={isSubmitting}
+            className="flex-1 px-3 py-2 rounded-lg border border-neutral-200 text-sm
+                       focus:outline-none focus:ring-2 focus:ring-neutral-900/10"
+          />
+          <button
+            type="submit"
+            disabled={!code.trim() || isSubmitting}
+            className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm font-medium
+                       disabled:bg-neutral-300 flex items-center gap-1"
+          >
+            {isSubmitting ? 'Checking…' : 'Continue'}
+            {!isSubmitting && <HiOutlineArrowRight className="w-3.5 h-3.5" />}
+          </button>
+        </form>
+      )}
+
+      {price !== null && (
+        <button
+          onClick={() => !isSubmitting && onSubmit({ payment: price })}
+          disabled={isSubmitting}
+          className="mt-2 w-full px-4 py-2 rounded-lg border border-neutral-200 text-sm
+                     flex items-center justify-center gap-1.5 hover:bg-neutral-50"
+        >
+          <HiOutlineCreditCard className="w-4 h-4 text-neutral-400" />
+          Pay ${price.toFixed(2)} to start
+        </button>
+      )}
+
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
         "clsx": "^2.1.1",
-        "connectonion": "^0.1.10",
+        "connectonion": "^0.2.0",
         "next": "16.0.10",
         "prism-react-renderer": "^2.4.1",
         "qrcode.react": "^4.2.0",
@@ -3656,9 +3656,9 @@
       "license": "MIT"
     },
     "node_modules/connectonion": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.1.10.tgz",
-      "integrity": "sha512-k38L+5wQ8qlmaRDbh087odifAwU4mW+os+Y9fkHMd9PmOOG3YZSvFqwySgrIN7b1Dubh5fFegEsEQHehg1y2/Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.2.0.tgz",
+      "integrity": "sha512-JypqWeq9qcSFx7DMoDgK8Hg5beUoOJpp18ivpzN+tSIEKTpmSh/kftSEeH6TOIuF19aJxDMOJsubukaoVZrWow==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.1.10",
+    "connectonion": "^0.2.0",
     "next": "16.0.10",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
Closes #27.

## What a stranger met

Click an example prompt → the message goes out → *then* "Verification Required" appears asking for an invite code → the message they sent is gone. In testing this also left `Reasoning…` spinning for **eleven minutes** while the request sat behind a gate nobody had mentioned, with the Home pane never arriving either, because the dashboard only ships over a session that onboarding had not let open.

None of it was necessary. `/info` has answered `onboard: {"invite_code": true}` the whole time. The client could not see it because the SDK's `toAgentInfo` allowlist dropped the field — fixed in **connectonion@0.2.0**, which this PR bumps to.

## After

The landing page still shows everything it showed before — name, model, trust, version, Share, example prompts, skill and tool counts. Only the composer changes:

> **naturewill is invite-only**
> Enter a code to start talking. Nothing you write is sent until you are in.
> `[Invite code]` `[Continue →]`

Deliberately **not** a wall in front of the page. Those details are what convince someone to go and ask for a code; putting the code first asks for the ticket before showing the film.

## The part that is easy to get wrong

`onboard` states the **agent's policy**, never **this reader's standing** — it says a code is accepted, not that you already gave one. Rendering the gate from it alone would show an invite box forever to people already inside.

`profile` is the other half: it arrives over the authenticated socket, so having it *is* proof of access. Gated policy **and** no profile is the one combination where a composer would invite someone to write something the agent is going to refuse.

The in-transcript `OnboardRequired` card stays untouched — it still covers what this cannot: an agent that starts open and gates mid-session, where there is no landing page left to render.

## Verified

Ran against a live gated agent (naturewill, `invite_code` in its `.co/trust.md`) on a dev server: the landing page renders the gate on load, before any typing. Screenshot in the loop thread.

`tsc --noEmit` clean · 30 tests pass · depends on connectonion@0.2.0 (published, verified in the tarball: `AgentInfo.onboard` in `types.d.ts`, passthrough in `endpoint.js`).