### PR TITLE
feat(onboard): the invite gate covers the page

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -125,6 +125,15 @@ export default function AgentLandingPage() {
     agentAddress: address, sessionId: draftSessionId, onError: onGateError,
   })
 
+  // NOTE: getting the code wrong once and then right is currently broken, and the
+  // cause is not here. remote-agent.ts runs `_closeWs()` on every ERROR frame, and a
+  // refused invite code is an ERROR frame — so the socket the host deliberately keeps
+  // open for a retry ("a failed one keeps it so a retry on the same socket can still
+  // complete the interrupted CONNECT", session.py) is closed by this side, and the
+  // second submit sits on "Checking…" forever. Reconnecting from here was tried and
+  // is worse: `reconnect` is a fresh function every render, so an effect that depends
+  // on it reconnects in a loop until the tab dies. It belongs in the SDK.
+
   // Two answers to "what is this agent", and the difference is the point: the relay
   // directory is public and lists the published skill subset, while `profile` arrives over
   // the authenticated socket and holds everything. Layer, don't replace — the frame is
@@ -203,6 +212,20 @@ export default function AgentLandingPage() {
     if (needsOnboard) { gateInputRef.current?.focus(); return }
     handleSend(content)
   }, [needsOnboard, handleSend])
+
+  // Whether this reader arrived at a gate, remembered after the gate is gone.
+  //
+  // defaultMobileView="home" is about arriving, not about every later change, and
+  // passing the gate is a later change that looks exactly like arriving: the code is
+  // accepted, dashboardHtml arrives for the first time, hasDashboard flips true, and
+  // WorkspaceShell's derived view moves a phone off the chat and onto Home — one
+  // frame after the reader pressed Continue. Landing somewhere you did not ask to go,
+  // immediately after acting, reads as "my code did something strange".
+  // Adjusted during render rather than in an effect: this is derived from a prop-like
+  // value and React's own guidance is to set it here, where the very next render sees
+  // it, instead of after a paint that would show the wrong pane first.
+  const [wasGated, setWasGated] = useState(false)
+  if (needsOnboard && !wasGated) setWasGated(true)
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -326,30 +349,6 @@ export default function AgentLandingPage() {
               </div>
             )}
 
