### PR TITLE
Show the agent's address, and make the top-up link actually work

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -12,6 +12,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
+import { AgentAddress, TopUp } from '@/components/agent-address'
 
 /** A chip is a speech act — it must complete "Help me ___". Extract a short
  *  imperative from the skill description's opening (cutting at the first
@@ -320,9 +321,14 @@ export default function AgentLandingPage() {
                 </p>
               )}
 
-              {/* Balance lives in Settings now (it's the connected agent's balance,
-                  not this browser identity's) — the header only offers sharing. */}
-              <div className="mt-3 flex items-center justify-center gap-2">
+              {/* The address is the agent's only durable name, and it is what a
+                  top-up is addressed to — so it belongs on the page people land on,
+                  not only in Settings. Balance appears when the agent published one. */}
+              <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+                <AgentAddress address={address} />
+                {typeof agentInfo?.balance_usd === 'number' && (
+                  <TopUp address={address} balanceUsd={agentInfo.balance_usd} />
+                )}
                 <QrShare address={address} />
               </div>
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -22,6 +22,7 @@ import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { TopUp } from '@/components/agent-address'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 
 export default function SettingsPage() {
@@ -323,20 +324,9 @@ export default function SettingsPage() {
                         {/* Agent balance — the account that actually spends credits.
                             Only co/* managed-key agents publish it (see AgentInfo). */}
                         {typeof info?.balance_usd === 'number' && (
-                          <a
-                            href={`https://o.openonion.ai/purchase?agent=${address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="group/balance shrink-0 flex flex-col items-end gap-0.5 px-3 py-1.5 rounded-xl hover:bg-neutral-50 transition-colors"
-                            title="Top up this agent"
-                          >
-                            <span className="text-sm font-bold text-neutral-900 tabular-nums">
-                              ${info.balance_usd.toFixed(2)}
-                            </span>
-                            <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider group-hover/balance:text-neutral-600 transition-colors">
-                              Top up →
-                            </span>
-                          </a>
+                          <div className="shrink-0">
+                            <TopUp address={address} balanceUsd={info.balance_usd} />
+                          </div>
                         )}
 
                         {/* Delete */}

--- a/components/agent-address.test.tsx
+++ b/components/agent-address.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @purpose Pin the top-up link's query parameter, because getting it wrong fails
+ *   silently: the purchase page reads `?key=`, ignores anything else, and renders
+ *   an empty form. Nothing throws, nothing is typed wrong, and the payer just sees
+ *   a blank field where the agent's address should be. That is exactly how the
+ *   previous `?agent=` link shipped and stayed broken.
+ * @llm-note The address in the URL is the whole payload — the checkout endpoint
+ *   takes an address and no auth ("anyone can pay for any address"), so the link
+ *   working is the entire feature.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { AgentAddress, TopUp } from './agent-address'
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+
+let container: HTMLDivElement | null = null
+
+function render(node: React.ReactElement) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(node))
+  return container
+}
+
+afterEach(() => {
+  container?.remove()
+  container = null
+})
+
+describe('TopUp', () => {
+  it('addresses the purchase page with ?key=, the only parameter it reads', () => {
+    const link = render(<TopUp address={ADDRESS} balanceUsd={1.5} />).querySelector('a')
+    expect(link?.getAttribute('href')).toBe(
+      `https://o.openonion.ai/purchase?key=${ADDRESS}`
+    )
+  })
+
+  it('carries the full address, not a truncated one', () => {
+    const link = render(<TopUp address={ADDRESS} balanceUsd={1.5} />).querySelector('a')
+    expect(new URL(link!.href).searchParams.get('key')).toBe(ADDRESS)
+  })
+
+  it('shows the balance so the reader knows whether topping up is needed', () => {
+    expect(render(<TopUp address={ADDRESS} balanceUsd={0.4} />).textContent).toContain('$0.40')
+  })
+
+  it('opens in a new tab without handing the opener to the payment page', () => {
+    const link = render(<TopUp address={ADDRESS} balanceUsd={1} />).querySelector('a')
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toContain('noopener')
+  })
+})
+
+describe('AgentAddress', () => {
+  it('abbreviates by default but keeps the full address reachable', () => {
+    const el = render(<AgentAddress address={ADDRESS} />)
+    expect(el.textContent).not.toContain(ADDRESS)
+    expect(el.querySelector('button')?.getAttribute('title')).toBe(ADDRESS)
+  })
+
+  it('shows the whole address once expanded — a payer has to be able to check it', () => {
+    const el = render(<AgentAddress address={ADDRESS} />)
+    act(() => el.querySelector('button')!.click())
+    expect(el.textContent).toContain(ADDRESS)
+  })
+})

