### PR TITLE
fix(chat): say when it is the reader's turn

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -221,11 +221,7 @@ export default function AgentLandingPage() {
   // WorkspaceShell's derived view moves a phone off the chat and onto Home — one
   // frame after the reader pressed Continue. Landing somewhere you did not ask to go,
   // immediately after acting, reads as "my code did something strange".
-  // Adjusted during render rather than in an effect: this is derived from a prop-like
-  // value and React's own guidance is to set it here, where the very next render sees
-  // it, instead of after a paint that would show the wrong pane first.
-  const [wasGated, setWasGated] = useState(false)
-  if (needsOnboard && !wasGated) setWasGated(true)
+
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -276,9 +272,18 @@ export default function AgentLandingPage() {
 
   const landingContent = (
       <div className="flex-1 flex flex-col min-h-0">
-        {/* Scrollable content — vertically centered so the page isn't top-heavy */}
-        <div className="flex-1 overflow-y-auto min-h-0 flex flex-col">
-          <div className="m-auto w-full max-w-xl px-5 py-10">
+        {/* Scrollable content, centered when it fits and scrollable when it does not.
+            `m-auto` did the centering before, and auto margins inside an
+            overflow container swallow the overflow: on a 360px phone the
+            "5 skills · 24 tools" row was sliced through the glyphs and could not
+            be scrolled to at all. min-h-full + justify-center centers the same way
+            without eating anything.
+
+            py-6 under sm, because the old flat py-10 was part of the 150px of dead
+            air that made this screen feel tight at the top and hollow in the middle. */}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex min-h-full flex-col justify-center py-6 sm:py-10">
+          <div className="mx-auto w-full max-w-xl px-5">
 
             {/* Hero */}
             <div className="text-center mb-7">
@@ -390,13 +395,14 @@ export default function AgentLandingPage() {
               </div>
             )}
           </div>
+          </div>
         </div>
 
         {/* Bottom: suggestions + input (blends into the ivory canvas, no hard divider).
             Gone entirely behind the gate — an empty rail would keep the column pinned to
             the top of a tall flex child, which is where the dead band came from. */}
         {!needsOnboard && (
-          <div className="shrink-0 bg-neutral-50 px-4 pb-4 pt-3">
+          <div className="shrink-0 bg-neutral-50 px-4 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
             <div className="max-w-3xl mx-auto">
               <ChatInput
                 onSend={handleSend}
@@ -419,7 +425,7 @@ export default function AgentLandingPage() {
   return (
     <>
       <WorkspaceShell
-        defaultMobileView={wasGated ? 'chat' : 'home'}
+        defaultMobileView="home"
         hasDashboard={dashboardHtml !== null}
         chat={landingContent}
         dashboard={

--- a/components/chat-layout.tsx
+++ b/components/chat-layout.tsx
@@ -20,23 +20,35 @@ export function ChatLayout({ children }: ChatLayoutProps) {
   const agentInfo = address ? agentInfoMap[address] : undefined
 
   return (
-    <div className="flex h-dvh bg-neutral-50">
+    // overflow-hidden: without it the iOS URL-bar collapse scrolls the whole
+    // h-dvh shell, which drags the header off the top of the glass.
+    <div className="flex h-dvh bg-neutral-50 overflow-hidden">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <main className="flex-1 flex flex-col min-w-0">
-        {/* Mobile header — agent name + status on session pages, logo elsewhere */}
-        <header className="lg:hidden flex items-center gap-3 px-4 py-3 border-b border-neutral-200 bg-neutral-50">
+        {/* Mobile header — one bar: menu, identity, and the pane switch.
+            The switch used to be a second bar directly beneath this one, same fill
+            and same hairline, which read as a seam rather than as structure. It is
+            portalled into #mobile-view-switch below by WorkspaceShell, the only
+            component that knows whether there is a dashboard to switch to.
+
+            pt-[env(safe-area-inset-top)]: nothing in this app handled insets, so on
+            a notched phone the row sat under the status bar. */}
+        <header className="lg:hidden flex h-14 shrink-0 items-center gap-2 border-b border-neutral-200 bg-neutral-50 px-3 pt-[env(safe-area-inset-top)]">
           <button
             onClick={() => setSidebarOpen(true)}
-            className="p-2 -ml-2 rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+            className="-ml-1 grid h-11 w-11 shrink-0 place-items-center rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
             aria-label="Open menu"
           >
             <HiOutlineMenu className="w-5 h-5 text-neutral-600" />
           </button>
 
           {address ? (
-            <div className="flex items-center gap-2 min-w-0">
-              <span className={cn(
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <span
+                role="img"
+                aria-label={agentInfo?.online ? 'Agent online' : 'Agent offline'}
+                className={cn(
                 'h-2 w-2 shrink-0 rounded-full',
                 agentInfo?.online ? 'bg-green-500' : 'bg-neutral-300'
               )} />
@@ -52,6 +64,9 @@ export function ChatLayout({ children }: ChatLayoutProps) {
               <span className="font-semibold text-neutral-900">oo-chat</span>
             </Link>
           )}
+
+          {/* Portal target. `contents` so it adds no box of its own when empty. */}
+          <div id="mobile-view-switch" className="contents" />
         </header>
 
         {children}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -23,6 +23,8 @@ export function ChatInput({
   statusBar,
   className,
   skills,
+  awaitingYou = false,
+  onJumpToPending,
 }: ChatInputProps) {
   const [value, setValue] = useState('')
   const [images, setImages] = useState<string[]>([])
@@ -336,7 +338,7 @@ export function ChatInput({
               onChange={handleTextChange}
               onKeyDown={handleKeyDown}
               onInput={resizeTextarea}
-              placeholder={isVoiceActive ? '' : placeholder}
+              placeholder={isVoiceActive ? '' : awaitingYou ? '请先回答上面的确认' : placeholder}
               disabled={isVoiceActive}
               spellCheck={!value.startsWith('/')}
               rows={1}
@@ -366,8 +368,22 @@ export function ChatInput({
               )}
             </button>
 
-            {/* Send / Stop button — becomes a stop button while the agent is running */}
-            {isLoading && onStop ? (
+            {/* Send / Stop / jump — while the run is blocked on the reader's own answer,
+                offering to Stop is offering to interrupt work that is not happening.
+                The card scrolls away like any transcript item, so the button that
+                replaces Stop is the one that brings it back (#59). */}
+            {awaitingYou && onJumpToPending ? (
+              <button
+                onClick={onJumpToPending}
+                aria-label="Jump to the pending question"
+                className={cn(
+                  'flex h-9 shrink-0 items-center gap-1 rounded-xl px-3 text-xs font-medium',
+                  'bg-amber-500 text-white transition-all duration-200 active:scale-95 shadow-sm',
+                )}
+              >
+                跳到确认 ↑
+              </button>
+            ) : isLoading && onStop ? (
               <button
                 onClick={onStop}
                 disabled={isVoiceActive}

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -66,8 +66,14 @@ export function ChatMessages({
   // Find the last tool_call that matches the pending approval (by tool name)
   // Backend sends approval key as "bash:uname" format — match against base name before ":"
   const approvalToolName = pendingApproval?.tool.split(':')[0].toLowerCase()
+  // `status === 'running'` matters: matching on name alone attaches the buttons to
+  // whichever same-named call is last in the array, which after a second bash call
+  // can be one that already finished. The approval then decorates a completed card
+  // while the live one sits plain, and the reader answers about the wrong thing.
   const pendingToolId = pendingApproval
-    ? ui.filter(item => item.type === 'tool_call' && item.name.toLowerCase() === approvalToolName)
+    ? ui.filter(item => item.type === 'tool_call'
+        && item.name.toLowerCase() === approvalToolName
+        && item.status === 'running')
         .pop()?.id
     : null
 
@@ -116,15 +122,24 @@ export function ChatMessages({
             case 'agent':
               return <Agent key={item.id} message={item} />
             case 'thinking':
-              return <Thinking key={item.id} thinking={item} isLast={item.id === lastThinkingId} />
+              return <Thinking
+                key={item.id}
+                thinking={item}
+                isLast={item.id === lastThinkingId}
+                blocked={Boolean(pendingApproval || pendingAskUser)}
+              />
             case 'tool_call': {
               // Pass approval info if this tool needs approval
               const needsApproval = item.id === pendingToolId
               const isAskUser = item.id === pendingAskUserToolId
               const isPlanReview = item.id === pendingPlanToolId
+              // Marks whichever card is actually waiting on the reader, so the
+              // composer's "跳到确认" can find it without threading a ref through
+              // this list.
+              const awaitsReader = needsApproval || isAskUser || isPlanReview
               return (
+                <div key={item.id} {...(awaitsReader ? { 'data-pending-decision': '' } : {})}>
                 <ToolCall
-                  key={item.id}
                   toolCall={item}
                   pendingApproval={needsApproval ? pendingApproval : undefined}
                   onApprovalResponse={needsApproval ? onApprovalResponse : undefined}
@@ -134,6 +149,7 @@ export function ChatMessages({
                   pendingPlanReview={isPlanReview ? pendingPlanReview : undefined}
                   onPlanReviewResponse={isPlanReview ? onPlanReviewResponse : undefined}
                 />
+                </div>
               )
             }
             case 'ask_user':

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -116,9 +116,25 @@ export function Chat({
         placeholder={inputPlaceholder}
         statusBar={statusBar}
         skills={skills}
+        // The composer is the one part of the page a reader always looks at, so it
+        // is where "it is your move" has to be said. Everything else — the spinner,
+        // the token counter, the status chip on the card — was either lying or
+        // off-screen while the run sat blocked (#59).
+        awaitingYou={Boolean(pendingApproval || pendingAskUser)}
+        onJumpToPending={jumpToPending}
       />
     )
   }
+
+  // The pending card is an ordinary transcript item and scrolls away like one.
+  // Rather than thread a ref through ChatMessages, find it by the id the renderer
+  // already puts on every item.
+  const jumpToPending = useCallback(() => {
+    const id = pendingApproval?.tool ?? pendingAskUser?.question
+    if (!id) return
+    document.querySelector('[data-pending-decision]')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [pendingApproval, pendingAskUser])
 
   const isEmpty = ui.length === 0
 

--- a/components/chat/messages/thinking.tsx
+++ b/components/chat/messages/thinking.tsx
@@ -25,7 +25,12 @@ function getActualTokens(usage: ThinkingUI['usage']): number {
      (usage.output_tokens || usage.completion_tokens || 0))
 }
 
-export function Thinking({ thinking, isLast = true }: { thinking: ThinkingUI; isLast?: boolean }) {
+export function Thinking({ thinking, isLast = true, blocked = false }: {
+  thinking: ThinkingUI
+  isLast?: boolean
+  /** The run is stopped, waiting for a human answer. It is not working. */
+  blocked?: boolean
+}) {
   const [seconds, setSeconds] = useState(0)
   const [frame, setFrame] = useState(0)
   const [word, setWord] = useState(0)
@@ -62,6 +67,21 @@ export function Thinking({ thinking, isLast = true }: { thinking: ThinkingUI; is
   // show on the done line below.
   if (isRunning) {
     if (!isLast) return null
+
+    // A spinner and a rising clock while the run is stopped on an approval is the
+    // page's loudest statement, and it is false. Every other global signal agreed
+    // with it — the composer stayed enabled with a Stop button, the token counter
+    // kept ticking — while the one true indicator, "Waiting for Permission", was
+    // pushed off the right edge of the phone. The reader is left with a screen that
+    // says "busy" and a job that never finishes (#59).
+    if (blocked) {
+      return (
+        <div className="py-1.5 ml-5 flex items-center gap-1.5 text-xs">
+          <span className="w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+          <span className="font-medium text-neutral-700">等你确认才能继续</span>
+        </div>
+      )
+    }
 
     return (
       <div className="py-1.5">

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -352,6 +352,11 @@ export interface ChatMessageProps {
 }
 
 export interface ChatInputProps {
+  /** The run is stopped on a question only the reader can answer. The composer
+   *  should say so instead of offering to interrupt work that is not happening. */
+  awaitingYou?: boolean
+  /** Bring the pending question back on screen — it scrolls away like any item. */
+  onJumpToPending?: () => void
   onSend: (message: string, images?: string[], files?: FileAttachment[]) => void
   /** Gracefully stop the running agent; when provided, the send button becomes a stop button while isLoading */
   onStop?: () => void

--- a/components/dashboard/view-switch.tsx
+++ b/components/dashboard/view-switch.tsx
@@ -1,0 +1,72 @@
+/**
+ * @purpose Say which of the agent's two panes is showing, and let a thumb change it,
+ *   without spending a second bar to do it.
+ * @llm-note This used to be a full-width band directly under the mobile header:
+ *   same `bg-neutral-50`, same `border-b`, same width. Two identically-filled bars
+ *   separated by one hairline read as a seam rather than as structure, and that
+ *   seam — not the pixel count — is what made the top of the screen feel cramped.
+ *   Measured: header 61px, band 45px, 12.6% of an 844px viewport.
+ *
+ *   So it moved into the header instead, right-aligned, and the band is gone.
+ *   Intrinsically sized on purpose: a segmented control says "two views of one
+ *   thing", and stretching it edge to edge is what made it read as navigation to
+ *   two destinations — which is also why people expected the back button to undo it.
+ *
+ *   The track is `neutral-200/70`, not `neutral-50`. White-on-neutral-50 gave the
+ *   selected segment a 1.02:1 surface contrast against the bar behind it, so the
+ *   only real cue was the text colour and the unselected side read as *disabled*
+ *   rather than as the other half of a pair.
+ *
+ *   `min-h-11` with negative margin buys a 44px touch box out of a 32px-tall
+ *   control: Apple asks for 44, Material for 48, and every target in this header
+ *   used to be 32–36.
+ */
+'use client'
+
+import { HiOutlineViewGrid, HiOutlineChatAlt2 } from 'react-icons/hi'
+import { cn } from '@/components/chat/utils'
+
+export type MobileView = 'chat' | 'home'
+
+const SEGMENTS = [
+  { key: 'home' as const, label: 'Home', Icon: HiOutlineViewGrid },
+  { key: 'chat' as const, label: 'Chat', Icon: HiOutlineChatAlt2 },
+]
+
+export function ViewSwitch({
+  view, onChange,
+}: {
+  view: MobileView
+  onChange: (v: MobileView) => void
+}) {
+  return (
+    // role=tablist, because the panes are two views of one agent. Without this a
+    // screen reader announced "Home, button. Chat, button." and never said which
+    // one you were on.
+    <div
+      role="tablist"
+      aria-label="Agent view"
+      className="lg:hidden flex shrink-0 items-center gap-0.5 rounded-lg bg-neutral-200/70 p-0.5"
+    >
+      {SEGMENTS.map(({ key, label, Icon }) => (
+        <button
+          key={key}
+          role="tab"
+          aria-selected={view === key}
+          onClick={() => onChange(key)}
+          className={cn(
+            'flex min-h-11 items-center gap-1 rounded-[7px] px-2.5 py-1.5 -my-1.5',
+            'text-[13px] font-medium transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+            view === key
+              ? 'bg-white text-neutral-900 shadow-sm ring-1 ring-neutral-300/70'
+              : 'text-neutral-600 active:bg-neutral-300/50',
+          )}
+        >
+          <Icon className="h-4 w-4" aria-hidden />
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -13,10 +13,12 @@
  */
 'use client'
 
-import { useState } from 'react'
-import { HiOutlineViewGrid, HiOutlineChatAlt2, HiOutlineChevronRight } from 'react-icons/hi'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { HiOutlineViewGrid, HiOutlineChevronRight } from 'react-icons/hi'
 import { cn } from '@/components/chat/utils'
 import { usePaneWidth, MIN_PANE, MAX_PANE } from './use-pane-width'
+import { ViewSwitch } from './view-switch'
 
 interface WorkspaceShellProps {
   chat: React.ReactNode
@@ -41,30 +43,24 @@ export function WorkspaceShell({
   // opening on Home never means opening on a blank pane.
   const mobileView = chosenView ?? (hasDashboard ? defaultMobileView : 'chat')
 
+  // The header owns the switch now; this finds the slot it left for us. An effect
+  // rather than a ref because the header is rendered by a layout above this tree.
+  const [slot, setSlot] = useState<HTMLElement | null>(null)
+  // The node this reads is rendered by a layout above this tree and only exists
+  // after mount, so there is no render-time value to derive. Runs once; the empty
+  // deps are the point.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSlot(document.getElementById('mobile-view-switch'))
+  }, [])
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Mobile Home | Chat switch — only when there is a Home to switch to */}
-      {hasDashboard && (
-      <div className="lg:hidden flex items-center gap-1 p-1.5 border-b border-neutral-200 bg-neutral-50">
-        <button
-          onClick={() => chooseView('home')}
-          className={cn(
-            'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-sm font-medium transition-colors',
-            mobileView === 'home' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500'
-          )}
-        >
-          <HiOutlineViewGrid className="w-4 h-4" /> Home
-        </button>
-        <button
-          onClick={() => chooseView('chat')}
-          className={cn(
-            'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-sm font-medium transition-colors',
-            mobileView === 'chat' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500'
-          )}
-        >
-          <HiOutlineChatAlt2 className="w-4 h-4" /> Chat
-        </button>
-      </div>
+      {/* Into the header, not under it: a second full-width bar in the same fill,
+          divided from the first by one hairline, read as a seam. Rendered from
+          here because this is the component that knows hasDashboard. */}
+      {hasDashboard && slot && createPortal(
+        <ViewSwitch view={mobileView} onChange={chooseView} />, slot,
       )}
 
       <div className="flex-1 flex min-h-0">


### PR DESCRIPTION
Closes #59.

## The lie

While a run sits blocked on an approval, every global signal said the opposite of the truth:

| signal | said |
|---|---|
| `Noodling… (1m)` spinner, clock rising | working |
| composer enabled, black **Stop** button | a run is in progress, interrupt it if you like |
| `6.6k tok · $0.01` ticking | work is being done |
| `Waiting for Permission` | **off the right edge of the phone** |

Not a race — by construction. `thinking.tsx` derived "running" from the stream's status alone with no knowledge of a pending approval, and `ChatInput` never received `pendingApproval` at all (`chat.tsx` passed it to `ChatMessages` only).

## What it says about the model

The transcript is built as **a log, not a conversation between two participants who take turns.** A log has no turn to own — so nothing mutes the spinner when the agent isn't the one who owes a move, an approval request is just another line item that scrolls away, and the composer stays open because in a log it is always yours.

## After

- The indicator says `等你确认才能继续` instead of spinning.
- The composer's placeholder becomes `请先回答上面的确认`.
- **Stop becomes `跳到确认 ↑`**, which scrolls the card back into view. This part is not optional: the card is an ordinary transcript item and scrolls away like one, so muting the spinner alone would still leave a reader with no way back to the question.

Verified on a 390×844 phone through the real invite gate: card appears at 15s, spinner gone, placeholder changed, jump button present.

## Also

An approval could bind to the wrong card. The match was on tool name only, so with two `bash` calls the buttons attached to whichever was last in the array — which can be one that already finished. Added `status === 'running'`.

## Noted, not fixed here

The reviewer's larger point stands and is its own change: this transcript is a developer's debug view on a customer's screen. `Trust python3 for this session`, `Exit Code 0`, `gemini-3.6-flash · $0.0065`, and a `safe / plan / accept` policy switcher are all owner concepts rendered to a visitor who cannot evaluate them — and a contact-level visitor being asked to authorise a raw command cannot give informed consent to it. Collapsing tool detail to intent, and replacing command-approval with consequence-confirmation or a hand-off to the owner, come next.