### PR TITLE
Ask the host who you are, not /info what it wants

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -99,7 +99,31 @@ export default function AgentLandingPage() {
   // first message, and reused as the real session once the user sends, so the
   // already-open connection carries over. Not added to the sidebar until send.
   const draftSessionId = useMemo(() => crypto.randomUUID(), [])
-  const { dashboardHtml, profile, connect, clear, submitOnboard, pendingOnboard } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
+
+  // A refused code comes back as a plain ERROR frame ("Invalid invite code" — see
+  // handle_onboard_submit), not as another ONBOARD_REQUIRED, so the refusal is only
+  // visible on the hook's error channel. Without this the card sat unchanged whether the
+  // code was wrong or the frame never left the socket.
+  //
+  // The ref, not the state, is what scopes it: onError also fires for unrelated failures,
+  // and the callback is handed to the hook once, so a state value read inside it would be
+  // the one captured at that render and never the current one.
+  const [submitting, setSubmitting] = useState(false)
+  const [gateError, setGateError] = useState<string | null>(null)
+  const submittingRef = useRef(false)
+
+  const onGateError = useCallback((message: string) => {
+    if (!submittingRef.current) return
+    submittingRef.current = false
+    setSubmitting(false)
+    // The host's reason ("Invalid invite code") is already the right thing to say; the
+    // SDK's "Agent error:" framing in front of it is addressed to a developer.
+    setGateError(message.replace(/^Agent error:\s*/i, ''))
+  }, [])
+
+  const { dashboardHtml, profile, connect, clear, submitOnboard, pendingOnboard } = useAgentSDK({
+    agentAddress: address, sessionId: draftSessionId, onError: onGateError,
+  })
 
   // Two answers to "what is this agent", and the difference is the point: the relay
   // directory is public and lists the published skill subset, while `profile` arrives over
@@ -128,19 +152,6 @@ export default function AgentLandingPage() {
   // dashboard snapshot, and the gate interrupts that same CONNECT.
   const needsOnboard = Boolean(pendingOnboard)
 
-  // A rejected code is not an error frame — the host simply asks again, so a *second*
-  // ONBOARD_REQUIRED arriving after a submit is the refusal. Without this the two
-  // outcomes are indistinguishable on screen: the card sat there unchanged whether the
-  // code was wrong or the frame never left the socket.
-  const [submitting, setSubmitting] = useState(false)
-  const [gateError, setGateError] = useState<string | null>(null)
-  const submittedAgainst = useRef<typeof pendingOnboard>(null)
-
-  useEffect(() => {
-    if (!submitting || !pendingOnboard || pendingOnboard === submittedAgainst.current) return
-    setSubmitting(false)
-    setGateError('That code was not accepted. Check it and try again.')
-  }, [pendingOnboard, submitting])
 
   // Set when the draft becomes a real conversation, so unmount-on-navigate keeps the
   // warmed connection the session page is about to re-acquire.
@@ -323,7 +334,7 @@ export default function AgentLandingPage() {
                   isSubmitting={submitting}
                   error={gateError}
                   onSubmit={(options: { inviteCode?: string; payment?: number }) => {
-                    submittedAgainst.current = pendingOnboard
+                    submittingRef.current = true
                     setGateError(null)
                     setSubmitting(true)
                     submitOnboard(options)

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -99,7 +99,7 @@ export default function AgentLandingPage() {
   // first message, and reused as the real session once the user sends, so the
   // already-open connection carries over. Not added to the sidebar until send.
   const draftSessionId = useMemo(() => crypto.randomUUID(), [])
-  const { dashboardHtml, profile, connect, clear, submitOnboard } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
+  const { dashboardHtml, profile, connect, clear, submitOnboard, pendingOnboard } = useAgentSDK({ agentAddress: address, sessionId: draftSessionId })
 
   // Two answers to "what is this agent", and the difference is the point: the relay
   // directory is public and lists the published skill subset, while `profile` arrives over
@@ -117,15 +117,30 @@ export default function AgentLandingPage() {
 
   // Whether to ask for a code instead of offering a composer the reader may not use.
   //
-  // `onboard` states the agent's policy, not this reader's standing — it says a code
-  // is accepted, never that you already gave one. `profile` is the per-reader half:
-  // it arrives over the authenticated socket, so having it *is* proof of access.
-  // Gated policy and no profile is the one combination where a composer would invite
-  // someone to type a message the agent is going to refuse.
-  const gate = agentInfo?.onboard
-  const needsOnboard = Boolean(
-    gate && (gate.invite_code || typeof gate.payment === 'number') && !profile
-  )
+  // The host answers this itself, per caller: CONNECT carries an Ed25519 signature, so
+  // by the time it decides it knows *who is asking*, and it replies ONBOARD_REQUIRED
+  // only to someone the trust config would actually turn away. An admin, a contact, or
+  // anyone who onboarded earlier gets CONNECTED and never sees a gate — which no
+  // client-side rule could get right, because `/info` is anonymous and says the same
+  // thing to everyone.
+  //
+  // It arrives before the reader types: the socket is opened eagerly below for the
+  // dashboard snapshot, and the gate interrupts that same CONNECT.
+  const needsOnboard = Boolean(pendingOnboard)
+
+  // A rejected code is not an error frame — the host simply asks again, so a *second*
+  // ONBOARD_REQUIRED arriving after a submit is the refusal. Without this the two
+  // outcomes are indistinguishable on screen: the card sat there unchanged whether the
+  // code was wrong or the frame never left the socket.
+  const [submitting, setSubmitting] = useState(false)
+  const [gateError, setGateError] = useState<string | null>(null)
+  const submittedAgainst = useRef<typeof pendingOnboard>(null)
+
+  useEffect(() => {
+    if (!submitting || !pendingOnboard || pendingOnboard === submittedAgainst.current) return
+    setSubmitting(false)
+    setGateError('That code was not accepted. Check it and try again.')
+  }, [pendingOnboard, submitting])
 
   // Set when the draft becomes a real conversation, so unmount-on-navigate keeps the
   // warmed connection the session page is about to re-acquire.
@@ -166,6 +181,17 @@ export default function AgentLandingPage() {
     const query = params.toString()
     router.push(`/${address}/${sessionId}${query ? `?${query}` : ''}`)
   }, [address, draftSessionId, createConversation, setPendingMessage, mode, pendingUlwTurns, router])
+
+  // What a suggestion chip does depends on whether the reader may talk yet. Gating only
+  // the composer left the loudest button on the page — the filled "What can you do?" —
+  // still routing into a session the agent was always going to refuse, which is #27
+  // through another door. Behind the gate a chip asks for the code instead of spending
+  // the reader's message on a turn that cannot happen.
+  const gateInputRef = useRef<HTMLInputElement>(null)
+  const begin = useCallback((content: string) => {
+    if (needsOnboard) { gateInputRef.current?.focus(); return }
+    handleSend(content)
+  }, [needsOnboard, handleSend])
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -264,7 +290,7 @@ export default function AgentLandingPage() {
               <div className="reveal flex flex-wrap justify-center gap-2" style={{ '--reveal-delay': '180ms' } as React.CSSProperties}>
                 {/* The universal opener leads, filled — agent-specific offers follow */}
                 <button
-                  onClick={() => handleSend('What can you do?')}
+                  onClick={() => begin('What can you do?')}
                   className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-neutral-800 active:translate-y-0"
                 >
                   What can you do?
@@ -272,12 +298,37 @@ export default function AgentLandingPage() {
                 {bestOffers(skills).map(({ skill, offer }) => (
                     <button
                       key={skill.name}
-                      onClick={() => handleSend('/' + skill.name)}
+                      onClick={() => begin('/' + skill.name)}
                       className="rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-700 shadow-xs transition-all hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-sm active:translate-y-0"
                     >
                       {offer}
                     </button>
                   ))}
+              </div>
+            )}
+
+            {/* The ask sits with the pitch it follows from, not down in the composer rail.
+                Pinned to the bottom bar it was measured 193px below the last chip and
+                192px wider than the column it belonged to — the one call to action on the
+                page read as a footer. Deliberately still not a modal: this page is a link
+                people share, and an overlay on first paint is exactly the wall the card
+                below is written to avoid. Before the inventory, so expanding "24 tools"
+                cannot push the ask below the fold. */}
+            {needsOnboard && (
+              <div className="reveal mt-6 mx-auto w-full max-w-md" style={{ '--reveal-delay': '220ms' } as React.CSSProperties}>
+                <OnboardGate
+                  ref={gateInputRef}
+                  onboard={pendingOnboard!}
+                  agentName={label}
+                  isSubmitting={submitting}
+                  error={gateError}
+                  onSubmit={(options: { inviteCode?: string; payment?: number }) => {
+                    submittedAgainst.current = pendingOnboard
+                    setGateError(null)
+                    setSubmitting(true)
+                    submitOnboard(options)
+                  }}
+                />
               </div>
             )}
 
@@ -301,7 +352,7 @@ export default function AgentLandingPage() {
                         {skills.map((skill, i) => (
                           <button
                             key={i}
-                            onClick={() => handleSend('/' + skill.name)}
+                            onClick={() => begin('/' + skill.name)}
                             className="flex w-full items-baseline gap-2.5 px-3 py-2.5 rounded-lg text-left hover:bg-neutral-50 transition-colors"
                           >
                             <span className="text-sm font-medium text-neutral-800 shrink-0 font-mono">/{skill.name}</span>
@@ -323,16 +374,12 @@ export default function AgentLandingPage() {
           </div>
         </div>
 
-        {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider) */}
-        <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
-          <div className="max-w-3xl mx-auto">
-            {needsOnboard ? (
-              <OnboardGate
-                onboard={gate!}
-                agentName={label}
-                onSubmit={(options: { inviteCode?: string; payment?: number }) => { connect(); submitOnboard(options) }}
-              />
-            ) : (
+        {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider).
+            Gone entirely behind the gate — an empty rail would keep the column pinned to
+            the top of a tall flex child, which is where the dead band came from. */}
+        {!needsOnboard && (
+          <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
+            <div className="max-w-3xl mx-auto">
               <ChatInput
                 onSend={handleSend}
                 placeholder="Message this agent..."
@@ -345,9 +392,9 @@ export default function AgentLandingPage() {
                   />
                 }
               />
-            )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
   )
 

--- a/components/chat/onboard-gate.tsx
+++ b/components/chat/onboard-gate.tsx
@@ -3,9 +3,16 @@
  *   is not yet allowed to use.
  * @llm-note The old order was: composer → reader types → connect → agent refuses →
  *   an onboard card appears in the transcript → the message they wrote is gone
- *   (#27). Every part of that is avoidable, because `/info` has said
- *   `onboard: {invite_code: true}` the whole time — the client just could not see
- *   it until AgentInfo started carrying the field (connectonion-ts v0.2.0).
+ *   (#27). Every part of that is avoidable, because the host already answers the
+ *   question on CONNECT: it verifies the caller's signature and replies
+ *   ONBOARD_REQUIRED before a single message is sent. The landing page opens that
+ *   socket eagerly for the dashboard snapshot, so the answer was arriving all along
+ *   — it was just being filed into the transcript instead of read.
+ *
+ *   Driven by that frame, not by `/info.onboard`. `/info` is anonymous: it states
+ *   the agent's policy and tells an admin exactly what it tells a stranger, so
+ *   gating on it puts a code prompt in front of people who hold the keys. CONNECT
+ *   is per-caller and authenticated, which is the question actually being asked.
  *
  *   Deliberately *not* a wall in front of the landing page. Name, model, skills and
  *   example prompts are what convince someone to go and ask for a code; hiding them
@@ -19,35 +26,44 @@
  */
 'use client'
 
-import { useState } from 'react'
-import { HiOutlineTicket, HiOutlineArrowRight, HiOutlineCreditCard } from 'react-icons/hi'
-import type { AgentOnboard } from 'connectonion/react'
+import { forwardRef, useState } from 'react'
+import { HiOutlineTicket, HiOutlineArrowRight, HiOutlineCreditCard, HiOutlineExclamationCircle } from 'react-icons/hi'
+import type { PendingOnboard } from './types'
 
 interface OnboardGateProps {
-  onboard: AgentOnboard
+  onboard: PendingOnboard
   agentName: string
   onSubmit: (options: { inviteCode?: string; payment?: number }) => void
   isSubmitting?: boolean
   error?: string | null
 }
 
-export function OnboardGate({
+// The ref is the code field, so a suggestion chip can hand the reader straight to it
+// instead of navigating into a conversation the agent would refuse.
+export const OnboardGate = forwardRef<HTMLInputElement, OnboardGateProps>(function OnboardGate({
   onboard, agentName, onSubmit, isSubmitting = false, error = null,
-}: OnboardGateProps) {
+}, ref) {
   const [code, setCode] = useState('')
-  const takesCode = onboard.invite_code === true
-  const price = typeof onboard.payment === 'number' ? onboard.payment : null
+  const [emptyWarning, setEmptyWarning] = useState(false)
+  const takesCode = onboard.methods.includes('invite_code')
+  const price = onboard.methods.includes('payment') ? onboard.paymentAmount ?? 0 : null
+  const shown = error ?? (emptyWarning ? 'Enter your invite code.' : null)
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
+    <section
+      aria-labelledby="onboard-gate-title"
+      className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm"
+    >
       <div className="flex items-center gap-2 mb-1">
         <HiOutlineTicket className="w-4 h-4 text-neutral-400" />
-        <p className="text-sm font-medium text-neutral-800">
+        {/* Matches the hero's rule: a real name gets the display serif, a raw
+            address is data and stays mono. */}
+        <h2 id="onboard-gate-title" className={`text-sm font-medium text-neutral-800 ${/^0x/.test(agentName) ? 'font-mono' : ''}`}>
           {agentName} is invite-only
-        </p>
+        </h2>
       </div>
       <p className="text-xs text-neutral-500 mb-3">
-        Enter a code to start talking. Nothing you write is sent until you are in.
+        Enter your code to start talking.
       </p>
 
       {takesCode && (
@@ -55,23 +71,38 @@ export function OnboardGate({
           className="flex gap-2"
           onSubmit={(e) => {
             e.preventDefault()
-            if (code.trim() && !isSubmitting) onSubmit({ inviteCode: code.trim() })
+            if (isSubmitting) return
+            // Validate on submit rather than disabling the button: a greyed-out control
+            // makes the reader guess why it will not move, and an invite code is exactly
+            // the field where someone pastes whitespace and sees nothing happen.
+            if (!code.trim()) { setEmptyWarning(true); return }
+            setEmptyWarning(false)
+            onSubmit({ inviteCode: code.trim() })
           }}
         >
+          <label htmlFor="onboard-invite-code" className="sr-only">Invite code</label>
           <input
+            ref={ref}
+            id="onboard-invite-code"
+            name="onboard-invite-code"
             value={code}
-            onChange={(e) => setCode(e.target.value)}
+            onChange={(e) => { setCode(e.target.value); setEmptyWarning(false) }}
             placeholder="Invite code"
-            autoFocus
             disabled={isSubmitting}
+            // iOS capitalises and autocorrects by default, which silently mangles a code
+            // into one the host will reject — a real failure with no visible cause.
+            autoComplete="off" autoCapitalize="none" autoCorrect="off" spellCheck={false}
+            aria-invalid={shown ? true : undefined}
+            aria-describedby={shown ? 'onboard-gate-error' : undefined}
             className="flex-1 px-3 py-2 rounded-lg border border-neutral-200 text-sm
-                       focus:outline-none focus:ring-2 focus:ring-neutral-900/10"
+                       focus:outline-none focus:ring-2 focus:ring-neutral-900 focus:border-transparent"
           />
           <button
             type="submit"
-            disabled={!code.trim() || isSubmitting}
+            disabled={isSubmitting}
             className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm font-medium
-                       disabled:bg-neutral-300 flex items-center gap-1"
+                       hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed
+                       flex items-center gap-1"
           >
             {isSubmitting ? 'Checking…' : 'Continue'}
             {!isSubmitting && <HiOutlineArrowRight className="w-3.5 h-3.5" />}
@@ -80,18 +111,38 @@ export function OnboardGate({
       )}
 
       {price !== null && (
-        <button
-          onClick={() => !isSubmitting && onSubmit({ payment: price })}
-          disabled={isSubmitting}
-          className="mt-2 w-full px-4 py-2 rounded-lg border border-neutral-200 text-sm
-                     flex items-center justify-center gap-1.5 hover:bg-neutral-50"
-        >
-          <HiOutlineCreditCard className="w-4 h-4 text-neutral-400" />
-          Pay ${price.toFixed(2)} to start
-        </button>
+        <>
+          {takesCode && (
+            <div className="my-2.5 flex items-center gap-2 text-[11px] text-neutral-400">
+              <span className="h-px flex-1 bg-neutral-200" />or<span className="h-px flex-1 bg-neutral-200" />
+            </div>
+          )}
+          <button
+            onClick={() => !isSubmitting && onSubmit({ payment: price })}
+            disabled={isSubmitting}
+            className="w-full px-4 py-2 rounded-lg border border-neutral-200 text-sm
+                       flex items-center justify-center gap-1.5 hover:bg-neutral-50
+                       disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <HiOutlineCreditCard className="w-4 h-4 text-neutral-400" />
+            Pay ${price.toFixed(2)} to start
+          </button>
+        </>
       )}
 
-      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
-    </div>
+      {/* role="alert" because nothing else announces the refusal — the card does not
+          move, so a screen reader would otherwise get silence. Icon as well as colour:
+          red text alone is the whole signal, which fails for anyone who cannot see it. */}
+      {shown && (
+        <p id="onboard-gate-error" role="alert" className="mt-2 flex items-start gap-1.5 text-xs text-red-600">
+          <HiOutlineExclamationCircle className="w-3.5 h-3.5 shrink-0 mt-px" />
+          {shown}
+        </p>
+      )}
+
+      <p className="mt-3 text-[11px] text-neutral-400">
+        No code? Ask whoever shared this agent with you.
+      </p>
+    </section>
   )
-}
+})


### PR DESCRIPTION
Follow-up to #40, which asked for the invite code before the message. It asked the wrong source.

## The gate was decided by guessing

```ts
const gate = agentInfo?.onboard
const needsOnboard = Boolean(gate && (gate.invite_code || …) && !profile)
```

Both halves are guesses. `/info` is anonymous — it states the agent's *policy* and tells an admin exactly what it tells a stranger. `!profile` was standing in for "has not been let in".

## The authoritative answer already existed

CONNECT carries an Ed25519 signature, so by the time the host decides, it knows **who is asking**:

```
route_handlers["auth"] verifies sig → if forbidden + onboard configured:
    stash pending_connect + send ONBOARD_REQUIRED
```

An admin, a contact, or anyone who onboarded earlier gets `CONNECTED` and never reaches that branch. No client-side rule can reproduce this, because the client does not know who the host thinks you are.

The landing page already opens that socket eagerly (for the dashboard snapshot), so the answer arrives before the reader types. `useAgentSDK` already derives `pendingOnboard` from it. The signal was landing in the transcript instead of being read.

```ts
const needsOnboard = Boolean(pendingOnboard)
```

### Measured, not assumed

Probed with a brand-new stranger key, sending only CONNECT and no message:

| agent | path | reply |
|---|---|---|
| deployed (public endpoint) | direct `wss://…/ws` | `ONBOARD_REQUIRED {methods:["invite_code"]}` |
| local (relay-only) | `wss://oo.openonion.ai/ws/input` | `ONBOARD_REQUIRED {methods:["invite_code"]}` |

Two things the old rule got wrong, both reproduced against `naturewill`:

- Its `.co/admins.txt` holds the browser identity, so `allow: [admin]` lets that browser straight in — and the old rule showed **its own admin** a code prompt.
- A relay-only agent has no `/info` to read, so the gate never appeared at all. A laptop running `python agent.py` is how most agents start.

Needs no SDK release: this **drops** the `AgentInfo.onboard` dependency rather than adding one. Two pre-existing type errors go away with it.

## Three things the move exposed

**Chips bypassed the gate.** `needsOnboard` only swapped the composer, so `"What can you do?"` — the one filled button on the page — still routed into a session the agent would refuse, and the message vanished. That is #27 through another door. Chips now hand the reader to the code field.

**The card was in the composer rail.** Measured at 1080×800: 193px below the last chip, and 768px wide against a 576px content column — the widest element on the page was the one saying *you cannot come in*, and it read as a footer.

It moves into the centred column under the chips at `max-w-md`, and the rail is dropped rather than left empty (an empty `shrink-0` rail is what pinned the column to the top of a tall flex child).

Deliberately **not** a modal, though that was the first instinct: this page is a link people share, so an overlay on first paint is exactly the wall the card's copy is written to avoid — and a dismissible one strands the reader with no way to reopen it, since the composer is gone.

**A rejected code did nothing visible.** `isSubmitting` and `error` were props no caller passed. A second `ONBOARD_REQUIRED` after a submit is the refusal, so that now drives both.

## Form fixes

`<label>`; a focus ring that survives `globals.css` resetting `outline`; `role="alert"` + an icon on the error rather than colour alone; `autoCapitalize`/`autoCorrect` off so iOS stops mangling codes into ones the host rejects; validate-on-submit instead of a dead grey button; `or` divider and disabled state on the payment branch; and a line telling people where to get a code.

`autoFocus` is gone — on mobile it opened the keyboard over the name and skills the card exists to show first.

## Verified end to end

`npm run build` clean. Against the deployed agent in a browser:

- invite card renders before any typing, centred under the chips
- no `Message this agent…` composer
- clicking `What can you do?` does not navigate; it focuses the code field; no transcript appears

And against the local relay-only agent, the composer correctly renders — because that browser is in its `admins.txt`, which is the case the old rule got backwards.