### PR TITLE
<co-table> — a sortable table, declared not scripted (#38)

### DIFF
--- a/components/dashboard/build-srcdoc.ts
+++ b/components/dashboard/build-srcdoc.ts
@@ -78,6 +78,14 @@ co-filter input {
 co-filter input:focus { outline: 2px solid rgba(127,127,127,.45); outline-offset: -1px; }
 co-filter [data-ochat-count] { display: block; margin-top: 6px; font-size: .85em; opacity: .6; }
 [data-ochat-hidden] { display: none !important; }
+
+co-table { display: none; }
+[data-ochat-sortable] th[data-ochat-sort] { cursor: pointer; user-select: none; }
+[data-ochat-sortable] th[data-ochat-sort]::after {
+  content: ''; opacity: .35; margin-left: .4em; font-size: .85em;
+}
+[data-ochat-sortable] th[aria-sort="ascending"]::after { content: '\\2191'; opacity: .9; }
+[data-ochat-sortable] th[aria-sort="descending"]::after { content: '\\2193'; opacity: .9; }
 </style>`
 }
 
@@ -145,15 +153,78 @@ function ochatFilter(host) {
   apply();
 }
 
-function ochatFilters() {
-  var hosts = document.querySelectorAll('co-filter');
-  for (var i = 0; i < hosts.length; i++) ochatFilter(hosts[i]);
+// <co-table target="#runs"> — the agent declares that a table is sortable; we
+// make its headers controls. The column type is inferred rather than declared:
+// asking a model to label a column "number" is one more thing for it to get
+// wrong, and the cells already say what they are.
+function ochatTable(host) {
+  if (host.getAttribute('data-ochat-ready')) return;
+  var table = document.querySelector(host.getAttribute('target') || '');
+  if (!table || !table.tHead || !table.tBodies.length) return;
+  host.setAttribute('data-ochat-ready', '1');
+  table.setAttribute('data-ochat-sortable', '1');
+
+  var body = table.tBodies[0];
+  var headers = table.tHead.rows.length ? table.tHead.rows[0].cells : [];
+
+  function sortBy(index, dir) {
+    var rows = [];
+    for (var i = 0; i < body.rows.length; i++) rows.push(body.rows[i]);
+    // Read every cell once, before sorting: a comparator that re-reads the DOM
+    // on each comparison is where a sort of a few hundred rows gets slow.
+    var keyed = rows.map(function (row) {
+      var cell = row.cells[index];
+      return { row: row, text: (cell ? cell.textContent : '') || '' };
+    });
+    var numeric = keyed.every(function (k) {
+      return k.text.trim() === '' || !isNaN(parseFloat(k.text.replace(/[,%$\\s]/g, '')));
+    });
+    keyed.sort(function (a, b) {
+      var cmp;
+      if (numeric) {
+        cmp = parseFloat(a.text.replace(/[,%$\\s]/g, '') || '0')
+            - parseFloat(b.text.replace(/[,%$\\s]/g, '') || '0');
+      } else {
+        // localeCompare so 'B' sorts after 'a', which is what a reader expects
+        // and what a raw < comparison gets wrong.
+        cmp = a.text.trim().toLowerCase().localeCompare(b.text.trim().toLowerCase());
+      }
+      return dir === 'descending' ? -cmp : cmp;
+    });
+    for (var j = 0; j < keyed.length; j++) body.appendChild(keyed[j].row);
+
+    for (var h = 0; h < headers.length; h++) {
+      if (h === index) headers[h].setAttribute('aria-sort', dir);
+      else headers[h].removeAttribute('aria-sort');
+    }
+  }
+
+  for (var c = 0; c < headers.length; c++) {
+    (function (index) {
+      var th = headers[index];
+      th.setAttribute('data-ochat-sort', '1');
+      th.setAttribute('tabindex', '0');
+      th.setAttribute('role', 'button');
+      th.addEventListener('click', function () {
+        var next = th.getAttribute('aria-sort') === 'ascending'
+          ? 'descending' : 'ascending';
+        sortBy(index, next);
+      });
+    })(c);
+  }
+}
+
+function ochatComponents() {
+  var filters = document.querySelectorAll('co-filter');
+  for (var i = 0; i < filters.length; i++) ochatFilter(filters[i]);
+  var tables = document.querySelectorAll('co-table');
+  for (var j = 0; j < tables.length; j++) ochatTable(tables[j]);
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', ochatFilters);
+  document.addEventListener('DOMContentLoaded', ochatComponents);
 } else {
-  ochatFilters();
+  ochatComponents();
 }
 </script>`
 }

--- a/components/dashboard/co-table.test.ts
+++ b/components/dashboard/co-table.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @purpose The <co-table> component in a real DOM: the agent declares that a
+ *   table is sortable, and the bridge — the only script with a nonce — makes its
+ *   headers work. Sorting is a behaviour, so it is asserted by clicking.
+ * @llm-note Column type is inferred from the cells, not declared by the agent.
+ *   Asking a model to label a column "number" is one more thing for it to get
+ *   wrong, and the cells already say what they are.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { bridgeScript } from './build-srcdoc'
+
+const NONCE = 'deadbeefdeadbeefdeadbeefdeadbeef'
+
+function render(agentHtml: string) {
+  document.body.innerHTML = agentHtml
+  const source = bridgeScript(NONCE)
+    .replace(/^<script nonce="[^"]*">/, '')
+    .replace(/<\/script>$/, '')
+  // eslint-disable-next-line no-new-func
+  new Function(source)()
+}
+
+const TABLE = `
+  <co-table target="#runs"></co-table>
+  <table id="runs">
+    <thead><tr><th>skill</th><th>runs</th></tr></thead>
+    <tbody>
+      <tr><td>deploy</td><td>10</td></tr>
+      <tr><td>Alpha</td><td>9</td></tr>
+      <tr><td>review</td><td>100</td></tr>
+    </tbody>
+  </table>`
+
+function column(index: number) {
+  return Array.from(document.querySelectorAll('#runs tbody tr'))
+    .map((row) => row.cells[index].textContent)
+}
+
+function header(index: number) {
+  return document.querySelectorAll('#runs thead th')[index] as HTMLElement
+}
+
+describe('<co-table>', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('leaves the rows alone until a header is clicked', () => {
+    render(TABLE)
+
+    expect(column(0)).toEqual(['deploy', 'Alpha', 'review'])
+  })
+
+  it('sorts text ascending on the first click', () => {
+    render(TABLE)
+
+    header(0).click()
+
+    expect(column(0)).toEqual(['Alpha', 'deploy', 'review'])
+  })
+
+  it('reverses on the second click', () => {
+    render(TABLE)
+
+    header(0).click()
+    header(0).click()
+
+    expect(column(0)).toEqual(['review', 'deploy', 'Alpha'])
+  })
+
+  it('sorts numbers by value, not as text', () => {
+    // The bug this exists to prevent: '100' < '9' lexicographically.
+    render(TABLE)
+
+    header(1).click()
+
+    expect(column(1)).toEqual(['9', '10', '100'])
+  })
+
+  it('reads 1,200 and $30 and 5% as numbers', () => {
+    render(`
+      <co-table target="#t"></co-table>
+      <table id="t">
+        <thead><tr><th>cost</th></tr></thead>
+        <tbody>
+          <tr><td>$1,200</td></tr><tr><td>$30</td></tr><tr><td>$500</td></tr>
+        </tbody>
+      </table>`)
+
+    ;(document.querySelector('#t thead th') as HTMLElement).click()
+
+    expect(Array.from(document.querySelectorAll('#t tbody td'))
+      .map((c) => c.textContent)).toEqual(['$30', '$500', '$1,200'])
+  })
+
+  it('sorts case-insensitively, so B does not come before a', () => {
+    render(TABLE)
+
+    header(0).click()
+
+    expect(column(0)[0]).toBe('Alpha')
+  })
+
+  it('marks the sorted column for a screen reader, and only that one', () => {
+    render(TABLE)
+
+    header(1).click()
+
+    expect(header(1).getAttribute('aria-sort')).toBe('ascending')
+    expect(header(0).hasAttribute('aria-sort')).toBe(false)
+  })
+
+  it('does nothing when the target is not a table with a body', () => {
+    render('<co-table target="#nope"></co-table><div id="nope">not a table</div>')
+
+    expect(document.querySelector('[data-ochat-sortable]')).toBeNull()
+  })
+
+  it('composes with a filter over the same rows', () => {
+    // Sorting reorders; filtering hides. Neither should undo the other.
+    render(`
+      <co-filter target="#runs tbody" placeholder="Filter"></co-filter>
+      ${TABLE}`)
+
+    header(1).click()
+    const input = document.querySelector('co-filter input') as HTMLInputElement
+    input.value = 'e'
+    input.dispatchEvent(new Event('input'))
+
+    const showing = Array.from(document.querySelectorAll('#runs tbody tr'))
+      .filter((r) => !r.hasAttribute('data-ochat-hidden'))
+      .map((r) => r.cells[0].textContent)
+    expect(showing).toEqual(['deploy', 'review'])
+  })
+})


