### PR TITLE
Give every tool row the same quiet grammar

### DIFF
--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -217,20 +217,24 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
           ) : null}
         </div>
 
+        {/* The same quiet ledger meta generic-card already uses. Uppercase at
+            tracking-widest, bolded and pulsing, made the status of a finished tool
+            the loudest thing on the screen — louder than the agent's answer — and
+            animating text delays reading the one word that matters. */}
         <div className="flex items-center gap-2">
           {status === 'done' || status === 'error' ? (
-            <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide">
-              {status === 'done' ? 'Exit Code 0' : 'Exit Code 1'} {timing_ms && `(${formatTime(timing_ms)})`}
+            <span className="text-[11px] tabular-nums text-neutral-500">
+              {status === 'done' ? 'exit 0' : 'exit 1'}{timing_ms ? ` · ${formatTime(timing_ms)}` : ''}
             </span>
           ) : needsApproval && approvalSent === 'skipped' ? (
-            <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide">Skipped</span>
+            <span className="text-[11px] tabular-nums text-neutral-500">skipped</span>
           ) : needsApproval && approvalSent === 'stopped' ? (
-            <span className="text-red-500 text-[10px] uppercase font-bold tracking-widest">Stopped</span>
+            <span className="text-[11px] font-medium text-red-600">stopped</span>
           ) : needsApproval && !approvalSent ? (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">Waiting for Permission</span>
+            <span className="text-[11px] tabular-nums text-neutral-500">awaiting approval</span>
           ) : (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse tabular-nums">
-              Running{runningSeconds > 0 ? ` (${formatSeconds(runningSeconds)})` : ''}
+            <span className="text-[11px] tabular-nums text-neutral-500">
+              running{runningSeconds > 0 ? ` · ${formatSeconds(runningSeconds)}` : ''}
             </span>
           )}
         </div>

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -262,17 +262,17 @@ export function CompactHeader({
 
       <div className="flex items-center gap-3 shrink-0">
         {status === 'done' || status === 'error' ? (
-          <span className="text-neutral-500 text-[11px] uppercase font-semibold tracking-wide tabular-nums">
-            {status.toUpperCase()} {timingMs && `(${formatTime(timingMs)})`}
+          <span className="text-[11px] tabular-nums text-neutral-500">
+            {status}{timingMs ? ` · ${formatTime(timingMs)}` : ''}
           </span>
         ) : needsApproval && approvalSent ? (
-          <span className={cn("text-[10px] uppercase font-bold tracking-widest", approvalSent === 'skipped' ? "text-neutral-400" : "text-red-500")}>
-            {approvalSent.toUpperCase()}
+          <span className={cn("text-[11px]", approvalSent === 'skipped' ? "text-neutral-500" : "font-medium text-red-600")}>
+            {approvalSent}
           </span>
         ) : needsApproval ? (
-          <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">Pending Approval</span>
+          <span className="text-[11px] tabular-nums text-neutral-500">awaiting approval</span>
         ) : (
-          <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse tabular-nums">Processing</span>
+          <span className="text-[11px] tabular-nums text-neutral-500">running</span>
         )}
       </div>
     </div>

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -131,22 +131,27 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
         {status === 'running' && !needsApproval && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
 
         {/* Tool name with args */}
-        <span className="text-sm font-mono">
-          <span className="font-medium text-neutral-700">{name}</span>
+        {/* Truncate rather than wrap: a long pattern turned the header into two
+            lines while every other tool row stayed on one. */}
+        <span className="min-w-0 truncate text-[13px] font-mono">
+          <span className="font-medium text-neutral-800">{name}</span>
           {headerArgs && <span className="text-neutral-500">({headerArgs})</span>}
         </span>
 
         {/* Status text */}
         {status === 'done' || status === 'error' ? (
-          <>
-            {timing_ms && <span className="text-neutral-400 text-xs">{formatTime(timing_ms)}</span>}
-            {fileCount > 0 && !isExpanded && <span className="text-neutral-400 text-xs">{fileCount} files</span>}
-          </>
+          // One span, not two: as separate children they wrapped onto their own
+          // lines on a phone and made this row visibly taller than its neighbours.
+          <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] tabular-nums text-neutral-500">
+            {[timing_ms ? formatTime(timing_ms) : '', fileCount > 0 && !isExpanded ? `${fileCount} files` : '']
+              .filter(Boolean)
+              .join(' · ')}
+          </span>
         ) : needsApproval && approvalSent ? (
           approvalSent === 'skipped' ? (
-            <span className="text-neutral-400 text-xs font-medium">skipped</span>
+            <span className="ml-auto shrink-0 text-[11px] text-neutral-500">skipped</span>
           ) : approvalSent === 'stopped' ? (
-            <span className="text-red-500 text-xs font-medium">stopped</span>
+            <span className="ml-auto shrink-0 text-[11px] font-medium text-red-600">stopped</span>
           ) : (
             <span className="text-green-600 text-xs font-medium">approved — running...</span>
           )

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -18,7 +18,7 @@ import type { Page, WebSocketRoute } from '@playwright/test'
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'busy'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -96,6 +96,27 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
           type: 'approval_needed',
           tool: 'bash:uname',
           description: 'Run `uname -a`',
+        })
+        return
+      }
+
+      // A transcript with several kinds of card in it, which is what the reader
+      // actually scrolls through — one card on its own never shows whether the
+      // rows share a rhythm or each brings its own.
+      if (scenario === 'busy') {
+        send(ws, { type: 'tool_call', id: 'c1', name: 'read_file', args: { file_path: 'src/app/page.tsx' }, status: 'running' })
+        send(ws, { type: 'tool_result', id: 'c1', name: 'read_file', status: 'done', result: 'export default function Page() {\n  return <main>hello</main>\n}', timing_ms: 210 })
+        send(ws, { type: 'tool_call', id: 'c2', name: 'bash', args: { command: 'npm run build', description: 'build the site' }, status: 'running' })
+        send(ws, { type: 'tool_result', id: 'c2', name: 'bash', status: 'done', result: '✓ Compiled successfully in 4.2s', timing_ms: 4200 })
+        send(ws, { type: 'tool_call', id: 'c3', name: 'grep', args: { pattern: 'useAgentForHuman', path: 'components' }, status: 'running' })
+        send(ws, { type: 'tool_result', id: 'c3', name: 'grep', status: 'done', result: 'components/chat/use-agent-sdk.ts:4', timing_ms: 90 })
+        send(ws, { type: 'tool_call', id: 'c4', name: 'write_file', args: { file_path: 'src/app/layout.tsx', content: 'export default function Layout() {}' }, status: 'running' })
+        send(ws, { type: 'tool_result', id: 'c4', name: 'write_file', status: 'done', result: 'written', timing_ms: 130 })
+        send(ws, { type: 'thinking', id: 't1', status: 'done' })
+        send(ws, {
+          type: 'OUTPUT',
+          result: 'Read the page, rebuilt the site, and updated the layout.\n\n```ts\nexport default function Layout({ children }: { children: React.ReactNode }) {\n  return <html><body>{children}</body></html>\n}\n```\n\nThe build finished in 4.2 seconds.',
+          session: { session_id: 'e2e-session' },
         })
         return
       }

--- a/e2e/transcript.spec.ts
+++ b/e2e/transcript.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * A transcript with several kinds of tool in it.
+ *
+ * One card on its own never shows whether the rows share a grammar. Four in a
+ * row did: `DONE (0.2S)`, `EXIT CODE 0 (4.2S)` and `PROCESSING` were set in
+ * bold uppercase at tracking-widest and pulsing, so on a phone the status of a
+ * tool that had already finished was louder than the agent's actual answer —
+ * and grep's meta wrapped onto a second line, making that row taller than its
+ * neighbours for no reason a reader could see.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+async function busyTranscript(page: import('@playwright/test').Page) {
+  await mockAgent(page, 'busy')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText(/build finished in 4\.2 seconds/)).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('no tool row shouts, and none of them wrap', async ({ page, shot }) => {
+    await busyTranscript(page)
+
+    // The four rows are read as a column; if one is much taller than the others
+    // it is because its title or its meta wrapped.
+    const rows = page.locator('[role="log"]').getByText(/^(done|exit 0|running|awaiting approval)/)
+    const heights: number[] = []
+    for (const row of await rows.all()) {
+      const box = await row.boundingBox()
+      if (box) heights.push(box.height)
+    }
+    expect(heights.length, 'no tool meta rendered at all').toBeGreaterThan(1)
+    expect(Math.max(...heights), 'a tool row wrapped onto a second line').toBeLessThan(Math.min(...heights) * 1.8)
+
+    await shot('busy')
+  })
+
+  test('status meta is quiet — not uppercase, not animated', async ({ page }) => {
+    await busyTranscript(page)
+
+    const loud = await page.evaluate(() =>
+      [...document.querySelectorAll('[role="log"] span')]
+        .filter(el => {
+          const s = getComputedStyle(el)
+          const text = (el.textContent || '').trim()
+          if (!text || text.length > 30) return false
+          return s.textTransform === 'uppercase' || s.animationName.includes('pulse')
+        })
+        .map(el => (el.textContent || '').trim().slice(0, 30))
+    )
+    // A finished tool's status is reference material. Uppercase at wide tracking
+    // is a shout, and animating text delays reading the word that matters.
+    expect(loud, 'a tool status is still shouting or blinking').toEqual([])
+  })
+
+  test('nothing in a busy transcript pushes the page sideways', async ({ page }) => {
+    await busyTranscript(page)
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow).toBeLessThanOrEqual(0)
+  })
+})
+
+test('desktop keeps the same grammar', async ({ page, shot }) => {
+  await busyTranscript(page)
+  await expect(page.getByText('exit 0 · 4.2s')).toBeVisible()
+  await expect(page.getByText(/^done · 0\.2s$/)).toBeVisible()
+  await shot('busy')
+})