--- a/components/agent-address.tsx
+++ b/components/agent-address.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useState } from 'react'
+import { HiOutlineCheck, HiOutlineClipboardCopy } from 'react-icons/hi'
+
+/** The agent's public key, shown in full on click and copyable in one press.
+ *
+ *  It is the only durable name an agent has — the display name is whatever the
+ *  agent chose to publish and can change. It is also what a top-up is addressed
+ *  to, so someone paying for an agent needs to be able to read and check it. */
+export function AgentAddress({ address }: { address: string }) {
+  const [copied, setCopied] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  const copy = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      onClick={() => setExpanded(v => !v)}
+      title={expanded ? 'Show less' : address}
+      className="group inline-flex max-w-full items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] font-mono text-neutral-500 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
+    >
+      <span className={expanded ? 'break-all text-left' : 'truncate'}>
+        {expanded ? address : `${address.slice(0, 10)}…${address.slice(-6)}`}
+      </span>
+      <span
+        onClick={copy}
+        role="button"
+        tabIndex={0}
+        aria-label="Copy agent address"
+        onKeyDown={e => e.key === 'Enter' && copy(e as unknown as React.MouseEvent)}
+        className="shrink-0 text-neutral-400 transition-colors hover:text-neutral-700"
+      >
+        {copied
+          ? <HiOutlineCheck className="h-3.5 w-3.5 text-green-600" />
+          : <HiOutlineClipboardCopy className="h-3.5 w-3.5" />}
+      </span>
+    </button>
+  )
+}
+
+/** Anyone can pay for any address — the checkout endpoint takes an address and no
+ *  auth. The purchase page reads it from `?key=`; any other parameter name lands
+ *  on an empty form and the payer has to paste the address themselves.
+ *
+ *  Only rendered when the agent published a balance, which only co/* managed-key
+ *  agents do. That is also the proof the address exists in the backend: checkout
+ *  404s with "User not found" for an address that never authenticated. */
+export function TopUp({ address, balanceUsd }: { address: string; balanceUsd: number }) {
+  return (
+    <a
+      href={`https://o.openonion.ai/purchase?key=${address}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      title="Add credits to this agent"
+      className="group inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
+    >
+      <span className="font-mono tabular-nums text-neutral-900">${balanceUsd.toFixed(2)}</span>
+      <span className="text-neutral-400 transition-colors group-hover:text-neutral-700">Top up →</span>
+    </a>
+  )
+}


### PR DESCRIPTION
## The link was broken

Settings already had a top-up link. It was built as:

```jsx
href={`https://o.openonion.ai/purchase?agent=${address}`}
```

The purchase page reads exactly three parameters:

```js
const key = searchParams.get('key');
const message = searchParams.get('message');
const signature = searchParams.get('signature');
```

`agent` is not one of them. The address was dropped and the payer landed on `/purchase` with an **empty public-key field** — no error, no hint, just a form asking for a 66-character key.

And they had no way to get it: **oo-chat never showed the full address anywhere.** The landing page shows `shortAddress()` as a title, Settings shows an abbreviation, and `QrShare` shares the chat URL, not the address. So the one thing the payer needed was the one thing the app didn't display.

## What this adds

**The address, on the page people land on.** Abbreviated by default, click to expand to the full 66 characters, one press to copy. It is the agent's only durable name — the display name is whatever the agent published and can change — and it is what a payment is addressed to, so it should be readable and checkable.

**A top-up affordance next to it**, showing the current balance so the reader knows whether it's needed:

```
$0.40   Top up →
```

Both are also used by Settings now, so there is exactly **one** place in the codebase that builds the purchase URL. The previous arrangement had the link written inline at its only call site, which is how it drifted from the page it points at without anyone noticing.

## Why the top-up only appears sometimes

It renders only when the agent published `balance_usd`. Per the SDK: *"Present only for `co/*` managed-key agents that published it."*

That gate is doing real work. The checkout endpoint verifies the address exists:

```python
user = await conn.fetchrow("SELECT public_key FROM users WHERE public_key = $1", address)
if not user:
    raise HTTPException(status_code=404, detail="User not found. Please authenticate first.")
```

Confirmed against production:

```
$ curl -X POST https://oo.openonion.ai/api/v1/tokens/checkout \
    -d '{"address":"0x000…000","package":"mini"}'
{"detail":"User not found. Please authenticate first."}   HTTP 404
```

A published balance means the agent has an OpenOnion account, which means the address resolves. Showing "Top up" for an agent that would 404 would be worse than not showing it.

Paying for someone else's agent is supported by design — the endpoint is unauthenticated and its docstring says so outright: *"No auth required — anyone can pay for any address."*

## The test earns its place

A wrong parameter name is invisible to `tsc` and to lint — it is a valid string in a valid URL, and the failure happens on someone else's page. So the parameter is pinned by a test, and the test was verified to **fail against the old form first**:

```
FAIL  TopUp > addresses the purchase page with ?key=, the only parameter it reads
  expected 'https://o.openonion.ai/purchase?agent…' to be '…?key=0…'
FAIL  TopUp > carries the full address, not a truncated one
  expected null to be '0x1234…'

Tests  2 failed | 4 passed
```

After the fix: 6 passed.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npm run build      ✓ Compiled successfully
npx vitest run     4 files, 55 tests passed  (was 49)
```