### PR TITLE
UI audit: fix the ten worst problems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ components/dashboard/               # "Home" — the agent's own dashboard.html
 └── build-srcdoc.ts                 # Wraps agent HTML with the CSP + bridge
 
 hooks/use-identity.ts               # BIP39→Ed25519 user keypair + auth
-hooks/use-agent-info.ts             # Wraps SDK fetchAgentInfo (30s polling)
+hooks/use-agent-info.ts             # Wraps SDK fetchAgentInfo (cache-first; refetch on focus)
 store/chat-store.ts                 # Sidebar conversation INDEX (not the transcript)
 ```
 

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -283,7 +283,13 @@ export default function AgentLandingPage() {
             py-6 under sm, because the old flat py-10 was part of the 150px of dead
             air that made this screen feel tight at the top and hollow in the middle. */}
         <div className="flex-1 overflow-y-auto min-h-0">
-          <div className="flex min-h-full flex-col justify-center py-6 sm:py-10">
+          {/* justify-center-safe, not justify-center: centring a column that is taller
+              than its scroll container pushes the overflow off both ends, and the top
+              half is unreachable because scrollTop is already 0. Expanding the skills
+              and tools list is enough to trigger it, and what disappears is the avatar,
+              the agent name and the online pill — the identity of the agent you are
+              about to talk to. Safe alignment falls back to flex-start on overflow. */}
+          <div className="flex min-h-full flex-col justify-center-safe py-6 sm:py-10">
           <div className="mx-auto w-full max-w-xl px-5">
 
             {/* Hero */}
@@ -430,8 +436,12 @@ export default function AgentLandingPage() {
 
   return (
     <>
+      {/* A pending gate outranks the Home default. The gate lives inside the chat
+          pane, so a phone opening on Home hid the only route past ONBOARD_REQUIRED:
+          the visitor got a dashboard whose buttons do nothing, with no error and no
+          prompt. chosenView still lets them switch back. */}
       <WorkspaceShell
-        defaultMobileView="home"
+        defaultMobileView={needsOnboard ? 'chat' : 'home'}
         hasDashboard={dashboardHtml !== null}
         chat={landingContent}
         dashboard={

--- a/components/chat/chat-error.tsx
+++ b/components/chat/chat-error.tsx
@@ -15,7 +15,9 @@ export function ChatError({ error, onRetry, onDismiss }: ChatErrorProps) {
   }
 
   return (
-    <div className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-red-50 px-4 py-2 border border-red-200">
+    // role="alert" so a failure interrupts rather than waiting its turn — the
+    // reader is otherwise left waiting on a run that has already stopped.
+    <div role="alert" className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-red-50 px-4 py-2 border border-red-200">
       <div className="flex items-center gap-2 flex-1">
         <HiOutlineExclamationCircle className="h-4 w-4 text-red-600 flex-shrink-0" />
         <span className="text-sm text-red-600">

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -114,7 +114,19 @@ export function ChatMessages({
       className={cn('flex-1 overflow-y-auto overflow-x-hidden py-6 px-4', className)}
     >
       {/* Centered container with max-width matching input */}
-      <div ref={contentRef} className="mx-auto max-w-3xl space-y-1">
+      {/* The transcript is append-only, which is what role="log" describes, and
+          polite so a reply does not interrupt what the reader is already hearing.
+          Without it a screen-reader user sends a message and hears nothing back:
+          not the reply, not "thinking", and not the approval card that has paused
+          the run waiting on them. */}
+      <div
+        ref={contentRef}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-label="Conversation"
+        className="mx-auto max-w-3xl space-y-1"
+      >
         {ui.map((item) => {
           switch (item.type) {
             case 'user':

--- a/components/chat/messages/tools/approval-buttons.tsx
+++ b/components/chat/messages/tools/approval-buttons.tsx
@@ -44,9 +44,9 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
       <div className="py-2 px-1 border-t border-neutral-100 mt-1 animate-in fade-in duration-300">
         <div className="flex items-center gap-2 text-[11px] text-neutral-500 font-medium italic">
           {approvalSent === 'skipped' ? (
-            <span className="flex items-center gap-1.5"><HiOutlineX className="w-3.5 h-3.5" /> Tool rejected</span>
+            <span className="flex items-center gap-1.5"><HiOutlineX className="w-3.5 h-3.5 shrink-0" /> Tool rejected</span>
           ) : approvalSent === 'stopped' ? (
-            <span className="flex items-center gap-1.5 text-red-500"><HiOutlineStop className="w-3.5 h-3.5" /> Execution stopped</span>
+            <span className="flex items-center gap-1.5 text-red-500"><HiOutlineStop className="w-3.5 h-3.5 shrink-0" /> Execution stopped</span>
           ) : (
             <span className="flex items-center gap-1.5 text-green-600">
               <HiOutlineCheck className="w-3.5 h-3.5" />
@@ -69,7 +69,7 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
           <HiOutlineCheck className="w-4 h-4 text-neutral-400 group-hover:text-green-600" />
           <div className="flex-1">
             <span className="text-sm font-semibold text-neutral-800">Allow once</span>
-            <span className="text-xs text-neutral-400 ml-2 font-normal">{description || 'Only this command'}</span>
+            <span className="text-xs text-neutral-500 ml-2 font-normal">{description || 'Only this command'}</span>
           </div>
         </button>
 
@@ -79,42 +79,47 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
           className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white transition-colors group"
         >
           <HiOutlineShieldCheck className="w-4 h-4 text-neutral-400 group-hover:text-neutral-600" />
-          <div className="flex-1">
-            <span className="text-sm text-neutral-600">Trust {toolName || 'this tool'}</span>
-            <span className="text-xs text-neutral-400 ml-2">for this session</span>
+          <div className="flex-1 min-w-0">
+            {/* Same weight as "Allow once": this grant is the broader of the two,
+                and rendering it lighter made the wider permission read as the
+                more casual choice. The consequence is spelled out rather than
+                implied by the words "for this session". */}
+            <span className="text-sm font-semibold text-neutral-800">Trust {toolName || 'this tool'}</span>
+            <span className="text-xs text-neutral-500 ml-2">for this session</span>
+            <span className="block text-xs text-neutral-500">Won&apos;t ask again this conversation</span>
           </div>
         </button>
 
         <div className="mx-3 my-1 border-t border-neutral-100" />
 
         {/* Reject/Stop actions */}
-        <div className="flex items-center">
+        <div className="flex flex-wrap items-center">
           <button
             onClick={() => onApproval(false, 'once', 'reject_soft')}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
+            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
           >
-            <HiOutlineX className="w-3.5 h-3.5" />
+            <HiOutlineX className="w-3.5 h-3.5 shrink-0" />
             <span>Reject</span>
-            <span className="text-neutral-300">this tool</span>
+            <span className="text-neutral-500">this tool</span>
           </button>
           <div className="w-px h-4 bg-neutral-100" />
           <button
             onClick={() => onApproval(false, 'once', 'reject_hard')}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-xs text-neutral-500 hover:text-red-600 hover:bg-white transition-colors"
+            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-red-600 hover:bg-white transition-colors"
           >
-            <HiOutlineStop className="w-3.5 h-3.5" />
+            <HiOutlineStop className="w-3.5 h-3.5 shrink-0" />
             <span>Stop</span>
-            <span className="text-neutral-300">all & redirect</span>
+            <span className="text-neutral-500">all & redirect</span>
           </button>
           <div className="w-px h-4 bg-neutral-100" />
           <button
             onClick={() => onApproval(false, 'once', 'reject_explain')}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
+            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
             title="I don't understand - please explain this action"
           >
-            <HiOutlineQuestionMarkCircle className="w-3.5 h-3.5" />
+            <HiOutlineQuestionMarkCircle className="w-3.5 h-3.5 shrink-0" />
             <span>Explain</span>
-            <span className="text-neutral-300">why?</span>
+            <span className="text-neutral-500">why?</span>
           </button>
         </div>
       </div>

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -194,9 +194,13 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
               <HiOutlineX className="w-2.5 h-2.5 text-red-600" />
             </div>
           ) : status === 'running' ? (
+            /* Same dot as generic-card and browser-card: brand green means running,
+               neutral means waiting on you. These rows stream into one column, and
+               when "running" was black here and green there, scanning the transcript
+               for what is still executing did not work. */
             <div className={cn(
               "w-2 h-2 rounded-full animate-pulse ml-1",
-              needsApproval && !approvalSent ? "bg-neutral-500" : "bg-neutral-900"
+              needsApproval && !approvalSent ? "bg-neutral-400" : "bg-brand-500"
             )} />
           ) : (
             <div className="w-2 h-2 rounded-full bg-neutral-300 ml-1" />
@@ -207,19 +211,19 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
           {/* Command is collapsed by default, so the header must never be blank: */}
           {/* show the description if given, otherwise fall back to the command itself. */}
           {description ? (
-            <span className="text-xs text-neutral-400 truncate ml-1">{description}</span>
+            <span className="text-xs text-neutral-500 truncate ml-1">{description}</span>
           ) : command ? (
-            <span className="text-xs text-neutral-400/80 font-mono truncate ml-1">{command}</span>
+            <span className="text-xs text-neutral-500 font-mono truncate ml-1">{command}</span>
           ) : null}
         </div>
 
         <div className="flex items-center gap-2">
           {status === 'done' || status === 'error' ? (
-            <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest">
+            <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide">
               {status === 'done' ? 'Exit Code 0' : 'Exit Code 1'} {timing_ms && `(${formatTime(timing_ms)})`}
             </span>
           ) : needsApproval && approvalSent === 'skipped' ? (
-            <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest">Skipped</span>
+            <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide">Skipped</span>
           ) : needsApproval && approvalSent === 'stopped' ? (
             <span className="text-red-500 text-[10px] uppercase font-bold tracking-widest">Stopped</span>
           ) : needsApproval && !approvalSent ? (

--- a/components/chat/messages/tools/browser-card.tsx
+++ b/components/chat/messages/tools/browser-card.tsx
@@ -155,7 +155,7 @@ export function BrowserCard({ toolCall, pendingApproval, onApprovalResponse }: B
         <span className={`text-[13px] font-medium shrink-0 whitespace-nowrap ${isError ? 'text-red-600' : 'text-neutral-800'}`}>{verb}</span>
         {detail && <span className="min-w-0 flex-1 truncate font-mono text-xs text-neutral-500">{detail}</span>}
 
-        <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] tabular-nums text-neutral-400">
+        <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] tabular-nums text-neutral-500">
           {status === 'done' || status === 'error' ? (
             timing_ms ? formatTime(timing_ms) : null
           ) : needsApproval && approvalSent ? (
@@ -185,13 +185,13 @@ export function BrowserCard({ toolCall, pendingApproval, onApprovalResponse }: B
         <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
           {hasArgs && (
             <div className={`px-3 py-2.5 ${hasOutput ? 'border-b border-neutral-100' : ''}`}>
-              <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400">Arguments</div>
+              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Arguments</div>
               <KVRows data={unwrapArgs(args)} />
             </div>
           )}
           {hasOutput && (
             <div className={`px-3 py-2.5 ${isError ? 'bg-red-50/50' : ''}`}>
-              <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400">Result</div>
+              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Result</div>
               {typeof parsedResult === 'string' ? (
                 <pre className={`whitespace-pre-wrap font-mono text-xs leading-relaxed max-h-72 overflow-y-auto ${isError ? 'text-red-700' : 'text-neutral-700'}`}>
                   {parsedResult}

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -262,7 +262,7 @@ export function CompactHeader({
 
       <div className="flex items-center gap-3 shrink-0">
         {status === 'done' || status === 'error' ? (
-          <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest tabular-nums">
+          <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide tabular-nums">
             {status.toUpperCase()} {timingMs && `(${formatTime(timingMs)})`}
           </span>
         ) : needsApproval && approvalSent ? (

--- a/components/chat/messages/tools/generic-card.tsx
+++ b/components/chat/messages/tools/generic-card.tsx
@@ -80,7 +80,7 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
         <span className={`text-[13px] font-medium shrink-0 whitespace-nowrap ${isError ? 'text-red-600' : 'text-neutral-800'}`}>{name}</span>
         {argsStr && <span className="min-w-0 flex-1 truncate font-mono text-xs text-neutral-500">{argsStr}</span>}
 
-        <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] tabular-nums text-neutral-400">
+        <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] tabular-nums text-neutral-500">
           {status === 'done' || status === 'error' ? (
             <>
               {!isExpanded && outputLines > 1 && `${outputLines} lines · `}
@@ -114,7 +114,7 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
       {needsApproval && hasArgs && isExpanded && (
         <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
           <div className="px-3 py-2.5">
-            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400">Arguments</div>
+            <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Arguments</div>
             <KVRows data={args} />
           </div>
         </div>
@@ -124,7 +124,7 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
       {!needsApproval && hasOutput && isExpanded && (
         <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
           <div className={`px-3 py-2.5 ${isError ? 'bg-red-50/50' : ''}`}>
-            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400">Result</div>
+            <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Result</div>
             {typeof parsedResult === 'string' ? (
               <pre className={`whitespace-pre-wrap font-mono text-xs leading-relaxed max-h-72 overflow-y-auto ${isError ? 'text-red-700' : 'text-neutral-700'}`}>
                 {result}

--- a/components/chat/messages/tools/plan-card.tsx
+++ b/components/chat/messages/tools/plan-card.tsx
@@ -368,7 +368,11 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
                   </div>
 
                   {/* Three Action Buttons - Top Right (Always Visible) */}
-                  <div className="absolute top-4 right-4 flex gap-2">
+                  {/* In flow on a phone, pinned to the corner from sm up. Absolute
+                      positioning put ~300px of buttons in a 343px-wide modal, where
+                      they overlapped the plan text and spilled past the rounded edge —
+                      approving or rejecting a plan was unusable on mobile. */}
+                  <div className="flex flex-wrap gap-2 px-6 pt-4 sm:absolute sm:top-4 sm:right-4 sm:px-0 sm:pt-0">
                     <button
                       onClick={() => handleReaction(section.id, 'like')}
                       className={`px-4 py-2.5 rounded-lg font-semibold text-sm transition-colors border ${
@@ -418,7 +422,7 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
                   </div>
 
                   {/* Section Content */}
-                  <div className="p-6 pr-40">
+                  <div className="p-6 sm:pr-40">
                     <div className={`${SECTION_PROSE}`}>
                       <ReactMarkdown components={components}>
                         {section.content}

--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -183,19 +183,19 @@ export function ModeStatusBar({ mode, onModeChange, disabled, sessionState, conn
         <button
           onClick={() => onModeChange('safe')}
           disabled={disabled}
-          className="text-[11px] font-medium px-2 py-0.5 rounded-full border border-red-200 bg-red-50 text-red-600 hover:bg-red-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="inline-flex min-h-6 items-center text-[11px] font-medium px-2.5 py-1 rounded-full border border-red-200 bg-red-50 text-red-600 hover:bg-red-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           title="Ultra Work — fully autonomous · Click to exit to safe"
         >
           ultra{typeof ulwTurnsRemaining === 'number' ? ` · ${ulwTurnsRemaining} left` : ''}
         </button>
       ) : (
-        <div className="inline-flex rounded-md border border-neutral-200 bg-neutral-100 p-0.5" role="group" aria-label="Approval mode">
+        <div className="inline-flex gap-0.5 rounded-md border border-neutral-200 bg-neutral-100 p-0.5" role="group" aria-label="Approval mode">
           {CYCLE_MODES.map((m) => (
             <button
               key={m}
               onClick={() => onModeChange(m)}
               disabled={disabled}
-              className={`text-[11px] px-2 py-0.5 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              className={`inline-flex min-h-6 items-center text-[11px] px-2.5 py-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                 m === mode
                   ? 'bg-neutral-900 border border-neutral-900 font-medium text-white'
                   : 'border border-transparent text-neutral-500 hover:text-neutral-700'

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -115,10 +115,21 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         />
       )}
 
-      <aside className={`
+      {/* `invisible` when closed, not just translated off-screen. A drawer that is
+          only moved out of view stays in the tab order and in the accessibility
+          tree: on a phone, tabbing off the menu button walked through every agent
+          row, every session link, and every Remove/Delete button while the page
+          appeared frozen — and those destructive buttons were activatable unseen.
+          visibility also removes it from the a11y tree, costs no JS, and follows
+          the lg breakpoint on its own. Transitioning it lets the slide-out finish
+          before it flips (visibility is discrete: it waits the full duration going
+          to hidden, and applies immediately coming back). */}
+      <aside
+        aria-label="Conversations"
+        className={`
         fixed lg:relative inset-y-0 left-0 z-50 w-72 bg-white flex flex-col
-        transform transition-transform duration-200 ease-out lg:translate-x-0
-        ${isOpen ? 'translate-x-0' : '-translate-x-full'}
+        transform transition-[transform,visibility] duration-200 ease-out lg:translate-x-0 lg:visible
+        ${isOpen ? 'translate-x-0' : '-translate-x-full invisible'}
         border-r border-neutral-200
       `}>
         {/* Header with Logo */}

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -22,20 +22,28 @@ export function Modal({
   maxWidth = 'max-w-5xl'
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
 
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
-      window.addEventListener('keydown', handleEscape)
-    }
+    if (!isOpen) return
+
+    // Keyboard focus has to come with the dialog and go back where it was. Without
+    // this, Tab from an "open" button walks the page behind the overlay instead of
+    // the dialog, and closing leaves focus on nothing.
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    closeRef.current?.focus()
+
+    document.body.style.overflow = 'hidden'
+    window.addEventListener('keydown', handleEscape)
 
     return () => {
       document.body.style.overflow = 'unset'
       window.removeEventListener('keydown', handleEscape)
+      previouslyFocused?.focus()
     }
   }, [isOpen, onClose])
 
@@ -52,6 +60,9 @@ export function Modal({
       {/* Modal Content */}
       <div 
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
         className={cn(
           "relative w-full h-full flex flex-col bg-[#1e1e1e] rounded-2xl border border-neutral-800 shadow-2xl overflow-hidden animate-in zoom-in-95 fade-in duration-300",
           maxWidth,
@@ -60,11 +71,13 @@ export function Modal({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-800 bg-[#252526]">
-          <h3 className="text-base font-bold text-neutral-100 truncate">
+          <h3 id="modal-title" className="text-base font-bold text-neutral-100 truncate">
             {title || 'Preview'}
           </h3>
           <button
+            ref={closeRef}
             onClick={onClose}
+            aria-label="Close"
             className="p-2 text-neutral-400 hover:text-white hover:bg-neutral-800 rounded-xl transition-all"
           >
             <HiOutlineX className="w-5 h-5" />

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,7 +72,7 @@ owner (the SDK); the sidebar store just lists conversations:
 | `components/dashboard/dashboard-pane.tsx` | the Home iframe + the button→skill bridge |
 | `components/dashboard/build-srcdoc.ts` | wraps agent HTML with the CSP and bridge |
 | `hooks/use-identity.ts` | your keypair + login |
-| `hooks/use-agent-info.ts` | agent profile + online status (polls every 30s) |
+| `hooks/use-agent-info.ts` | agent profile + online status (cache-first; refetch on tab focus) |
 | `store/chat-store.ts` | the sidebar index |
 | `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
 

--- a/hooks/use-agent-info.ts
+++ b/hooks/use-agent-info.ts
@@ -25,7 +25,10 @@ const infoCache: Record<string, AgentInfo> = {}
  * Hook to fetch info for multiple agent addresses.
  * Returns a map of address → AgentInfo.
  * Agents render immediately — info loads in background without blocking UI.
- * Polls every 30 seconds to keep status fresh.
+ * Cache-first: refetched on mount and whenever the tab regains focus, plus a slow
+ * background revalidate every 10 minutes. The focus refetch is what keeps status
+ * fresh for someone actually looking at the page; the interval only catches an
+ * agent going offline while the tab stays open and untouched.
  */
 export function useAgentInfo(addresses: string[]): Record<string, AgentInfo> {
   // Seed from the module cache so a remount renders last-known status instantly


### PR DESCRIPTION
A UI/UX audit of every major surface, then fixes. Ranked by what the user actually loses. Three findings needed correcting before I acted on them — noted inline.

## 1 · The landing page clipped its own header, unrecoverably

`app/[address]/page.tsx` — the page people share.

```jsx
<div className="flex-1 overflow-y-auto min-h-0">
  <div className="flex min-h-full flex-col justify-center py-6 sm:py-10">
```

Centring a column that is taller than its scroll container pushes the overflow off **both** ends, and the top is unreachable — `scrollTop` is already 0. Expanding the "12 skills · 24 tools" disclosure adds enough height to trigger it on a phone, and what disappears is the avatar, the agent name, and the online pill: the identity of the agent you are about to talk to.

`justify-center-safe` falls back to `flex-start` the moment content overflows. Short pages stay centred, tall pages stay scrollable. Verified the utility actually compiles — `safe center` is present in the built CSS.

## 2 · The approval card, three ways

`components/chat/messages/tools/approval-buttons.tsx`. This is the highest-stakes control in the product.

**Invisible qualifiers.** `text-neutral-300` on `bg-neutral-50/50` is **1.5:1**. Those qualifiers are the only thing separating the three reject buttons:

```
Reject  this tool        →  reject one call
Stop    all & redirect   →  kill the entire run
Explain why?             →  ask a question
```

Without them the user sees three near-identical words. → `neutral-500`.

**Clipped on a phone.** Three `flex-1` children, no wrap, no `min-w-0`, inside a transcript with `overflow-x-hidden`. At 375px the row overflows and the third button is **cut off rather than scrollable**. → `flex-wrap` + `min-w-[7.5rem]`.

**The riskier option looked safer.** "Allow once" was `font-semibold text-neutral-800`; "Trust {tool} for this session" — which pre-approves every later call of that tool — was `text-neutral-600`, lighter. The broader grant read as the more casual one. → same weight, plus an explicit consequence line: "Won't ask again this conversation".

## 3 · The closed mobile drawer was still focusable

`components/sidebar.tsx` — only translated off-screen, never hidden. On a phone, tabbing off the menu button walked through the entire invisible drawer: every agent row, every session link, **every Remove agent and Delete chat button**, activatable while unseen, with the focus ring painting off-screen so the page looked frozen for ~30 presses.

Fixed with `invisible` / `lg:visible` rather than the `inert` + `useMediaQuery` the audit proposed: `visibility` removes it from the tab order *and* the a11y tree, needs no JS, and follows the breakpoint on its own. Transitioning it keeps the slide-out animation — visibility is discrete, so it waits the full duration going to hidden and applies immediately coming back.

## 4 · The transcript was silent to screen readers

One `aria-live` existed in the whole app, inside the sandboxed agent HTML. A screen-reader user sent a message and heard nothing: not the reply, not "thinking", and not the approval card that had **paused the run waiting on them**.

→ `role="log" aria-live="polite"` on the transcript (append-only is exactly what `log` describes), `role="alert"` on the error banner.

## 5 · The plan modal broke on phones and had no dialog semantics

~300px of absolutely-positioned buttons in a 343px-wide card, overlapping the plan text they sat on top of. → in-flow and wrapping below `sm`, pinned from `sm` up.

`components/ui/modal.tsx` had no `role="dialog"`, no `aria-modal`, no `aria-labelledby`, no focus move on open, no focus restore on close — Tab escaped into the page behind the overlay. All added.

## 6 · Reported as a bug; it isn't one

The audit flagged `POLL_INTERVAL = 600000` as contradicting the docs' "30s" and wanted it lowered. But the constant carries its own rationale, and there **is** a `visibilitychange` refetch — status refreshes whenever the reader returns to the tab. Dropping to 30s would multiply relay traffic 20× for a case that mostly does not arise.

**The stale thing was the documentation**, which claimed 30s in three places. Corrected the docstring, `CLAUDE.md`, and `docs/ARCHITECTURE.md`. Interval unchanged.

## 7 · An invite-only agent hid its own invite form on mobile

`OnboardGate` lives in the chat pane, but a phone opens on Home when the agent ships a dashboard. The visitor got a dashboard whose buttons do nothing — the run is gated — with no error and no prompt. One line: a pending gate outranks the Home default.

## 8 · The trust-mode switch was a 20px target

`px-2 py-0.5` on 11px text ≈ 20×30px, below the 24px floor, three segments abutting, sitting in the composer's status strip where thumbs are. **The mis-tap lands on `accept`** — the setting that stops asking permission before file edits. The only mis-tap in the app with a security consequence, on the smallest control in the app. → `min-h-6`, `px-2.5 py-1`, `gap-0.5`. Same for the ULW exit pill, the button that leaves fully-autonomous mode.

## 9 · The audit trail was too faint to read

`text-neutral-400` on white is **2.58:1**; `text-neutral-400/80` is ~2.1:1 — and that one is the **command**. The bash card is collapsed by default, so that faint 12px mono line is the only visible statement of what the agent just ran on a machine. → `neutral-500` (4.83:1) for anything that is content, `neutral-400` kept for icons and separators. Also dropped `text-[10px] tracking-widest` to `text-[11px] tracking-wide` on the status chips — the two properties that hurt legibility most, stacked on the lowest contrast in the app.

Left alone: the dark-surface `neutral-400` inside the output panel, where it passes.

## 10 · "Running" was two different colours

`bash-card` drew running as `bg-neutral-900`; `generic-card` and `browser-card` as `bg-brand-500`. Same state, different colour, streamed into one column — so scanning for what is still executing did not work. Unified on the brand dot.

The audit also proposed extracting a shared `tool-row.tsx` to reconcile two whole header idioms. **Not done here** — it touches every tool card at once, and the colour was the part a user actually feels. Worth its own PR.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npm run build      ✓ Compiled successfully
npx vitest run     4 files, 55 tests passed
```