### PR DESCRIPTION
The first slice of the round-2 restyle, chosen by screenshot rather than by working down the audit list.

## What a busy transcript actually looked like

I added a scenario that streams `read_file`, `bash`, `grep` and `write_file` into one column and then an agent reply with a code block — because one card on its own never shows whether the rows share a grammar. Four in a row did:

```
✓ 👁 Read_file  page.tsx              DONE (0.2S)
>  ✓ Bash       build the site        EXIT CODE 0 (4.2S)
>  ✓ grep(components,                 0.1s
        useAgentForHuman)             1 files
>    write_file src/app/layout…       0.1s
```

**The status of a tool that had already finished was the loudest thing on the screen.** `DONE (0.2S)` and `EXIT CODE 0 (4.2S)` in bold uppercase at `tracking-widest`, with `animate-pulse` on the in-progress variants — shouting past the agent's actual answer, which is the only thing on the page the reader came for.

**grep stood a head taller than its neighbours.** Its meta was two sibling spans, so `0.1s` and `1 files` wrapped onto separate lines; its call signature wrapped too. Nothing about that row was more important, so the extra height was pure noise.

## What they use now

The quiet ledger meta `generic-card` already had:

```
text-[11px] tabular-nums text-neutral-500
```

lowercase, joined with a middot, on one line:

