### PR TITLE
fix(mobile): one bar at the top, and content you can reach

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -221,11 +221,7 @@ export default function AgentLandingPage() {
   // WorkspaceShell's derived view moves a phone off the chat and onto Home — one
   // frame after the reader pressed Continue. Landing somewhere you did not ask to go,
   // immediately after acting, reads as "my code did something strange".
-  // Adjusted during render rather than in an effect: this is derived from a prop-like
-  // value and React's own guidance is to set it here, where the very next render sees
-  // it, instead of after a paint that would show the wrong pane first.
-  const [wasGated, setWasGated] = useState(false)
-  if (needsOnboard && !wasGated) setWasGated(true)
+
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -276,9 +272,18 @@ export default function AgentLandingPage() {
 
   const landingContent = (
       <div className="flex-1 flex flex-col min-h-0">
-        {/* Scrollable content — vertically centered so the page isn't top-heavy */}
-        <div className="flex-1 overflow-y-auto min-h-0 flex flex-col">
-          <div className="m-auto w-full max-w-xl px-5 py-10">
+        {/* Scrollable content, centered when it fits and scrollable when it does not.
+            `m-auto` did the centering before, and auto margins inside an
+            overflow container swallow the overflow: on a 360px phone the
+            "5 skills · 24 tools" row was sliced through the glyphs and could not
+            be scrolled to at all. min-h-full + justify-center centers the same way
+            without eating anything.
+
+            py-6 under sm, because the old flat py-10 was part of the 150px of dead
+            air that made this screen feel tight at the top and hollow in the middle. */}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex min-h-full flex-col justify-center py-6 sm:py-10">
+          <div className="mx-auto w-full max-w-xl px-5">
 
             {/* Hero */}
             <div className="text-center mb-7">
@@ -390,13 +395,14 @@ export default function AgentLandingPage() {
               </div>
             )}
           </div>
+          </div>
         </div>
 
         {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider).
             Gone entirely behind the gate — an empty rail would keep the column pinned to
             the top of a tall flex child, which is where the dead band came from. */}
         {!needsOnboard && (
-          <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
+          <div className="shrink-0 bg-neutral-50 px-4 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
             <div className="max-w-3xl mx-auto">
               <ChatInput
                 onSend={handleSend}
@@ -419,7 +425,7 @@ export default function AgentLandingPage() {
   return (
     <>
       <WorkspaceShell
-        defaultMobileView={wasGated ? 'chat' : 'home'}
+        defaultMobileView="home"
         hasDashboard={dashboardHtml !== null}
         chat={landingContent}
         dashboard={

--- a/components/chat-layout.tsx
+++ b/components/chat-layout.tsx
@@ -20,23 +20,35 @@ export function ChatLayout({ children }: ChatLayoutProps) {
   const agentInfo = address ? agentInfoMap[address] : undefined
 
   return (
-    <div className="flex h-dvh bg-neutral-50">
+    // overflow-hidden: without it the iOS URL-bar collapse scrolls the whole
+    // h-dvh shell, which drags the header off the top of the glass.
+    <div className="flex h-dvh bg-neutral-50 overflow-hidden">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <main className="flex-1 flex flex-col min-w-0">
-        {/* Mobile header — agent name + status on session pages, logo elsewhere */}
-        <header className="lg:hidden flex items-center gap-3 px-4 py-3 border-b border-neutral-200 bg-neutral-50">
+        {/* Mobile header — one bar: menu, identity, and the pane switch.
+            The switch used to be a second bar directly beneath this one, same fill
+            and same hairline, which read as a seam rather than as structure. It is
+            portalled into #mobile-view-switch below by WorkspaceShell, the only
+            component that knows whether there is a dashboard to switch to.
+
+            pt-[env(safe-area-inset-top)]: nothing in this app handled insets, so on
+            a notched phone the row sat under the status bar. */}
+        <header className="lg:hidden flex h-14 shrink-0 items-center gap-2 border-b border-neutral-200 bg-neutral-50 px-3 pt-[env(safe-area-inset-top)]">
           <button
             onClick={() => setSidebarOpen(true)}
-            className="p-2 -ml-2 rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+            className="-ml-1 grid h-11 w-11 shrink-0 place-items-center rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
             aria-label="Open menu"
           >
             <HiOutlineMenu className="w-5 h-5 text-neutral-600" />
           </button>
 
           {address ? (
-            <div className="flex items-center gap-2 min-w-0">
-              <span className={cn(
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <span
+                role="img"
+                aria-label={agentInfo?.online ? 'Agent online' : 'Agent offline'}
+                className={cn(
                 'h-2 w-2 shrink-0 rounded-full',
                 agentInfo?.online ? 'bg-green-500' : 'bg-neutral-300'
               )} />
@@ -52,6 +64,9 @@ export function ChatLayout({ children }: ChatLayoutProps) {
               <span className="font-semibold text-neutral-900">oo-chat</span>
             </Link>
           )}
+
+          {/* Portal target. `contents` so it adds no box of its own when empty. */}
+          <div id="mobile-view-switch" className="contents" />
         </header>
 
         {children}

--- a/components/dashboard/view-switch.tsx
+++ b/components/dashboard/view-switch.tsx
@@ -1,0 +1,72 @@
+/**
+ * @purpose Say which of the agent's two panes is showing, and let a thumb change it,
+ *   without spending a second bar to do it.
+ * @llm-note This used to be a full-width band directly under the mobile header:
+ *   same `bg-neutral-50`, same `border-b`, same width. Two identically-filled bars
+ *   separated by one hairline read as a seam rather than as structure, and that
+ *   seam — not the pixel count — is what made the top of the screen feel cramped.
+ *   Measured: header 61px, band 45px, 12.6% of an 844px viewport.
+ *
+ *   So it moved into the header instead, right-aligned, and the band is gone.
+ *   Intrinsically sized on purpose: a segmented control says "two views of one
+ *   thing", and stretching it edge to edge is what made it read as navigation to
+ *   two destinations — which is also why people expected the back button to undo it.
+ *
+ *   The track is `neutral-200/70`, not `neutral-50`. White-on-neutral-50 gave the
+ *   selected segment a 1.02:1 surface contrast against the bar behind it, so the
+ *   only real cue was the text colour and the unselected side read as *disabled*
+ *   rather than as the other half of a pair.
+ *
+ *   `min-h-11` with negative margin buys a 44px touch box out of a 32px-tall
+ *   control: Apple asks for 44, Material for 48, and every target in this header
+ *   used to be 32–36.
+ */
+'use client'
+
+import { HiOutlineViewGrid, HiOutlineChatAlt2 } from 'react-icons/hi'
+import { cn } from '@/components/chat/utils'
+
+export type MobileView = 'chat' | 'home'
+
+const SEGMENTS = [
+  { key: 'home' as const, label: 'Home', Icon: HiOutlineViewGrid },
+  { key: 'chat' as const, label: 'Chat', Icon: HiOutlineChatAlt2 },
+]
+
+export function ViewSwitch({
+  view, onChange,
+}: {
+  view: MobileView
+  onChange: (v: MobileView) => void
+}) {
+  return (
+    // role=tablist, because the panes are two views of one agent. Without this a
+    // screen reader announced "Home, button. Chat, button." and never said which
+    // one you were on.
+    <div
+      role="tablist"
+      aria-label="Agent view"
+      className="lg:hidden flex shrink-0 items-center gap-0.5 rounded-lg bg-neutral-200/70 p-0.5"
+    >
+      {SEGMENTS.map(({ key, label, Icon }) => (
+        <button
+          key={key}
+          role="tab"
+          aria-selected={view === key}
+          onClick={() => onChange(key)}
+          className={cn(
+            'flex min-h-11 items-center gap-1 rounded-[7px] px-2.5 py-1.5 -my-1.5',
+            'text-[13px] font-medium transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+            view === key
+              ? 'bg-white text-neutral-900 shadow-sm ring-1 ring-neutral-300/70'
+              : 'text-neutral-600 active:bg-neutral-300/50',
+          )}
+        >
+          <Icon className="h-4 w-4" aria-hidden />
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -13,10 +13,12 @@
  */
 'use client'
 
-import { useState } from 'react'
-import { HiOutlineViewGrid, HiOutlineChatAlt2, HiOutlineChevronRight } from 'react-icons/hi'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { HiOutlineViewGrid, HiOutlineChevronRight } from 'react-icons/hi'
 import { cn } from '@/components/chat/utils'
 import { usePaneWidth, MIN_PANE, MAX_PANE } from './use-pane-width'
+import { ViewSwitch } from './view-switch'
 
 interface WorkspaceShellProps {
   chat: React.ReactNode
@@ -41,30 +43,24 @@ export function WorkspaceShell({
   // opening on Home never means opening on a blank pane.
   const mobileView = chosenView ?? (hasDashboard ? defaultMobileView : 'chat')
 
+  // The header owns the switch now; this finds the slot it left for us. An effect
+  // rather than a ref because the header is rendered by a layout above this tree.
+  const [slot, setSlot] = useState<HTMLElement | null>(null)
+  // The node this reads is rendered by a layout above this tree and only exists
+  // after mount, so there is no render-time value to derive. Runs once; the empty
+  // deps are the point.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSlot(document.getElementById('mobile-view-switch'))
+  }, [])
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Mobile Home | Chat switch — only when there is a Home to switch to */}
-      {hasDashboard && (
-      <div className="lg:hidden flex items-center gap-1 p-1.5 border-b border-neutral-200 bg-neutral-50">
-        <button
-          onClick={() => chooseView('home')}
-          className={cn(
-            'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-sm font-medium transition-colors',
-            mobileView === 'home' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500'
-          )}
-        >
-          <HiOutlineViewGrid className="w-4 h-4" /> Home
-        </button>
-        <button
-          onClick={() => chooseView('chat')}
-          className={cn(
-            'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-sm font-medium transition-colors',
-            mobileView === 'chat' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500'
-          )}
-        >
-          <HiOutlineChatAlt2 className="w-4 h-4" /> Chat
-        </button>
-      </div>
+      {/* Into the header, not under it: a second full-width bar in the same fill,
+          divided from the first by one hairline, read as a seam. Rendered from
+          here because this is the component that knows hasDashboard. */}
+      {hasDashboard && slot && createPortal(
+        <ViewSwitch view={mobileView} onChange={chooseView} />, slot,
       )}
 
       <div className="flex-1 flex min-h-0">


### PR DESCRIPTION
Closes #54, #55, #56, #57. Three independent UI reviews of the same screenshots, then the overlap.

## Before / after, measured

| | before | after |
|---|---|---|
| top chrome | 61px header + 45px switch bar = **106px** | **56px**, one bar |
| horizontal rules | 2 | 1 |
| switch touch target | 32px | 44px |
| selected-state contrast | 1.02:1 surface | ring + `neutral-200/70` track |
| screen-reader state | "Home, button" | `role=tab` + `aria-selected` |
| 360px landing column | tail clipped, unreachable | scrolls |
| safe-area insets | zero in the repo | header, composer, drawer |
| pane after entering a code | empty chat | the agent's Home |

## The part worth reading

**It was the seam, not the sum.** Two bars in the same `bg-neutral-50` with the same `border-b`, at the same width — similarity says "one thing", the hairline says "two". 12.6% of the viewport is not unusual for a mobile header; a striped unresolved band is. And the full-width stretch is what made a segmented control read as *navigation to two destinations*, which is why the Android back button felt like it should undo it (it doesn't — the state is `useState`).

**Not a bottom tab bar.** All three reviewers rejected it independently, and the reason is concrete: the composer plus mode row already own ~155px of the bottom edge, so when the keyboard opens "Home" is one mistap from "send" — and mobile Safari's URL bar is down there too.

**`m-auto` was two bugs in one line.** Auto margins inside an overflow container absorb the overflow, so at 360px the tail of the column was cut through the glyphs and unreachable; on taller screens the same centring produced 150px of dead air — *more than the chrome above it*. Cramped at the top and hollow in the middle, from one property.

**The landing-pane line was mine, from yesterday.** `wasGated ? 'chat' : 'home'` fixed a real jolt — passing the gate flipped `hasDashboard` and yanked the view — but the jolt was the *unrequested change*, not the destination. Every visitor who entered an invite code was then sent to the empty chat rather than to a dashboard showing their own data.

## Verified

Playwright, fresh context, 390×844 and 360×740, through the real invite gate against production data. Chrome measured at 56px with the tablist inside the header. `tsc`, lint, build and 49 tests pass.

## Known, not fixed here

Swipe between panes, and view state in the URL so Android back undoes a switch. Both were recommended; both are their own change.