### PR TITLE
Walk the phone flow end to end, and fix what it turned up

### DIFF
--- a/components/agent-address.tsx
+++ b/components/agent-address.tsx
@@ -28,7 +28,7 @@ export function AgentAddress({ address }: { address: string }) {
         onClick={() => setExpanded(v => !v)}
         title={expanded ? 'Show less' : address}
         aria-expanded={expanded}
-        className="min-w-0 text-left"
+        className="inline-flex min-h-6 min-w-0 items-center text-left"
       >
         <span className={expanded ? 'break-all' : 'block truncate'}>
           {expanded ? address : `${address.slice(0, 10)}\u2026${address.slice(-6)}`}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -338,7 +338,7 @@ export function ChatInput({
               onChange={handleTextChange}
               onKeyDown={handleKeyDown}
               onInput={resizeTextarea}
-              placeholder={isVoiceActive ? '' : awaitingYou ? 'Answer the question above to continue' : placeholder}
+              placeholder={isVoiceActive ? '' : awaitingYou ? 'Answer above' : placeholder}
               disabled={isVoiceActive}
               spellCheck={!value.startsWith('/')}
               rows={1}
@@ -383,7 +383,9 @@ export function ChatInput({
                   'bg-neutral-900 text-white transition-all duration-200 hover:bg-neutral-800 active:scale-95 shadow-sm',
                 )}
               >
-                Jump to it ↑
+                <span className="hidden sm:inline">Jump to it</span>
+                <span className="sm:hidden">Jump</span>
+                <span aria-hidden="true">↑</span>
               </button>
             ) : isLoading && onStop ? (
               <button

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -150,7 +150,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               target="_blank"
               rel="noopener noreferrer"
               title={`@connectonion/react v${connectonionVersion} — view on npm`}
-              className="px-1.5 py-0.5 rounded-md text-[10px] font-mono font-medium text-neutral-400 bg-neutral-100 hover:text-neutral-700 hover:bg-neutral-200 transition-colors"
+              className="inline-flex min-h-6 items-center px-1.5 rounded-md text-[10px] font-mono font-medium text-neutral-400 bg-neutral-100 hover:text-neutral-700 hover:bg-neutral-200 transition-colors"
             >
               v{connectonionVersion}
             </a>
@@ -283,8 +283,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       </Link>
 
                       {/* Action buttons — always visible on touch, hover-revealed on desktop */}
-                      {/* 36px+ touch targets on mobile (gap keeps + and × apart); compact on desktop */}
-                      <div className="flex items-center gap-1 lg:gap-0 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100 transition-opacity">
+                      {/* 36px+ touch targets on mobile; compact on desktop. The gap is 8px, not 4:
+                          × removes the agent and sits next to +, which starts a chat, and a
+                          thumb is about 9mm wide. The confirm dialog is the real backstop,
+                          but nobody should be reaching it by accident. */}
+                      <div className="flex items-center gap-2 lg:gap-0 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100 transition-opacity">
                         <Link
                           href={`/${address}`}
                           onClick={onClose}

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -33,7 +33,7 @@ test.describe('agent landing page', () => {
   test('shows who the agent is, its address, and how to pay it', async ({ page }) => {
     await landing(page)
 
-    await expect(page.getByText('online')).toBeVisible()
+    await expect(page.getByText('online', { exact: true })).toBeVisible()
     await expect(page.getByText(PROFILE.model)).toBeVisible()
 
     // The address is the agent's only durable name and the target of a top-up.

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * The phone walk-through, end to end.
+ *
+ * Most people open a shared agent link on a phone, and this path had never been
+ * walked at 375px: land, read who the agent is, find its balance, reach the
+ * top-up, send a message, answer an approval, open the drawer, switch between
+ * Home and Chat. Each step here is a thing a user does, not a thing a component
+ * renders — and every one of them leaves a screenshot.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+test.use({ viewport: { width: 375, height: 667 } })
+
+/** Nothing may stick out sideways: the transcript clips overflow-x, so anything
+ *  wider than the viewport is cut off rather than scrollable. */
+async function expectNoSideScroll(page: import('@playwright/test').Page) {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow, 'the page scrolls sideways on a phone').toBeLessThanOrEqual(0)
+}
+
+test.describe('landing on a phone', () => {
+  test('identity, balance and the way to pay are all reachable without scrolling sideways', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+    await expectNoSideScroll(page)
+
+    // The balance is the reason someone tops up; it has to be on the page they
+    // land on, not only in a settings screen they will never open on a phone.
+    const topUp = page.getByRole('link', { name: /top up/i })
+    await expect(topUp).toBeVisible()
+    await expect(topUp).toHaveAttribute('href', `https://o.openonion.ai/purchase?key=${AGENT_ADDRESS}`)
+    await expect(page.getByText(`$${PROFILE.balance_usd.toFixed(2)}`)).toBeVisible()
+
+    await shot('landing')
+  })
+
+  test('every control on the landing page is big enough to hit', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+    // WCAG 2.5.8 puts the floor at 24x24. A thumb is not a mouse.
+    const small: string[] = []
+    for (const el of await page.locator('button:visible, a:visible').all()) {
+      const box = await el.boundingBox()
+      if (!box) continue
+      if (box.width < 24 || box.height < 24) {
+        small.push(`${(await el.getAttribute('aria-label')) || (await el.innerText()).trim().slice(0, 30)} — ${Math.round(box.width)}x${Math.round(box.height)}`)
+      }
+    }
+    expect(small, 'targets below the 24px floor').toEqual([])
+  })
+})
+
+test.describe('a conversation on a phone', () => {
+  test('send a message and read the reply', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 15_000 })
+    await expectNoSideScroll(page)
+    await shot('reply')
+  })
+
+  test('an approval is answerable — all four buttons on screen and hittable', async ({ page, shot }) => {
+    await mockAgent(page, 'approval')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+
+    const allow = page.getByRole('button', { name: /allow once/i })
+    await expect(allow).toBeVisible({ timeout: 15_000 })
+    await expectNoSideScroll(page)
+
+    for (const name of [/allow once/i, /trust/i, /reject/i, /stop/i, /explain/i]) {
+      const button = page.getByRole('button', { name }).first()
+      await expect(button).toBeInViewport()
+      const box = await button.boundingBox()
+      expect(box!.height, `${name} is too short to tap`).toBeGreaterThanOrEqual(24)
+    }
+    await shot('approval')
+  })
+})
+
+test.describe('the drawer', () => {
+  test('a destructive control is not a thumb-width from a routine one', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: /menu/i }).first().click()
+
+    const remove = page.getByRole('button', { name: /remove agent/i }).first()
+    const newChat = page.getByRole('link', { name: /new chat/i }).first()
+    await expect(remove).toBeVisible()
+
+    const [a, b] = [await newChat.boundingBox(), await remove.boundingBox()]
+    for (const box of [a, b]) {
+      expect(box!.width).toBeGreaterThanOrEqual(24)
+      expect(box!.height).toBeGreaterThanOrEqual(24)
+    }
+    // Removing an agent is confirmed, but nobody should reach the confirm by
+    // accident. A thumb is about 9mm; 4px of air between + and x is not enough.
+    expect(b!.x - (a!.x + a!.width), 'gap between New chat and Remove agent').toBeGreaterThanOrEqual(8)
+  })
+
+  test('opens, lists the agent, and closes again', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+    const drawer = page.locator('aside')
+    await expect(drawer).toHaveCSS('visibility', 'hidden')
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    await expect(drawer).toHaveCSS('visibility', 'visible')
+    await expect(drawer.getByText(/agents/i).first()).toBeVisible()
+    await shot('drawer-open')
+
+    // The scrim is the obvious way back out on a phone.
+    await page.locator('.fixed.inset-0').first().click({ position: { x: 340, y: 400 } })
+    await expect(drawer).toHaveCSS('visibility', 'hidden')
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -47,7 +47,10 @@ const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
  * integration test with none of the guarantees.
  */
 export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
-  await page.routeWebSocket(/oo\.openonion\.ai/, ws => {
+  // Every socket except Next's dev-mode hot reload. Which host the SDK dials
+  // depends on what the relay record advertises — relay socket for a hosted agent,
+  // the agent's own endpoint for a direct one — and the test should not care.
+  await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
     ws.onMessage(raw => {
       const msg = JSON.parse(String(raw)) as { type: string; prompt?: string }
 
@@ -114,15 +117,30 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
   // directory first, then a direct /info probe. Both have to answer, or the page
   // renders the offline state and every screenshot is a picture of that instead
   // of the product.
-  const info = (route: import('@playwright/test').Route) =>
+  // The relay wraps the profile — {endpoints, relay, last_seen, profile} — while a
+  // direct /info probe returns the profile flat. Returning the flat shape from both
+  // is what made the sidebar show "ALL AGENTS OFFLINE" next to a landing page saying
+  // online: the socket had a profile, the HTTP path could not read one.
+  await page.route(/oo\.openonion\.ai\/api\/agents\//, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        endpoints: scenario === 'offline' ? [] : ['https://scriptbot.example'],
+        relay: 'wss://oo.openonion.ai/ws',
+        last_seen: new Date(0).toISOString(),
+        profile: PROFILE,
+      }),
+    })
+  )
+
+  await page.route(/\/info(\?|$)/, route =>
     route.fulfill({
       status: scenario === 'offline' ? 503 : 200,
       contentType: 'application/json',
       body: JSON.stringify(PROFILE),
     })
-
-  await page.route(/oo\.openonion\.ai\/api\/agents\//, info)
-  await page.route(/\/info(\?|$)/, info)
+  )
 
   // Auth is a real round trip to the backend on a preview deploy. Answering it
   // here keeps the run hermetic and stops a backend hiccup failing a UI test.


### PR DESCRIPTION
Most people open a shared agent link on a phone. That path had never been walked at 375px, so this walks it: land and find the balance and the way to pay, check every control against the 24px floor, send a message, answer an approval, open and close the drawer. Six specs, each one a thing a user does.

## What the walk-through found

**The address button was 113×17.** I added `AgentAddress` two PRs ago and gave the copy button `min-h-6 min-w-6` while leaving the text button at 17px tall.

**The composer instruction was clipped mid-word.**

```
Answer the        ← what a phone actually rendered
```

Replacing the Chinese placeholder with English made it longer than the ~130px the textarea is left with once the mic and the jump button take their share. The line that tells you the run is blocked was the line being truncated. Now `Answer above`, and the jump button drops to `Jump` below `sm`.

**Remove agent sat 4px from New chat**, both permanently visible on mobile — the `lg:opacity-0 lg:group-hover:opacity-100` that hides them on desktop has nothing to hide behind on a touch screen. A thumb is about 9mm. There is a confirm dialog, so this is not data loss, but the confirm should not be something you arrive at by accident. Now 8px, with a test that measures the gap rather than trusting the class.

**The version link was 19px tall.**

## The mock was lying, and it nearly cost an afternoon

The drawer screenshot showed **ALL AGENTS OFFLINE** next to a landing page saying **online**, with the agent listed by address instead of by name. That reads like a real bug in the sidebar, and I started looking for it there.

It was the test double. The relay returns a wrapper:

```json
{ "endpoints": [...], "relay": "...", "last_seen": "...", "profile": { ... } }
```

while a direct `/info` probe returns the profile flat. The mock returned the flat shape from both, so the socket path had a profile and the HTTP path — which is what the sidebar uses — could not read one. The two panes disagreed because the mock made them disagree.

With the real shape the sidebar resolves both the name and the status. The WebSocket route also had to widen from `oo.openonion.ai` to "any socket that isn't Next's HMR", because which host the SDK dials depends on what the relay record advertises — relay socket for a hosted agent, the agent's own endpoint for a direct one.

A fixture that models the protocol loosely produces bugs that don't exist and hides ones that do.

## Verified along the CI path

`CI=1 npx playwright test` — production build, full parallelism, exactly what the runner does:

```
18 passed (49.9s)
e2e-screenshots/   23 files
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
```

I read the phone screenshots before and after each fix; the clipped placeholder was only ever visible that way.

## Deliberately left

`Automation` and `Schedule` occupy prime vertical space in the drawer marked `SOON`. That is a product call, not a layout one.