### PR TITLE
One rail for every tool row

### DIFF
--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -178,7 +178,11 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
         className="flex items-center gap-2 cursor-pointer group mb-2"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <div className="flex items-center gap-1.5 flex-1">
+        {/* One rail. Every tool row reserves the same 60px for its disclosure,
+            status and icon, so the names line up down the column however many
+            of those a given card actually has — bash carries three, read_file
+            two, and their titles used to start 26px apart. */}
+        <div className="flex w-[60px] shrink-0 items-center gap-1.5">
           {isExpanded ? (
             <HiOutlineChevronDown className="w-3.5 h-3.5 text-neutral-400 group-hover:text-neutral-600 transition-colors" />
           ) : (
@@ -206,8 +210,11 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
             <div className="w-2 h-2 rounded-full bg-neutral-300 ml-1" />
           )}
 
-          <HiOutlineTerminal className="w-4 h-4 text-neutral-500 ml-0.5" />
-          <span className="text-sm font-bold text-neutral-700 tracking-tight">Bash</span>
+          <HiOutlineTerminal className="w-4 h-4 shrink-0 text-neutral-500" />
+        </div>
+
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="shrink-0 text-[13px] font-medium text-neutral-800">Bash</span>
           {/* Command is collapsed by default, so the header must never be blank: */}
           {/* show the description if given, otherwise fall back to the command itself. */}
           {description ? (

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -235,7 +235,11 @@ export function CompactHeader({
 }: CompactHeaderProps) {
   return (
     <div className="flex items-center gap-2 mb-2 group cursor-default">
-      <div className="flex items-center gap-1.5 flex-1 min-w-0">
+      {/* Same 60px rail as the other tool rows. This card has no disclosure
+          chevron, so the slot stays empty rather than letting the title slide
+          left of its neighbours. */}
+      <div className="flex w-[60px] shrink-0 items-center gap-1.5">
+        <span className="w-3.5 shrink-0" aria-hidden="true" />
         <div className="w-4 h-4 flex items-center justify-center shrink-0">
           {status === 'done' ? (
             <div className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-neutral-100">
@@ -256,8 +260,11 @@ export function CompactHeader({
         </div>
         
         <Icon className="w-4 h-4 text-neutral-500 shrink-0" />
-        <span className="text-sm font-bold text-neutral-700 tracking-tight shrink-0">{toolName}</span>
-        <span className="text-xs font-bold text-neutral-500 truncate ml-1 font-mono tracking-tighter">{fileName}</span>
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className="shrink-0 text-[13px] font-medium text-neutral-800">{toolName}</span>
+        <span className="min-w-0 truncate font-mono text-xs text-neutral-500">{fileName}</span>
       </div>
 
       <div className="flex items-center gap-3 shrink-0">

--- a/components/chat/messages/tools/generic-card.tsx
+++ b/components/chat/messages/tools/generic-card.tsx
@@ -62,20 +62,26 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
         className={`flex h-7 w-full items-center gap-1.5 cursor-pointer select-none text-left rounded-md px-1.5 -mx-1.5 py-1 -my-1 ${isError ? 'bg-red-50/60 hover:bg-red-50' : 'hover:bg-neutral-100/70'}`}
         onClick={() => (hasOutput || (needsApproval && hasArgs)) && setIsExpanded(!isExpanded)}
       >
+        {/* Same 60px rail as the other tool rows. This card is the fallback for
+            any tool without its own renderer, so if it drifts every unrecognised
+            tool drifts with it. No tool icon here, so that slot stays empty. */}
+        <div className="flex w-[60px] shrink-0 items-center gap-1.5">
         {(hasOutput || (needsApproval && hasArgs)) ? (
-          <HiOutlineChevronRight className={`w-3 h-3 shrink-0 text-neutral-400 transition-transform duration-150 ${isExpanded ? 'rotate-90' : ''}`} />
-        ) : (
-          <span className="w-3 shrink-0" />
-        )}
+            <HiOutlineChevronRight className={`w-3 h-3 shrink-0 text-neutral-400 transition-transform duration-150 ${isExpanded ? 'rotate-90' : ''}`} />
+          ) : (
+            <span className="w-3 shrink-0" />
+          )}
 
-        {/* Status slot: quiet when done, pulsing dot while live, red X on error/rejection */}
-        {isError || (status === 'running' && rejected) ? (
-          <HiOutlineX className="w-4 h-4 shrink-0 text-red-500" />
-        ) : status === 'running' ? (
-          <span className={`mx-[5px] h-1.5 w-1.5 shrink-0 rounded-full animate-pulse ${needsApproval && !approvalSent ? 'bg-neutral-400' : 'bg-brand-500'}`} />
-        ) : (
-          <span className="w-4 shrink-0" />
-        )}
+          {/* Status slot: quiet when done, pulsing dot while live, red X on error/rejection */}
+          {isError || (status === 'running' && rejected) ? (
+            <HiOutlineX className="w-4 h-4 shrink-0 text-red-500" />
+          ) : status === 'running' ? (
+            <span className={`mx-[5px] h-1.5 w-1.5 shrink-0 rounded-full animate-pulse ${needsApproval && !approvalSent ? 'bg-neutral-400' : 'bg-brand-500'}`} />
+          ) : (
+            <span className="w-4 shrink-0" />
+          )}
+          <span className="w-4 shrink-0" aria-hidden="true" />
+        </div>
 
         <span className={`text-[13px] font-medium shrink-0 whitespace-nowrap ${isError ? 'text-red-600' : 'text-neutral-800'}`}>{name}</span>
         {argsStr && <span className="min-w-0 flex-1 truncate font-mono text-xs text-neutral-500">{argsStr}</span>}

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -115,20 +115,25 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
         className="flex items-center gap-2 cursor-pointer"
         onClick={() => setIsExpanded(!isExpanded)}
       >
+        {/* Same 60px rail. grep carries a chevron and a status but no tool
+            icon, so that slot stays empty instead of pulling the name left. */}
+        <div className="flex w-[60px] shrink-0 items-center gap-1.5">
         {/* Expand icon */}
-        {isExpanded ? (
-          <HiOutlineChevronDown className="w-3.5 h-3.5 text-neutral-400" />
-        ) : (
-          <HiOutlineChevronRight className="w-3.5 h-3.5 text-neutral-400" />
-        )}
+          {isExpanded ? (
+            <HiOutlineChevronDown className="w-3.5 h-3.5 text-neutral-400" />
+          ) : (
+            <HiOutlineChevronRight className="w-3.5 h-3.5 text-neutral-400" />
+          )}
 
-        {/* Status */}
-        {status === 'done' && <span className="text-green-600">✓</span>}
-        {status === 'error' && <span className="text-red-500">✗</span>}
-        {status === 'running' && needsApproval && (approvalSent === 'skipped' || approvalSent === 'stopped') && <span className="text-red-500">✗</span>}
-        {status === 'running' && needsApproval && approvalSent && approvalSent !== 'skipped' && approvalSent !== 'stopped' && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
-        {status === 'running' && needsApproval && !approvalSent && <span className="w-2 h-2 rounded-full bg-neutral-500 animate-pulse" />}
-        {status === 'running' && !needsApproval && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
+          {/* Status */}
+          {status === 'done' && <span className="text-green-600">✓</span>}
+          {status === 'error' && <span className="text-red-500">✗</span>}
+          {status === 'running' && needsApproval && (approvalSent === 'skipped' || approvalSent === 'stopped') && <span className="text-red-500">✗</span>}
+          {status === 'running' && needsApproval && approvalSent && approvalSent !== 'skipped' && approvalSent !== 'stopped' && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
+          {status === 'running' && needsApproval && !approvalSent && <span className="w-2 h-2 rounded-full bg-neutral-500 animate-pulse" />}
+          {status === 'running' && !needsApproval && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
+          <span className="w-4 shrink-0" aria-hidden="true" />
+        </div>
 
         {/* Tool name with args */}
         {/* Truncate rather than wrap: a long pattern turned the header into two

--- a/e2e/transcript.spec.ts
+++ b/e2e/transcript.spec.ts
@@ -57,6 +57,22 @@ test.describe('phone', () => {
     expect(loud, 'a tool status is still shouting or blinking').toEqual([])
   })
 
+  test('every tool name starts on the same rail', async ({ page }) => {
+    await busyTranscript(page)
+
+    // Cards carry different numbers of leading icons — bash has a chevron, a
+    // status and a terminal glyph; read_file has no chevron; grep has no tool
+    // icon — so without a reserved rail their titles started up to 26px apart
+    // and the left edge of the transcript read as ragged.
+    const xs = await page.evaluate(() =>
+      [...document.querySelectorAll('[role="log"] span')]
+        .filter(el => /^(Read_file|Bash|write_file|grep)$/.test((el.textContent || '').trim()))
+        .map(el => Math.round(el.getBoundingClientRect().x))
+    )
+    expect(xs.length, 'no tool titles found').toBeGreaterThan(2)
+    expect(Math.max(...xs) - Math.min(...xs), 'tool titles are not on one rail').toBeLessThanOrEqual(4)
+  })
+
   test('nothing in a busy transcript pushes the page sideways', async ({ page }) => {
     await busyTranscript(page)
     const overflow = await page.evaluate(


### PR DESCRIPTION
The second slice of the round-2 restyle. Last time the status meta at the right end of each row; this time the left edge.

## The transcript had a ragged left edge

Measured on a phone, the four tool titles started at four different places:

```
write_file  x=56
grep        x=58
Read_file   x=60
Bash        x=82      ← 26px spread
```

Not a spacing oversight — each card carries a different number of leading icons:

| card | before the title |
|---|---|
| `bash-card` | chevron + status + terminal glyph |
| `file-components` (read/write) | status + file icon, **no chevron** |
| `grep-card` | chevron + status, **no tool icon** |
| `generic-card` | chevron + status, no icon |

Each laid its icons out and let the title fall wherever they ended.

## One rail

Every row now reserves the same **60px** for disclosure, status and icon, and leaves the slot empty when it does not have one. All four titles land within 2px of each other.

`generic-card` is included deliberately: it is the fallback for any tool without a bespoke renderer, so if it drifts, every tool anyone adds later drifts with it.

## Titles quieted too

While in each header, the titles came down from `text-sm font-bold tracking-tight` to the `text-[13px] font-medium` the quiet cards already used, and file names from `text-xs font-bold tracking-tighter` to plain `font-mono text-xs`. Same pass as last time, other end of the row.

## The spec measures pixels, not classes

```js
expect(Math.max(...xs) - Math.min(...xs), 'tool titles are not on one rail').toBeLessThanOrEqual(4)
```

On the old layout:

```
Error: tool titles are not on one rail
Received: 26
```

Alignment is a rendered fact — a class-name assertion cannot see that one card's icons happen to add up differently.

## Verified along the CI path

```
CI=1 npx playwright test   33 passed
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

Screenshot in the `screenshots` artifact (`busy`) — the four names now sit on one vertical line.

## Deliberately left

`write_file` renders through `generic-card` rather than `FileCard`, because the tool→card mapping matches `write` and the agent sends `write_file`. That is a mapping question, not a layout one, and it is why the fallback card mattering was worth fixing rather than working around.

Still unshipped from round 2: the type scale (14 sizes down to 6) and one vertical rhythm across cards. And the code block inside an agent reply is still clipped at the right on a phone with no affordance showing it scrolls.