### PR TITLE
The chevron is the state

### DIFF
--- a/components/chat/messages/tools/file-card.tsx
+++ b/components/chat/messages/tools/file-card.tsx
@@ -20,6 +20,11 @@ interface FileCardProps {
 export function FileCard({ toolCall, pendingApproval, onApprovalResponse }: FileCardProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [approvalSent, setApprovalSent] = useState<ApprovalState>(null)
+  // This card used to have no open/closed state at all: it rendered its file
+  // body unconditionally and CompactHeader had no chevron to show, so a reader
+  // saw content with no control while the card beside it showed a chevron and
+  // nothing. The chevron is the state now, in every card.
+  const [isExpanded, setIsExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
 
   const { name, args, status, result, timing_ms } = toolCall
@@ -46,9 +51,11 @@ export function FileCard({ toolCall, pendingApproval, onApprovalResponse }: File
         fileName={getFileName(filePath)} Icon={getFileIcon(name)}
         status={status} timingMs={timing_ms} approvalSent={approvalSent}
         needsApproval={!!pendingApproval}
+        isExpanded={isExpanded} onToggle={content ? () => setIsExpanded(v => !v) : undefined}
       />
-      
-      <div className="ml-5 relative group/card">
+
+      {isExpanded && content && (
+      <div className="ml-[60px] relative group/card">
         <FileCodePeek content={content} filePath={filePath} onClick={() => setIsFullscreen(true)} />
         
         {content && (
@@ -63,13 +70,14 @@ export function FileCard({ toolCall, pendingApproval, onApprovalResponse }: File
           </div>
         )}
       </div>
+      )}
 
       <Modal isOpen={isFullscreen} onClose={() => setIsFullscreen(false)} title={`${name.charAt(0).toUpperCase() + name.slice(1).toLowerCase()}  ·  ${getFileName(filePath)}`}>
         <FileFullView content={content} filePath={filePath} />
       </Modal>
 
       {!!pendingApproval && status === 'running' && (
-        <div className="mt-4 ml-5">
+        <div className="mt-4 ml-[60px]">
           <ApprovalButtons 
             approvalSent={approvalSent} onApproval={handleApproval} 
             toolName={name} description={pendingApproval.description} 

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -5,7 +5,9 @@ import { Highlight, themes } from 'prism-react-renderer'
 import { 
   HiOutlineCheck, 
   HiOutlineX, 
-  HiOutlineArrowsExpand
+  HiOutlineArrowsExpand,
+  HiOutlineChevronRight,
+  HiOutlineChevronDown
 } from 'react-icons/hi'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -228,18 +230,36 @@ interface CompactHeaderProps {
   timingMs?: number
   approvalSent?: string | null
   needsApproval: boolean
+  /** Omit for a card with nothing to open. Passing it makes the row a button and
+   *  puts a chevron in the rail's first slot, which is the only thing in the
+   *  transcript allowed to say whether a body is showing. */
+  isExpanded?: boolean
+  onToggle?: () => void
 }
 
 export function CompactHeader({ 
-  toolName, fileName, Icon, status, timingMs, approvalSent, needsApproval 
+  toolName, fileName, Icon, status, timingMs, approvalSent, needsApproval, isExpanded, onToggle 
 }: CompactHeaderProps) {
   return (
-    <div className="flex items-center gap-2 mb-2 group cursor-default">
-      {/* Same 60px rail as the other tool rows. This card has no disclosure
-          chevron, so the slot stays empty rather than letting the title slide
-          left of its neighbours. */}
+    <div
+      onClick={onToggle}
+      role={onToggle ? 'button' : undefined}
+      tabIndex={onToggle ? 0 : undefined}
+      aria-expanded={onToggle ? isExpanded : undefined}
+      onKeyDown={onToggle ? e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle() } } : undefined}
+      className={cn('flex items-center gap-2 mb-2 group', onToggle ? 'cursor-pointer' : 'cursor-default')}
+    >
+      {/* Same 60px rail as the other tool rows. The first slot holds the
+          disclosure when the card has a body, and stays empty when it does not,
+          so titles line up either way. */}
       <div className="flex w-[60px] shrink-0 items-center gap-1.5">
-        <span className="w-3.5 shrink-0" aria-hidden="true" />
+        {onToggle ? (
+          isExpanded
+            ? <HiOutlineChevronDown className="w-3.5 h-3.5 shrink-0 text-neutral-400" />
+            : <HiOutlineChevronRight className="w-3.5 h-3.5 shrink-0 text-neutral-400" />
+        ) : (
+          <span className="w-3.5 shrink-0" aria-hidden="true" />
+        )}
         <div className="w-4 h-4 flex items-center justify-center shrink-0">
           {status === 'done' ? (
             <div className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-neutral-100">

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -72,13 +72,6 @@ function highlightPath(path: string): React.ReactNode {
   )
 }
 
-function getPreviewLines(result: string, maxLines = 5): { lines: string[]; remaining: number } {
-  const allLines = result.split('\n').filter(l => l.trim())
-  const lines = allLines.slice(0, maxLines)
-  const remaining = allLines.length - maxLines
-  return { lines, remaining: Math.max(0, remaining) }
-}
-
 export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: GrepCardProps) {
   const { name, args, status, result, timing_ms } = toolCall
   const [isExpanded, setIsExpanded] = useState(false)
@@ -101,10 +94,6 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
   const hasOutput = result && result.length > 0
   const allLines = hasOutput ? result.split('\n').filter(l => l.trim()) : []
   const fileCount = allLines.length
-  const { lines: previewLines, remaining } = hasOutput
-    ? getPreviewLines(result)
-    : { lines: [], remaining: 0 }
-
   // Format header: grep(path, pattern)
   const headerArgs = [path, pattern].filter(Boolean).join(', ')
 
@@ -167,8 +156,11 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
         )}
       </div>
 
-      {/* Terminal block - Monokai background */}
-      {hasOutput && (
+      {/* Terminal block — behind the chevron, like every other body. It used to
+          render whenever there was output, so a row showing ▸ still displayed a
+          preview and the chevron stopped meaning anything. The collapsed summary
+          it was duplicating already lives in the header meta ("0.1s · 3 files"). */}
+      {isExpanded && hasOutput && (
         <div className="mt-2 ml-5 bg-[#272822] rounded-lg overflow-hidden">
           <div
             className="cursor-pointer"
@@ -177,14 +169,11 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
             <div className="p-3 text-xs font-mono max-h-80 overflow-y-auto">
               {/* File list with left border */}
               <div className="border-l-2 border-[#3E3D32] pl-3 space-y-0.5">
-                {(isExpanded ? allLines : previewLines).map((line, i) => (
+                {allLines.map((line, i) => (
                   <div key={i} className="leading-5 truncate hover:bg-[#3E3D32]/50 -ml-3 pl-3 -mr-3 pr-3">
                     {highlightPath(line)}
                   </div>
                 ))}
-                {!isExpanded && remaining > 0 && (
-                  <div className="text-[#75715E] pt-1">+{remaining} more files</div>
-                )}
               </div>
             </div>
           </div>

--- a/e2e/transcript.spec.ts
+++ b/e2e/transcript.spec.ts
@@ -82,6 +82,51 @@ test.describe('phone', () => {
   })
 })
 
+test('the chevron is the state — no collapsed row shows a body', async ({ page, shot }) => {
+  await busyTranscript(page)
+
+  // One rule, and it used to be broken in both directions: grep showed a
+  // right-pointing chevron and rendered its matches anyway, while read_file
+  // rendered a whole code body with no chevron at all. A control that does not
+  // predict what you will see is worse than no control.
+  const rows = await page.evaluate(() => {
+    const log = document.querySelector('[role="log"]')!
+    return [...log.querySelectorAll('[aria-expanded], button')]
+      .map(el => {
+        const name = [...el.querySelectorAll('span')]
+          .map(s => (s.textContent || '').trim())
+          .find(t => /^(Read_file|Bash|write_file|grep)$/.test(t))
+        if (!name) return null
+        const expanded = el.getAttribute('aria-expanded')
+        // The body is the next sibling block, if any.
+        const body = el.parentElement?.querySelector('pre, .font-mono[class*="bg-"]')
+        return { name, expanded, hasBody: !!body }
+      })
+      .filter(Boolean)
+  })
+
+  expect(rows.length, 'no disclosure rows found').toBeGreaterThan(0)
+  for (const row of rows as { name: string; expanded: string | null; hasBody: boolean }[]) {
+    if (row.expanded === 'false') {
+      expect(row.hasBody, `${row.name} says collapsed but renders a body`).toBe(false)
+    }
+  }
+
+  await shot('collapsed')
+})
+
+test('opening a file card is possible at all', async ({ page }) => {
+  await busyTranscript(page)
+
+  // read_file had no open/closed state, so its content was permanently on
+  // screen and there was nothing to click.
+  const header = page.getByRole('button').filter({ hasText: 'Read_file' }).first()
+  await expect(header).toHaveAttribute('aria-expanded', 'false')
+  await header.click()
+  await expect(header).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByText('hello')).toBeVisible()
+})
+
 test('desktop keeps the same grammar', async ({ page, shot }) => {
   await busyTranscript(page)
   await expect(page.getByText('exit 0 · 4.2s')).toBeVisible()


### PR DESCRIPTION
Prerequisite for auto-collapsing execution history, and it turns out to deliver most of the benefit on its own.

## Three behaviours, one glyph position

From the busy-transcript screenshot on `main`:

| row | chevron says | actually shows |
|---|---|---|
| `Read_file page.tsx` | *no chevron at all* | a full code body |
| `Bash build the site` | ▸ collapsed | nothing ✓ |
| `grep(components, …)` | ▸ collapsed | its match list |

A reader who clicks ▸ on Bash and gets content, then sees ▸ on grep already showing content, learns the control means nothing.

## Why

`FileCard` had **no open/closed state whatsoever** — it tracked `isFullscreen`, `approvalSent` and `copied`, never expanded — so `CompactHeader` had no disclosure to render and the body was permanently on screen. There was nothing to click.

`grep-card` defaulted `isExpanded` to `false` but rendered its terminal block outside that conditional, showing `previewLines` when closed and `allLines` when open. The chevron was never wired to be authoritative.

## What changed

- `CompactHeader` gained a disclosure slot — `aria-expanded`, `role="button"`, Enter/Space — in the rail's first position, empty when a card has no body so titles still align.
- `FileCard` owns `isExpanded`; its body and its approval block sit behind it, on the 60px rail like everything else.
- grep's terminal block moved behind `isExpanded`. The summary it duplicated while collapsed already lives in the header meta (`0.1s · 3 files`), so nothing was lost — `getPreviewLines` and its two locals went with it.

## It delivers most of auto-collapse for free

The owner's instinct was that execution history should fold away so the answer is what you end on. With *collapsed meaning collapsed*, that mostly happens already:

Four tool rows now occupy four lines, and the agent's reply is the largest thing on screen. On `main` the same transcript spent ~320px on tool bodies and pushed the answer into the bottom third.

The remaining piece — collapsing prior steps automatically as a run progresses, with errors and pending approvals exempt — is now buildable, because there is finally one place that says whether a body is showing. It was not buildable before.

## Two specs

```
no row reporting aria-expanded="false" may render a body
a file card must be openable at all
```

The second fails on the old code by not finding a button — because there wasn't one:

```
Error: expect(locator).toHaveAttribute(expected) failed
Expected: "false"
Error: element(s) not found
```

## Verified along the CI path

```
CI=1 npx playwright test   35 passed
e2e-screenshots/           47 files
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

Screenshot `collapsed` in the artifact — four single-line rows, answer dominant.

## Deliberately left

grep still draws its status as a literal `✓` text character while the others use `HiOutlineCheck`, which is why it renders visibly heavier than its neighbours. That is one of three implementations of a 14px mark, and it goes away with the shared `ToolRow` — the next slice, which deletes the six hand-rolled headers rather than patching them.