### PR TITLE
Cover the Home/Chat split, and drop the two SOON rows from the drawer

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -12,8 +12,6 @@ import {
   HiOutlineChevronRight,
   HiOutlineSparkles,
   HiOutlineChatAlt2,
-  HiOutlineLightningBolt,
-  HiOutlineClock,
 } from 'react-icons/hi'
 import { useChatStore } from '@/store/chat-store'
 import { useAgentInfo } from '@/hooks/use-agent-info'
@@ -29,14 +27,6 @@ interface SidebarProps {
   isOpen: boolean
   onClose: () => void
 }
-
-// App-level destinations. `Chats` is live; the rest are reserved for upcoming
-// features (rendered disabled with a SOON badge). Add entries here as they ship.
-const NAV_ITEMS = [
-  { key: 'chats', label: 'Chats', Icon: HiOutlineChatAlt2, soon: false },
-  { key: 'automation', label: 'Automation', Icon: HiOutlineLightningBolt, soon: true },
-  { key: 'schedule', label: 'Schedule', Icon: HiOutlineClock, soon: true },
-] as const
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const router = useRouter()
@@ -180,44 +170,23 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           </span>
         </div>
 
-        {/* Nav rail — Chats live, others reserved */}
-        <nav className="px-2 pt-2 pb-1 space-y-0.5">
-          {NAV_ITEMS.map(({ key, label, Icon, soon }) => {
-            const active = key === 'chats' && isChatsActive
-            if (soon) {
-              return (
-                <div
-                  key={key}
-                  className="relative flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-neutral-400 cursor-not-allowed select-none"
-                  title="Coming soon"
-                >
-                  <Icon className="w-4 h-4 shrink-0" />
-                  <span className="flex-1">{label}</span>
-                  <span className="text-[9px] font-mono font-semibold tracking-widest text-neutral-400 border border-neutral-200 rounded px-1 py-0.5">
-                    SOON
-                  </span>
-                </div>
-              )
-            }
-            return (
-              <Link
-                key={key}
-                href="/"
-                onClick={onClose}
-                className={`relative flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
-                  active
-                    ? 'bg-neutral-100 text-neutral-900 font-medium'
-                    : 'text-neutral-600 hover:bg-neutral-100/70'
-                }`}
-              >
-                {active && (
-                  <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-neutral-900" />
-                )}
-                <Icon className={`w-4 h-4 shrink-0 ${active ? 'text-neutral-900' : 'text-neutral-400'}`} />
-                <span className="flex-1">{label}</span>
-              </Link>
-            )
-          })}
+        {/* One destination. Automation and Schedule used to sit here as disabled
+            SOON rows; automation belongs to an agent, not to the app, so a global
+            rail advertising it was pointing at the wrong place — and two dead rows
+            were taking the most valuable space in a phone drawer. */}
+        <nav className="px-2 pt-2 pb-1">
+          <Link
+            href="/"
+            onClick={onClose}
+            className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
+              isChatsActive
+                ? 'bg-neutral-100 text-neutral-900 font-medium'
+                : 'text-neutral-600 hover:bg-neutral-100/70'
+            }`}
+          >
+            <HiOutlineChatAlt2 className="w-4 h-4 shrink-0" />
+            <span>Chats</span>
+          </Link>
         </nav>
 
         {/* Agents section label */}

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Home and Chat, and the switch between them.
+ *
+ * On a phone the two panes are exclusive — one is `hidden` while the other shows —
+ * so the switch is not a convenience, it is the only way back. It is rendered
+ * through a portal into a slot the layout above owns, looked up once on mount.
+ * If that lookup ever misses, a reader who lands on Home is stuck on Home with a
+ * dashboard whose buttons do nothing, and nothing on screen says why.
+ *
+ * On a desktop both panes are visible at once and the question is different:
+ * collapsing Home must not take the chat with it.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('an agent with a dashboard opens on Home and can get back to Chat', async ({ page, shot }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    const switcher = page.getByRole('tab', { name: 'Home' })
+    await expect(switcher, 'the view switch never rendered — Home would be a dead end').toBeVisible({ timeout: 15_000 })
+    await shot('home')
+
+    // Home first, per defaultMobileView.
+    await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+    await shot('chat')
+
+    // And back again — the switch works in both directions, not just away from Home.
+    await page.getByRole('tab', { name: 'Home' }).click()
+    await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
+  })
+
+  test('the dashboard fits the viewport it is given', async ({ page }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'the dashboard pane pushes the page sideways').toBeLessThanOrEqual(0)
+
+    const box = await page.locator('iframe').boundingBox()
+    expect(box!.width, 'the dashboard is wider than the phone').toBeLessThanOrEqual(375)
+  })
+
+  test('an agent with no dashboard gets no switch and lands in the chat', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+    // A switch with nothing to switch to is worse than no switch.
+    await expect(page.getByRole('tab', { name: 'Home' })).toHaveCount(0)
+  })
+})
+
+test.describe('desktop', () => {
+  test('both panes show at once, and collapsing Home keeps the chat', async ({ page, shot }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
+    await shot('split')
+
+    await page.getByRole('button', { name: /collapse dashboard/i }).click()
+    await expect(page.locator('iframe')).toBeHidden()
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+    // The reopen strip is the only way back; without it the pane is gone for good.
+    await page.getByRole('button', { name: /open dashboard/i }).click()
+    await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -18,7 +18,7 @@ import type { Page, WebSocketRoute } from '@playwright/test'
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -35,6 +35,13 @@ export const PROFILE = {
     { name: 'summarise', description: 'Summarise a document you paste in' },
   ],
 }
+
+/** Deliberately plain: this is the agent's own page, rendered in a sandboxed
+ *  iframe, and the test cares about the pane it lives in rather than its content. */
+export const DASHBOARD_HTML =
+  '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1">' +
+  '<h1 style="font:600 18px system-ui;padding:16px">Deploy board</h1>' +
+  '<p style="font:14px system-ui;padding:0 16px">Last ship: 4 minutes ago.</p>'
 
 const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
   ws.send(JSON.stringify(frame))
@@ -57,6 +64,9 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
       if (msg.type === 'CONNECT') {
         send(ws, { type: 'CONNECTED', session_id: 'e2e-session', status: 'idle' })
         send(ws, { type: 'AGENT_PROFILE', ...PROFILE })
+        // Pushed on connect for agents that ship one. Its arrival is what flips
+        // hasDashboard, which is what splits the workspace in two.
+        if (scenario === 'dashboard') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
         return
       }
 


### PR DESCRIPTION
## Automation and Schedule are gone

They sat at the top of the sidebar as disabled rows with a `SOON` badge:

```
Chats
Automation   SOON
Schedule     SOON
─────────────────
AGENTS
```

**Automation belongs to an agent, not to the app** — a global rail advertising it points at the wrong place. And on a phone those two dead rows were taking the most valuable space in the drawer, pushing the agent list down below them.

Removing them left `NAV_ITEMS` with one entry, so the `.map()` and the `soon` branch went with it. That machinery existed to render a single link.

## The Home/Chat split needed coverage, not fixing

On a phone the two panes are exclusive — one is `hidden` while the other shows — so the switch is not a convenience, it is the only way back. It mounts through a portal into a slot the layout above owns, looked up once with an empty dependency list:

```js
useEffect(() => { setSlot(document.getElementById('mobile-view-switch')) }, [])
```

If that lookup ever missed, a reader landing on Home would be stuck there, looking at a dashboard whose buttons do nothing, with nothing on screen explaining why. That is the same class of dead end that `defaultMobileView` was fixed for two PRs ago, and it had no test.

Four specs now hold it down:

| | |
|---|---|
| phone | the switch renders, Home → Chat → Home all work |
| phone | the dashboard fits 375px and does not push the page sideways |
| phone | an agent *without* a dashboard gets no switch — a switch with nothing to switch to is worse than none |
| desktop | both panes at once; collapsing Home keeps the chat, and the reopen strip brings it back |

**The implementation was better than the tests I first wrote for it.** I asserted on `getByRole('button')` and got nothing; the markup is a proper `role="tablist"` with `role="tab"` children and `min-h-11` targets. My locators were wrong, not the component.

The mock can now push `DASHBOARD_SNAPSHOT`, which is what flips `hasDashboard` — without it none of this path is reachable in a test.

## Verified along the CI path

```
CI=1 npx playwright test   22 passed
e2e-screenshots/           30 files
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

I looked at the phone Home screenshot and the cleaned-up drawer before merging.

## Deliberately left

The Home view has no balance or top-up affordance — those live on the chat landing, one tab away. Putting money UI on the agent's own page is a product decision, not a layout fix.