### PR TITLE
One status mark, drawn one way

### DIFF
--- a/components/chat/messages/tools/background-card.tsx
+++ b/components/chat/messages/tools/background-card.tsx
@@ -5,13 +5,12 @@ import type { ToolCallUI, PendingApproval } from '../../types'
 import { 
   HiOutlineChevronRight, 
   HiOutlineChevronDown, 
-  HiOutlineCloud,
   HiOutlineCheck,
-  HiOutlineX,
   HiOutlineTerminal,
   HiOutlineClock
 } from 'react-icons/hi'
 import { ApprovalButtons } from './approval-buttons'
+import { ToolStatus } from './tool-status'
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -70,20 +69,7 @@ export function BackgroundCard({ toolCall, pendingApproval, onApprovalResponse }
               </>
             )}
             
-            {status === 'done' ? (
-              <div className="flex items-center justify-center w-5 h-5 rounded-full bg-green-100/50">
-                <HiOutlineCheck className="w-3 h-3 text-green-600" />
-              </div>
-            ) : status === 'error' ? (
-              <div className="flex items-center justify-center w-5 h-5 rounded-full bg-red-100/50">
-                <HiOutlineX className="w-3 h-3 text-red-600" />
-              </div>
-            ) : (
-              <HiOutlineCloud className={cn(
-                "w-4 h-4 relative z-10",
-                status === 'running' ? "text-neutral-600" : "text-neutral-500"
-              )} />
-            )}
+            <ToolStatus status={status} />
           </div>
 
           <div className="flex flex-col">

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -7,17 +7,10 @@ import {
   HiOutlineChevronDown, 
   HiOutlineTerminal,
   HiOutlineCheck,
-  HiOutlineX,
   HiOutlineClipboardCopy
 } from 'react-icons/hi'
 import { ApprovalButtons } from './approval-buttons'
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
-
+import { ToolStatus } from './tool-status'
 interface BashCardProps {
   toolCall: ToolCallUI
   pendingApproval?: PendingApproval | null
@@ -189,26 +182,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
             <HiOutlineChevronRight className="w-3.5 h-3.5 text-neutral-400 group-hover:text-neutral-600 transition-colors" />
           )}
 
-          {status === 'done' ? (
-            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-green-100/50">
-              <HiOutlineCheck className="w-2.5 h-2.5 text-green-600" />
-            </div>
-          ) : status === 'error' ? (
-            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-red-100/50">
-              <HiOutlineX className="w-2.5 h-2.5 text-red-600" />
-            </div>
-          ) : status === 'running' ? (
-            /* Same dot as generic-card and browser-card: brand green means running,
-               neutral means waiting on you. These rows stream into one column, and
-               when "running" was black here and green there, scanning the transcript
-               for what is still executing did not work. */
-            <div className={cn(
-              "w-2 h-2 rounded-full animate-pulse ml-1",
-              needsApproval && !approvalSent ? "bg-neutral-400" : "bg-brand-500"
-            )} />
-          ) : (
-            <div className="w-2 h-2 rounded-full bg-neutral-300 ml-1" />
-          )}
+          <ToolStatus status={status} awaitingApproval={needsApproval && !approvalSent} />
 
           <HiOutlineTerminal className="w-4 h-4 shrink-0 text-neutral-500" />
         </div>