```
done · 0.2s      exit 0 · 4.2s      0.1s · 1 files      0.1s
```

grep's two spans became one `whitespace-nowrap` span, and its header truncates instead of wrapping.

`animate-pulse` is off the status text everywhere. Animating the word that tells you what is happening delays reading it.

## The screenshots are the review

Before and after are both in the `screenshots` artifact (`busy`). The change is legible there in a way it is not in a diff: the transcript goes from four competing voices to one, and the agent's reply becomes the thing your eye lands on.

## Three specs, verified to fail on the old styling first

```
Error: a tool status is still shouting or blinking
Error: a tool row wrapped onto a second line
```

They assert computed style and measured height rather than class names — `textTransform === 'uppercase'`, `animationName` containing `pulse`, and no row taller than 1.8× the shortest. A class-name check would pass the moment someone reintroduced the same look under a different utility.

## Verified along the CI path

```
CI=1 npx playwright test   32 passed
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

## Deliberately left

The code block inside an agent reply is clipped at the right edge on a phone (`Layout({ ch…`). The page does not scroll sideways, so it is scrolling inside its own container correctly — but there is no affordance saying so, and a reader has no way to know the line continues. That is a rendering decision about long code in a narrow column, not a spacing fix, and it deserves its own look.

Also still unshipped from round 2: collapsing 14 font sizes to 6, one vertical rhythm across every card, and one indent rail instead of three. The left edge of the transcript is visibly ragged in these screenshots — Read_file, Bash and write_file all start their content at different x. That is the next slice.