-            {/* The ask sits with the pitch it follows from, not down in the composer rail.
-                Pinned to the bottom bar it was measured 193px below the last chip and
-                192px wider than the column it belonged to — the one call to action on the
-                page read as a footer. Deliberately still not a modal: this page is a link
-                people share, and an overlay on first paint is exactly the wall the card
-                below is written to avoid. Before the inventory, so expanding "24 tools"
-                cannot push the ask below the fold. */}
-            {needsOnboard && (
-              <div className="reveal mt-6 mx-auto w-full max-w-md" style={{ '--reveal-delay': '220ms' } as React.CSSProperties}>
-                <OnboardGate
-                  ref={gateInputRef}
-                  onboard={pendingOnboard!}
-                  agentName={label}
-                  isSubmitting={submitting}
-                  error={gateError}
-                  onSubmit={(options: { inviteCode?: string; payment?: number }) => {
-                    submittingRef.current = true
-                    setGateError(null)
-                    setSubmitting(true)
-                    submitOnboard(options)
-                  }}
-                />
-              </div>
-            )}
 
             {/* Full inventory lives behind one quiet disclosure row */}
             {(skills.length > 0 || tools.length > 0) && (
@@ -418,18 +417,49 @@ export default function AgentLandingPage() {
   )
 
   return (
-    <WorkspaceShell
-      defaultMobileView="home"
-      hasDashboard={dashboardHtml !== null}
-      chat={landingContent}
-      dashboard={
-        <DashboardPane
-          html={dashboardHtml}
-          skills={skills}
-          onRunSkill={runSkill}
-          className="w-full h-full border-0"
+    <>
+      <WorkspaceShell
+        defaultMobileView={wasGated ? 'chat' : 'home'}
+        hasDashboard={dashboardHtml !== null}
+        chat={landingContent}
+        dashboard={
+          <DashboardPane
+            html={dashboardHtml}
+            skills={skills}
+            onRunSkill={runSkill}
+            className="w-full h-full border-0"
+          />
+        }
+      />
+
+      {/* A sibling of the whole workspace, not a child of the column it used to sit in.
+          `position: fixed` is relative to the nearest transformed ancestor rather than
+          the viewport, and the landing column's `.reveal` animates a transform — so
+          nested there, the overlay covered only its own corner of the page and `z-50`
+          applied inside a stacking context that the page's own buttons sat above.
+          Playwright found it by failing to click Continue: an element behind the wall
+          was intercepting the pointer.
+
+          It used to be an inline card, "deliberately not a modal" on the grounds that a
+          shared link should not open with a wall. That held until it was measured on a
+          phone: header and avatar ≈ 240px, three rows of chips ≈ 190px, and the card
+          began near y≈470 of a ~600px viewport, under a filled black button that does
+          nothing while gated. Present, past the fold, and outranked. */}
+      {needsOnboard && (
+        <OnboardGate
+          ref={gateInputRef}
+          onboard={pendingOnboard!}
+          agentName={label}
+          isSubmitting={submitting}
+          error={gateError}
+          onSubmit={(options: { inviteCode?: string; payment?: number }) => {
+            submittingRef.current = true
+            setGateError(null)
+            setSubmitting(true)
+            submitOnboard(options)
+          }}
         />
-      }
-    />
+      )}
+    </>
   )
 }

--- a/components/chat/onboard-gate.tsx
+++ b/components/chat/onboard-gate.tsx
@@ -1,6 +1,6 @@
 /**
- * @purpose Say up front that an agent is gated, in place of a composer the reader
- *   is not yet allowed to use.
+ * @purpose Stand in front of an invite-only agent: the code is the only thing on
+ *   screen until it is accepted.
  * @llm-note The old order was: composer → reader types → connect → agent refuses →
  *   an onboard card appears in the transcript → the message they wrote is gone
  *   (#27). Every part of that is avoidable, because the host already answers the
@@ -14,19 +14,27 @@
  *   gating on it puts a code prompt in front of people who hold the keys. CONNECT
  *   is per-caller and authenticated, which is the question actually being asked.
  *
- *   Deliberately *not* a wall in front of the landing page. Name, model, skills and
- *   example prompts are what convince someone to go and ask for a code; hiding them
- *   behind the code is asking for the ticket before showing the film. What changes
- *   is only the composer: an input the reader may use, instead of one that will
- *   reject them.
+ *   This used to be an inline card that sat below the example chips, deliberately
+ *   not a wall — the argument being that name, model and skills are what convince
+ *   someone to go and ask for a code. On a phone that argument lost to arithmetic.
+ *   Measured at 375×667: header and avatar ≈ 240px, three rows of chips ≈ 190px,
+ *   and the card's title landed near y≈470 of a ~600px viewport. The one thing a
+ *   visitor must do was the fourth thing they could see, under a filled black
+ *   button that, while gated, does nothing but move focus.
+ *
+ *   So it is a wall now. The pitch is not gone — it is the first thing behind the
+ *   code, one submit away — but a page that requires a code opens by asking for
+ *   the code. Nothing else on screen is actionable until it is answered, which is
+ *   also the honest rendering of the state: every control behind this would be
+ *   refused.
  *
  *   The in-transcript OnboardRequired card stays as-is. It is still correct for the
  *   case this cannot cover — an agent that starts open and gates mid-session, where
- *   there is no landing page left to render.
+ *   there is a conversation behind it that must stay readable.
  */
 'use client'
 
-import { forwardRef, useState } from 'react'
+import { forwardRef, useEffect, useRef, useState } from 'react'
 import { HiOutlineTicket, HiOutlineArrowRight, HiOutlineCreditCard, HiOutlineExclamationCircle } from 'react-icons/hi'
 import type { PendingOnboard } from './types'
 
@@ -49,100 +57,155 @@ export const OnboardGate = forwardRef<HTMLInputElement, OnboardGateProps>(functi
   const price = onboard.methods.includes('payment') ? onboard.paymentAmount ?? 0 : null
   const shown = error ?? (emptyWarning ? 'Enter your invite code.' : null)
 
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Hold Tab inside the panel. There is nothing behind this worth reaching — every
+  // control back there is one the agent would refuse — and a keyboard user who tabs
+  // out of a wall lands in a page they cannot see and cannot use.
+  //
+  // No Escape handler on purpose: dismissing leaves nothing usable, so a key that
+  // looks like it should close this would either lie or do nothing visible. The
+  // honest answer to "can I get out of this" is the last line of the panel.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const focusable = panelRef.current?.querySelectorAll<HTMLElement>(
+        'input:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+      )
+      if (!focusable?.length) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus() }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus() }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    // The page behind still scrolls on iOS otherwise, under an overlay that looks fixed.
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = prev
+    }
+  }, [])
+
   return (
-    <section
-      aria-labelledby="onboard-gate-title"
-      className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm"
+    // Opaque, not a dim scrim. Content you can read through a veil but cannot touch
+    // is its own frustration, and half-hiding an agent's skills says "look at what
+    // you may not have" — which is the opposite of what the line at the bottom is
+    // trying to do for someone who has no code.
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto
+                 bg-neutral-50 px-5 py-8 dark:bg-neutral-950"
     >
-      <div className="flex items-center gap-2 mb-1">
-        <HiOutlineTicket className="w-4 h-4 text-neutral-400" />
-        {/* Matches the hero's rule: a real name gets the display serif, a raw
-            address is data and stays mono. */}
-        <h2 id="onboard-gate-title" className={`text-sm font-medium text-neutral-800 ${/^0x/.test(agentName) ? 'font-mono' : ''}`}>
-          {agentName} is invite-only
-        </h2>
-      </div>
-      <p className="text-xs text-neutral-500 mb-3">
-        Enter your code to start talking.
-      </p>
-
-      {takesCode && (
-        <form
-          className="flex gap-2"
-          onSubmit={(e) => {
-            e.preventDefault()
-            if (isSubmitting) return
-            // Validate on submit rather than disabling the button: a greyed-out control
-            // makes the reader guess why it will not move, and an invite code is exactly
-            // the field where someone pastes whitespace and sees nothing happen.
-            if (!code.trim()) { setEmptyWarning(true); return }
-            setEmptyWarning(false)
-            onSubmit({ inviteCode: code.trim() })
-          }}
-        >
-          <label htmlFor="onboard-invite-code" className="sr-only">Invite code</label>
-          <input
-            ref={ref}
-            id="onboard-invite-code"
-            name="onboard-invite-code"
-            value={code}
-            onChange={(e) => { setCode(e.target.value); setEmptyWarning(false) }}
-            placeholder="Invite code"
-            disabled={isSubmitting}
-            // iOS capitalises and autocorrects by default, which silently mangles a code
-            // into one the host will reject — a real failure with no visible cause.
-            autoComplete="off" autoCapitalize="none" autoCorrect="off" spellCheck={false}
-            aria-invalid={shown ? true : undefined}
-            aria-describedby={shown ? 'onboard-gate-error' : undefined}
-            className="flex-1 px-3 py-2 rounded-lg border border-neutral-200 text-sm
-                       focus:outline-none focus:ring-2 focus:ring-neutral-900 focus:border-transparent"
-          />
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm font-medium
-                       hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed
-                       flex items-center gap-1"
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboard-gate-title"
+        aria-describedby="onboard-gate-sub"
+        className="w-full max-w-sm rounded-2xl border border-neutral-200 bg-white p-6 shadow-xl
+                   shadow-neutral-900/5"
+      >
+        <div className="mb-1 flex items-center gap-2">
+          <HiOutlineTicket className="h-4 w-4 text-neutral-400" />
+          {/* Matches the hero's rule: a real name gets the display serif, a raw
+              address is data and stays mono. */}
+          <h2
+            id="onboard-gate-title"
+            className={`text-base font-semibold text-neutral-900 ${/^0x/.test(agentName) ? 'font-mono' : ''}`}
           >
-            {isSubmitting ? 'Checking…' : 'Continue'}
-            {!isSubmitting && <HiOutlineArrowRight className="w-3.5 h-3.5" />}
-          </button>
-        </form>
-      )}
-
-      {price !== null && (
-        <>
-          {takesCode && (
-            <div className="my-2.5 flex items-center gap-2 text-[11px] text-neutral-400">
-              <span className="h-px flex-1 bg-neutral-200" />or<span className="h-px flex-1 bg-neutral-200" />
-            </div>
-          )}
-          <button
-            onClick={() => !isSubmitting && onSubmit({ payment: price })}
-            disabled={isSubmitting}
-            className="w-full px-4 py-2 rounded-lg border border-neutral-200 text-sm
-                       flex items-center justify-center gap-1.5 hover:bg-neutral-50
-                       disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <HiOutlineCreditCard className="w-4 h-4 text-neutral-400" />
-            Pay ${price.toFixed(2)} to start
-          </button>
-        </>
-      )}
-
-      {/* role="alert" because nothing else announces the refusal — the card does not
-          move, so a screen reader would otherwise get silence. Icon as well as colour:
-          red text alone is the whole signal, which fails for anyone who cannot see it. */}
-      {shown && (
-        <p id="onboard-gate-error" role="alert" className="mt-2 flex items-start gap-1.5 text-xs text-red-600">
-          <HiOutlineExclamationCircle className="w-3.5 h-3.5 shrink-0 mt-px" />
-          {shown}
+            {agentName} is invite-only
+          </h2>
+        </div>
+        <p id="onboard-gate-sub" className="mb-5 text-sm text-neutral-500">
+          Enter your code to start talking.
         </p>
-      )}
 
-      <p className="mt-3 text-[11px] text-neutral-400">
-        No code? Ask whoever shared this agent with you.
-      </p>
-    </section>
+        {takesCode && (
+          <form
+            className="flex flex-col gap-2"
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (isSubmitting) return
+              // Validate on submit rather than disabling the button: a greyed-out control
+              // makes the reader guess why it will not move, and an invite code is exactly
+              // the field where someone pastes whitespace and sees nothing happen.
+              if (!code.trim()) { setEmptyWarning(true); return }
+              setEmptyWarning(false)
+              onSubmit({ inviteCode: code.trim() })
+            }}
+          >
+            <label htmlFor="onboard-invite-code" className="sr-only">Invite code</label>
+            <input
+              ref={ref}
+              id="onboard-invite-code"
+              name="onboard-invite-code"
+              value={code}
+              onChange={(e) => { setCode(e.target.value); setEmptyWarning(false) }}
+              placeholder="Invite code"
+              disabled={isSubmitting}
+              autoFocus
+              enterKeyHint="go"
+              // iOS capitalises and autocorrects by default, which silently mangles a code
+              // into one the host will reject — a real failure with no visible cause.
+              autoComplete="off" autoCapitalize="none" autoCorrect="off" spellCheck={false}
+              aria-invalid={shown ? true : undefined}
+              aria-describedby={shown ? 'onboard-gate-error' : undefined}
+              // text-base is load-bearing, not a size preference: Safari zooms the whole
+              // viewport when focusing any field under 16px, which shifts the panel
+              // sideways mid-typing.
+              className="w-full rounded-lg border border-neutral-300 px-3 py-3 text-base
+                         focus:border-transparent focus:outline-none focus:ring-2 focus:ring-neutral-900"
+            />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex w-full items-center justify-center gap-1 rounded-lg bg-neutral-900
+                         px-4 py-3 text-base font-medium text-white
+                         hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {isSubmitting ? 'Checking…' : 'Continue'}
+              {!isSubmitting && <HiOutlineArrowRight className="h-4 w-4" />}
+            </button>
+          </form>
+        )}
+
+        {price !== null && (
+          <>
+            {takesCode && (
+              <div className="my-3 flex items-center gap-2 text-xs text-neutral-500">
+                <span className="h-px flex-1 bg-neutral-200" />or<span className="h-px flex-1 bg-neutral-200" />
+              </div>
+            )}
+            <button
+              onClick={() => !isSubmitting && onSubmit({ payment: price })}
+              disabled={isSubmitting}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border
+                         border-neutral-300 px-4 py-3 text-base
+                         hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <HiOutlineCreditCard className="h-4 w-4 text-neutral-400" />
+              Pay ${price.toFixed(2)} to start
+            </button>
+          </>
+        )}
+
+        {/* role="alert" because nothing else announces the refusal — the panel does not
+            move, so a screen reader would otherwise get silence. Icon as well as colour:
+            red text alone is the whole signal, which fails for anyone who cannot see it. */}
+        {shown && (
+          <p id="onboard-gate-error" role="alert" className="mt-3 flex items-start gap-1.5 text-sm text-red-600">
+            <HiOutlineExclamationCircle className="mt-px h-4 w-4 shrink-0" />
+            {shown}
+          </p>
+        )}
+
+        {/* neutral-400 on white is about 2.5:1 — below WCAG 1.4.3, and this is the one
+            line that helps a reader who has no code and nothing else to try. */}
+        <p className="mt-5 text-xs text-neutral-500">
+          No code? Ask whoever shared this agent with you.
+        </p>
+      </div>
+    </div>
   )
 })


