### PR TITLE
Make the settings agent row usable on a phone

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -263,7 +263,13 @@ export default function SettingsPage() {
                   {agents.map(address => {
                     const info = infoMap[address]
                     return (
-                      <div key={address} className="flex items-center gap-4 px-8 py-5 group">
+                      // Stacked on a phone. In one row the fixed parts — 64px of
+                      // padding, three gaps, the status dot, the top-up pill and the
+                      // delete button — left about 96px for the agent, so the address
+                      // collapsed to "0…" and the tool chips wrapped one per line into
+                      // a tall column. Side by side again from sm up.
+                      <div key={address} className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-8 sm:py-5 group">
+                        <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
                         {/* Online indicator */}
                         <div className="shrink-0">
                           {info?.online !== undefined ? (
@@ -295,7 +301,7 @@ export default function SettingsPage() {
                             </span>
                             <button
                               onClick={() => copyToClipboard(address, `agent-${address}`)}
-                              className="shrink-0 p-1 text-neutral-300 hover:text-neutral-600 transition-colors"
+                              className="inline-flex min-h-6 min-w-6 shrink-0 items-center justify-center rounded text-neutral-300 hover:text-neutral-600 transition-colors"
                               title="Copy agent address"
                               aria-label="Copy agent address"
                             >
@@ -320,24 +326,24 @@ export default function SettingsPage() {
                             </div>
                           )}
                         </div>
+                        </div>
 
-                        {/* Agent balance — the account that actually spends credits.
-                            Only co/* managed-key agents publish it (see AgentInfo). */}
-                        {typeof info?.balance_usd === 'number' && (
-                          <div className="shrink-0">
+                        {/* Balance and delete travel together: on a phone they are their
+                            own row under the agent, on desktop they sit at the end of it.
+                            Only co/* managed-key agents publish a balance (see AgentInfo). */}
+                        <div className="flex shrink-0 items-center justify-end gap-3 sm:gap-4">
+                          {typeof info?.balance_usd === 'number' && (
                             <TopUp address={address} balanceUsd={info.balance_usd} />
-                          </div>
-                        )}
-
-                        {/* Delete */}
-                        <button
-                          onClick={() => setPendingRemove(address)}
-                          className="shrink-0 p-2 text-neutral-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
-                          title="Remove agent"
-                          aria-label="Remove agent"
-                        >
-                          <HiOutlineTrash className="w-4 h-4" />
-                        </button>
+                          )}
+                          <button
+                            onClick={() => setPendingRemove(address)}
+                            className="shrink-0 p-2 text-neutral-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
+                            title="Remove agent"
+                            aria-label="Remove agent"
+                          >
+                            <HiOutlineTrash className="w-4 h-4" />
+                          </button>
+                        </div>
                       </div>
                     )
                   })}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Settings, where an agent's balance lives and where its address is copied from.
+ *
+ * The agent row is the part that had never been looked at on a phone. In one
+ * horizontal row the fixed parts left about 96px for the agent itself, so the
+ * address rendered as "0…" and the tool chips stacked one per line into a tall
+ * column — the row was legible on a laptop and nonsense on the device most
+ * people open it on.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** Settings only lists agents the browser has already talked to. */
+async function settingsWithAnAgent(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+  await page.goto('/settings')
+  await expect(page.getByRole('heading', { name: /agents/i }).first()).toBeVisible()
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('the agent row shows a real address and lays its tools out sideways', async ({ page, shot }) => {
+    await settingsWithAnAgent(page)
+
+    const address = page.locator('main').getByText(AGENT_ADDRESS, { exact: true }).first()
+    await expect(address).toBeVisible()
+
+    // "0…" is what the squeezed column produced. Anything under a third of the
+    // width means the row has collapsed again.
+    const box = await address.boundingBox()
+    expect(box!.width, 'the address collapsed — the row is being squeezed').toBeGreaterThan(120)
+
+    // Tool chips belong on a line, not in a column: with six of them stacking, the
+    // row grew past the height of the phone.
+    const chips = page.getByText('read_file', { exact: true }).first()
+    if (await chips.count()) {
+      const first = await page.getByText('bash', { exact: true }).first().boundingBox()
+      const second = await chips.boundingBox()
+      expect(second!.y, 'tool chips are stacking one per line').toBeLessThan(first!.y + first!.height)
+    }
+
+    await shot('agents')
+  })
+
+  test('balance and top-up are reachable here too, at a tappable size', async ({ page }) => {
+    await settingsWithAnAgent(page)
+
+    const topUp = page.getByRole('link', { name: /top up/i })
+    await expect(topUp).toHaveAttribute('href', `https://o.openonion.ai/purchase?key=${AGENT_ADDRESS}`)
+    await expect(page.getByText(`$${PROFILE.balance_usd.toFixed(2)}`)).toBeVisible()
+
+    const box = await topUp.boundingBox()
+    expect(box!.height).toBeGreaterThanOrEqual(24)
+  })
+
+  test('every control is big enough to hit, and nothing scrolls sideways', async ({ page }) => {
+    await settingsWithAnAgent(page)
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'settings scrolls sideways on a phone').toBeLessThanOrEqual(0)
+
+    const small: string[] = []
+    for (const el of await page.locator('button:visible, a:visible').all()) {
+      const box = await el.boundingBox()
+      if (!box) continue
+      if (box.width < 24 || box.height < 24) {
+        const label = (await el.getAttribute('aria-label')) || (await el.innerText())
+        small.push(`${label.replace(/\s+/g, ' ').trim().slice(0, 30)} — ${Math.round(box.width)}x${Math.round(box.height)}`)
+      }
+    }
+    expect(small, 'targets below the 24px floor').toEqual([])
+  })
+})
+
+test.describe('desktop', () => {
+  test('the agent row is still one line', async ({ page, shot }) => {
+    await settingsWithAnAgent(page)
+
+    // The stacking is a phone concession; on a laptop the balance still sits at
+    // the end of the agent's own row rather than under it.
+    // Scoped to main: the sidebar lists the same agent, 547px up the page.
+    const name = await page.locator('main').getByText(PROFILE.name).first().boundingBox()
+    const topUp = await page.getByRole('link', { name: /top up/i }).boundingBox()
+    expect(topUp!.x, 'top-up dropped below the agent instead of beside it').toBeGreaterThan(name!.x)
+    expect(Math.abs(topUp!.y - name!.y), 'top-up is on a different line').toBeLessThan(80)
+
+    await shot('agents')
+  })
+})


### PR DESCRIPTION
Settings is where an agent's balance lives and where its address gets copied. The agent row had never been looked at on a phone, and it was broken there.

## What it looked like

```
Scriptbot  CAREFUL
0…              ⧉
bash
read_file            $4.20  Top up →     🗑
write_file
browser
send_email
+1 more
```

The address rendered as **`0…`** — unusable, on the row whose job is to let you copy it. The six tool chips wrapped one per line into a tall column, with the balance pill floating in the middle.

## Why

The row was one horizontal flex, and on a 375px screen the fixed parts add up:

```
px-8 padding      64
3 × gap-4         48
status dot        20
top-up pill      115
delete button     32
                 ───
                 279   →  ~96px left for the agent
```

At 96px the `min-w-0` info block does exactly what it is told: truncate the address, wrap the chips.

## What it looks like now

The row stacks below `sm` — agent and tools take the full width, balance and delete become their own row underneath — and goes back to one line from `sm` up. Padding drops from `px-8 py-5` to `px-5 py-4` on the phone, which is where the first 24px came from.

The copy-address button also went from **20×20** to the 24px floor.

## Four specs, verified to fail on the old layout first

```
Error: the address collapsed — the row is being squeezed
Error: targets below the 24px floor
```

After: 4 passed. They cover the address being a real width, the chips staying on a line, no sideways scroll, every control at 24px, the top-up still pointing at `?key=`, and — on desktop — the balance still sitting on the agent's own line rather than under it.

## Verified along the CI path

```
CI=1 npx playwright test   26 passed
e2e-screenshots/           36 files
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

I looked at the phone screenshot before and after.

## Deliberately left

**Reset** in the Account card is red text with no button chrome, sitting beside two bordered neutral buttons. It is the most destructive control on the page — it replaces the identity key — and it currently reads as the lightest. Changing how a destructive action is weighted is a judgement about how much friction it should carry, so it wants its own change rather than being folded into a layout fix.