--- a/components/chat/messages/tools/enter-plan-mode-card.tsx
+++ b/components/chat/messages/tools/enter-plan-mode-card.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { HiOutlineClipboardList, HiOutlineLightBulb } from 'react-icons/hi'
+import { ToolStatus } from './tool-status'
 
 interface EnterPlanModeCardProps {
   toolCall: {
@@ -14,14 +15,12 @@ interface EnterPlanModeCardProps {
 export function EnterPlanModeCard({ toolCall }: EnterPlanModeCardProps) {
   const { status, timing_ms } = toolCall
 
-  const statusColor = status === 'done' ? 'text-neutral-700' : status === 'error' ? 'text-red-600' : 'text-neutral-500'
-  const statusIcon = status === 'done' ? '✓' : status === 'error' ? '✗' : '●'
 
   return (
     <div className="py-2.5">
       {/* Header */}
       <div className="flex items-center gap-2 text-sm">
-        <span className={statusColor}>{statusIcon}</span>
+        <ToolStatus status={status} />
         <HiOutlineClipboardList className="w-4 h-4 text-neutral-500" />
         <span className="font-medium">Entered Plan Mode</span>
         {timing_ms !== undefined && (

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -3,13 +3,12 @@
 import type { IconType } from 'react-icons'
 import { Highlight, themes } from 'prism-react-renderer'
 import { 
-  HiOutlineCheck, 
-  HiOutlineX, 
   HiOutlineArrowsExpand,
   HiOutlineChevronRight,
   HiOutlineChevronDown
 } from 'react-icons/hi'
 import ReactMarkdown from 'react-markdown'
+import { ToolStatus } from './tool-status'
 import remarkGfm from 'remark-gfm'
 import { cn } from '../../utils'
 import { getLanguageFromPath, monokaiTheme, formatTime } from './file-utils'
@@ -260,25 +259,7 @@ export function CompactHeader({
         ) : (
           <span className="w-3.5 shrink-0" aria-hidden="true" />
         )}
-        <div className="w-4 h-4 flex items-center justify-center shrink-0">
-          {status === 'done' ? (
-            <div className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-neutral-100">
-              <HiOutlineCheck className="w-2.5 h-2.5 text-neutral-600" />
-            </div>
-          ) : status === 'error' ? (
-            <div className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-red-100/50">
-              <HiOutlineX className="w-2.5 h-2.5 text-red-600" />
-            </div>
-          ) : status === 'running' ? (
-            <div className={cn(
-              "w-1.5 h-1.5 rounded-full animate-pulse",
-              needsApproval && !approvalSent ? "bg-neutral-400" : "bg-brand-500"
-            )} />
-          ) : (
-            <div className="w-1.5 h-1.5 rounded-full bg-neutral-300" />
-          )}
-        </div>
-        
+        <ToolStatus status={status} awaitingApproval={needsApproval && !approvalSent} />
         <Icon className="w-4 h-4 text-neutral-500 shrink-0" />
       </div>
 

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import type { ToolCallUI, PendingApproval } from '../../types'
 import { HiOutlineChevronRight, HiOutlineChevronDown } from 'react-icons/hi'
+import { ToolStatus } from './tool-status'
 import { ApprovalButtons } from './approval-buttons'
 
 interface GrepCardProps {
@@ -115,12 +116,7 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
           )}
 
           {/* Status */}
-          {status === 'done' && <span className="text-green-600">✓</span>}
-          {status === 'error' && <span className="text-red-500">✗</span>}
-          {status === 'running' && needsApproval && (approvalSent === 'skipped' || approvalSent === 'stopped') && <span className="text-red-500">✗</span>}
-          {status === 'running' && needsApproval && approvalSent && approvalSent !== 'skipped' && approvalSent !== 'stopped' && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
-          {status === 'running' && needsApproval && !approvalSent && <span className="w-2 h-2 rounded-full bg-neutral-500 animate-pulse" />}
-          {status === 'running' && !needsApproval && <span className="h-1.5 w-1.5 rounded-full bg-brand-500 animate-pulse" />}
+          <ToolStatus status={status} awaitingApproval={needsApproval && !approvalSent} />
           <span className="w-4 shrink-0" aria-hidden="true" />
         </div>
 

--- a/components/chat/messages/tools/guide-card.tsx
+++ b/components/chat/messages/tools/guide-card.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { ToolStatus } from './tool-status'
 import { HiOutlineBookOpen, HiOutlineCheck, HiOutlineClipboard, HiOutlineChevronDown, HiOutlineChevronRight } from 'react-icons/hi'
 import { Modal } from '@/components/ui/modal'
 import ReactMarkdown from 'react-markdown'
@@ -38,8 +39,6 @@ export function GuideCard({ toolCall }: GuideCardProps) {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const statusColor = status === 'done' ? 'text-neutral-500' : status === 'error' ? 'text-red-500' : 'text-brand-500'
-  const statusIcon = status === 'done' ? '✓' : status === 'error' ? '✗' : '●'
 
   // Markdown code block renderer
   const components = {
@@ -88,7 +87,7 @@ export function GuideCard({ toolCall }: GuideCardProps) {
           ) : (
             <HiOutlineChevronRight className="w-4 h-4 text-neutral-400" />
           )}
-          <span className={statusColor}>{statusIcon}</span>
+          <ToolStatus status={status} />
           <HiOutlineBookOpen className="w-4 h-4 text-neutral-500" />
           <span className="font-medium">load_guide</span>
           <span className="text-neutral-500">({guidePath})</span>

--- a/components/chat/messages/tools/plan-card.tsx
+++ b/components/chat/messages/tools/plan-card.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { ToolStatus } from './tool-status'
 import { HiOutlineClipboardList, HiOutlineCheck, HiOutlineClipboard, HiOutlineHeart, HiHeart, HiOutlineExclamationCircle, HiOutlineArrowsExpand } from 'react-icons/hi'
 import { Modal } from '@/components/ui/modal'
 import ReactMarkdown from 'react-markdown'
@@ -225,7 +226,6 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
 
   // Status indicator
   const statusBg = status === 'done' ? 'bg-neutral-200 text-neutral-700' : status === 'error' ? 'bg-red-500/10 text-red-600' : 'bg-neutral-100 text-neutral-500'
-  const statusIcon = status === 'done' ? '✓' : status === 'error' ? '✗' : '●'
 
   return (
     <div className="py-2.5">
@@ -236,7 +236,7 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
           className="flex items-center gap-2 hover:bg-neutral-100 rounded px-1 -ml-1 transition-colors"
         >
           <span className={`flex items-center justify-center w-5 h-5 rounded-full ${statusBg}`}>
-            <span className="text-xs font-bold">{statusIcon}</span>
+            <ToolStatus status={status} />
           </span>
           <HiOutlineClipboardList className="w-4 h-4 text-neutral-500" />
           <span className="font-semibold text-sm">Implementation Plan</span>

--- a/components/chat/messages/tools/tool-status.tsx
+++ b/components/chat/messages/tools/tool-status.tsx
@@ -1,0 +1,46 @@
+import { HiOutlineCheck, HiOutlineX } from 'react-icons/hi'
+import { cn } from '../../utils'
+
+/**
+ * The one status mark a tool row is allowed to draw.
+ *
+ * There were five: a literal `✓` text character in grep-card, `HiOutlineCheck`
+ * inside a green circle in bash-card, the same icon inside a neutral circle in
+ * CompactHeader, the strings `'✓' / '✗' / '●'` in plan-card, guide-card and
+ * enter-plan-mode-card, and an `HiOutlineX`-or-nothing pair in generic-card.
+ * Text glyphs render at the font's own weight and baseline, which is why grep's
+ * check sat visibly heavier and lower than its neighbours in the same column.
+ *
+ * Fixed 16px box so the rail stays aligned whichever state is showing.
+ */
+export function ToolStatus({
+  status,
+  awaitingApproval = false,
+  className,
+}: {
+  status: 'running' | 'done' | 'error' | string
+  /** Neutral rather than brand while the run is parked on the reader. */
+  awaitingApproval?: boolean
+  className?: string
+}) {
+  return (
+    <span className={cn('flex h-4 w-4 shrink-0 items-center justify-center', className)}>
+      {status === 'done' ? (
+        <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-neutral-100">
+          <HiOutlineCheck className="h-2.5 w-2.5 text-neutral-600" />
+        </span>
+      ) : status === 'error' ? (
+        <HiOutlineX className="h-3.5 w-3.5 text-red-600" />
+      ) : status === 'running' ? (
+        <span
+          className={cn(
+            'h-1.5 w-1.5 rounded-full animate-pulse',
+            awaitingApproval ? 'bg-neutral-400' : 'bg-brand-500'
+          )}
+        />
+      ) : (
+        <span className="h-1.5 w-1.5 rounded-full bg-neutral-300" />
+      )}
+    </span>
+  )
+}

--- a/e2e/transcript.spec.ts
+++ b/e2e/transcript.spec.ts
@@ -127,6 +127,37 @@ test('opening a file card is possible at all', async ({ page }) => {
   await expect(page.getByText('hello')).toBeVisible()
 })
 
+test('one status mark, drawn one way', async ({ page }) => {
+  await busyTranscript(page)
+
+  // There were five implementations of this 14px mark: a literal ✓ text glyph
+  // in grep, an icon in a green circle in bash, the same icon in a neutral
+  // circle in the shared header, the strings '✓'/'✗'/'●' in three more cards,
+  // and an icon-or-nothing pair in generic-card. A text glyph renders at the
+  // font's own weight and baseline, which is why grep's check sat visibly
+  // heavier and lower than its neighbours in the same column.
+  const marks = await page.evaluate(() => {
+    const log = document.querySelector('[role="log"]')!
+    return [...log.querySelectorAll('span')]
+      .filter(el => ['✓', '✗', '●'].includes((el.textContent || '').trim()))
+      .map(el => (el.textContent || '').trim())
+  })
+  expect(marks, 'a status is still drawn as a text character').toEqual([])
+
+  // And the done marks that remain are all the same size, so the rail does not
+  // jitter between rows.
+  const sizes = await page.evaluate(() => {
+    const log = document.querySelector('[role="log"]')!
+    return [...log.querySelectorAll('svg')]
+      .map(el => el.getBoundingClientRect())
+      .filter(r => r.width > 6 && r.width < 20)
+      .map(r => Math.round(r.width))
+  })
+  if (sizes.length > 1) {
+    expect(Math.max(...sizes) - Math.min(...sizes), 'status marks are different sizes').toBeLessThanOrEqual(6)
+  }
+})
+
 test('desktop keeps the same grammar', async ({ page, shot }) => {
   await busyTranscript(page)
   await expect(page.getByText('exit 0 · 4.2s')).toBeVisible()


### PR DESCRIPTION
The owner's words were *"表示 status 的状态、颜色、形状,都好像不是统一的"*. They were right, and the count was higher than the audit's.

## Five implementations of one 14px mark

| card | how it drew "done" |
|---|---|
| `grep-card` | a literal `✓` **text character**, `text-green-600` |
| `bash-card` | `HiOutlineCheck` in a `bg-green-100/50` circle |
| `file-components` (`CompactHeader`) | `HiOutlineCheck` in a `bg-neutral-100` circle |
| `plan-card`, `guide-card`, `enter-plan-mode-card` | the strings `'✓' / '✗' / '●'` |
| `generic-card` | `HiOutlineX` for error, a spacer for done |
| `background-card`, `ask-user-card` | their own circle-and-icon copies again |

The text glyph is the one you can see without measuring: it renders at the font's own weight and baseline, so grep's check sat visibly heavier and lower than the icons beside it in the same column. That was the loudest "these cards were built by different people" tell in the transcript.

## One component

`ToolStatus` — fixed 16px box so the rail stays aligned whichever state is showing; neutral circled check for done, red X for error, brand dot while running, neutral dot while parked on the reader.

The running dot goes through `--color-brand-500` rather than being another hand-picked green, which is the same discipline as #68.

## It is a deletion

Adopting it removed:

- seven inline status implementations
- a **duplicate local `cn()`** in `bash-card` — the file had its own copy of the helper that already exists in `components/chat/utils`
- two orphaned `statusColor` helpers
- five icon imports that nothing referenced any more

## The spec

```
Error: a status is still drawn as a text character
+ Received  + 3
```

Three glyphs on the old code. It also measures the remaining marks and requires them within 6px of each other, because "same mark" that renders at two sizes is still two marks.

## Verified along the CI path

```
CI=1 npx playwright test   36 passed
e2e-screenshots/           48 files
npx tsc --noEmit           clean
npm run lint               clean
npx vitest run             55 passed
```

Screenshot `collapsed` — four rows, one mark, one baseline.

## Deliberately left

The **copied** ticks on copy-to-clipboard buttons still use raw `green-400` / `green-500` / `green-600` across five cards. That is button feedback rather than row status — a different statement — and folding it into `ToolStatus` would make the component mean "green tick" instead of "this is the state of this step". It wants its own pass, together with the other 15 raw greens inside the cards.

The shared `ToolRow` — collapsing the six remaining hand-rolled headers into `CompactHeader` — is still the big one. This PR did the smallest piece of it that is visible on every screen.