### PR DESCRIPTION
Second component from #38, after `<co-filter>` (#41). Same shape: the agent declares that a table is sortable, and the bridge makes its headers work.

```html
<co-table target="#runs"></co-table>
<table id="runs">
  <thead><tr><th>skill</th><th>runs</th></tr></thead>
  <tbody>…</tbody>
</table>
```

## The type is inferred, not declared

The obvious alternative is `<th data-ochat-sort="number">`. I did not do that: asking a model to label each column is one more thing for it to get wrong, and **the cells already say what they are**. A column sorts numerically when every non-blank cell parses as a number, and `$1,200` / `30%` / `1,000` parse — those are what a dashboard actually contains.

This is the bug the component exists to prevent, so there is a test for exactly it:

```
'100' < '9'    // lexicographic — what a naive sort does
9, 10, 100     // what a reader means
```

I checked that test earns its keep by forcing the lexicographic path and re-running: it and the currency case both go red, the other seven stay green.

## Details worth arguing with

- **Cells are read once, before sorting.** A comparator that re-reads the DOM per comparison is where a few hundred rows gets slow.
- **`localeCompare`, lowercased.** A raw `<` puts `B` before `a`, which no reader means.
- **`aria-sort` on the sorted column only**, and headers get `role="button"` and `tabindex` — a sort control that only exists for a mouse is half a control.
- **Nothing happens if the target is not a table with a body.** Same rule as `<co-filter>`: no half-rendered control.
- **It composes with `<co-filter>`.** Sorting reorders, filtering hides; neither undoes the other, and there is a test that does both to the same rows.

## Tests

9 new, in a real DOM (`jsdom`, added with #41). `49 passed` across the dashboard suite, `npm run build` green.

The agent-facing docs follow in openonion/connectonion#516, after this ships — an unknown tag renders as nothing, so the order only matters in that nobody should be told about a tag we do not yet honour.