### PR DESCRIPTION
## Why

Measured on a 375×667 phone, the old inline card began around **y≈470** of a ~600px viewport — header and avatar ≈ 240px, three rows of chips ≈ 190px, then the card. The one thing a visitor must do was the fourth thing they could see, under a filled black `What can you do?` button that, while gated, does nothing but move focus.

The card carried a deliberate comment against being a wall: *"hiding them behind the code is asking for the ticket before showing the film"*. That argument is about a stranger who lands cold and needs a reason to go ask for a code. It does not cover the person who **already has one** and cannot find where to put it — who is most of the traffic on a link you send someone.

## What

Opaque, not a dim scrim. Content you can read through a veil but not touch is its own frustration, and half-showing an agent's skills says *look at what you may not have* — the opposite of what the panel's last line is doing for someone with no code.

- Tab held inside the panel. Nothing behind is worth reaching; every control there is one the agent would refuse.
- **No Escape handler, on purpose.** Dismissing leaves nothing usable, so a key that looks like it should close this would either lie or do nothing visible.
- `text-base` on the input is load-bearing, not taste: Safari zooms the whole viewport when focusing any field under 16px, which shifts the panel sideways mid-typing.

## One bug this found, one it fixes

**Found by Playwright, not by looking:** the first version rendered inside the landing column and Continue could not be clicked — an element *behind* the wall was intercepting the pointer. `position: fixed` resolves against the nearest transformed ancestor rather than the viewport, and that column's `.reveal` animates a transform, so the overlay covered one corner and `z-50` applied inside a stacking context the page's own buttons sat above. It is now a sibling of the workspace.

**Fixed in passing:** passing the gate makes `dashboardHtml` arrive for the first time → `hasDashboard` flips → a phone was yanked off the chat and onto Home, one frame after the reader pressed Continue.

## Known, not introduced here

Getting the code **wrong once and then right** leaves the button on `Checking…` forever. `remote-agent.ts` runs `_closeWs()` on every ERROR frame and a refused code is an ERROR frame, so the socket the host deliberately keeps open for a retry (`session.py`: *"a failed one keeps it so a retry on the same socket can still complete the interrupted CONNECT"*) is closed by the client. The two ends disagree and the client is the one that is wrong — the branch directly above it is annotated *"Don't close WS — keep it for next input()"*.

Reconnecting from the page was tried and is worse: `reconnect` is a fresh function on every render, so an effect depending on it reconnects in a loop until the tab dies. Left to the SDK, with a note in the code pointing at it.

## Testing

Playwright, fresh browser context per run — the identity doing the testing is exactly the one that must not be an admin, and this machine's browser profile is one. Verified on 375×667 and 1440×900: gate present, input auto-focused and above the fold (y=296 / y=413), `elementFromPoint` over the chips behind returns the panel, a wrong code shows the host's own "Invalid invite code", and a clean correct code opens the page in ~5s.

`npm run build`, `npm run lint`, `tsc --noEmit` and 49 unit tests pass.