### PR TITLE
One green in the transcript too

### DIFF
--- a/components/chat/messages/eval.tsx
+++ b/components/chat/messages/eval.tsx
@@ -55,14 +55,14 @@ export function Eval({ eval: evalData }: EvalProps) {
 
     return (
       <div className="flex justify-start py-1">
-        <div className={`border-l-2 pl-3 ${passed ? 'border-green-200' : 'border-red-200'}`}>
+        <div className={`border-l-2 pl-3 ${passed ? 'border-brand-200' : 'border-red-200'}`}>
           {/* Summary line - clickable to expand if has details */}
           <button
             onClick={() => hasDetails && setExpanded(!expanded)}
             className={`flex items-start gap-1.5 text-xs text-neutral-500 ${hasDetails ? 'hover:text-neutral-700 cursor-pointer' : 'cursor-default'} transition-colors text-left`}
           >
             {/* Status icon */}
-            <span className={`flex-shrink-0 ${passed ? 'text-green-500' : 'text-red-500'}`}>
+            <span className={`flex-shrink-0 ${passed ? 'text-brand-500' : 'text-red-500'}`}>
               {passed ? '✓' : '✗'}
             </span>
             {/* Summary text */}

--- a/components/chat/messages/tools/approval-buttons.tsx
+++ b/components/chat/messages/tools/approval-buttons.tsx
@@ -48,7 +48,7 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
           ) : approvalSent === 'stopped' ? (
             <span className="flex items-center gap-1.5 text-red-500"><HiOutlineStop className="w-3.5 h-3.5 shrink-0" /> Execution stopped</span>
           ) : (
-            <span className="flex items-center gap-1.5 text-green-600">
+            <span className="flex items-center gap-1.5 text-brand-600">
               <HiOutlineCheck className="w-3.5 h-3.5" />
               {approvalSent === 'approved_session' ? 'Session authorized' : 'Approved'} — running...
             </span>
@@ -66,7 +66,7 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
           onClick={() => onApproval(true, 'once')}
           className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white transition-colors group"
         >
-          <HiOutlineCheck className="w-4 h-4 text-neutral-400 group-hover:text-green-600" />
+          <HiOutlineCheck className="w-4 h-4 text-neutral-400 group-hover:text-brand-600" />
           <div className="flex-1">
             <span className="text-sm font-semibold text-neutral-800">Allow once</span>
             <span className="text-xs text-neutral-500 ml-2 font-normal">{description || 'Only this command'}</span>

--- a/components/chat/messages/tools/ask-user-card.tsx
+++ b/components/chat/messages/tools/ask-user-card.tsx
@@ -112,12 +112,12 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
           )}
 
           {status === 'done' ? (
-            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-green-100/50">
-              <HiOutlineCheck className="w-2.5 h-2.5 text-green-600" />
+            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-brand-100/50">
+              <HiOutlineCheck className="w-2.5 h-2.5 text-brand-600" />
             </div>
           ) : responded ? (
-            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-green-50">
-              <HiOutlineCheck className="w-2.5 h-2.5 text-green-500 animate-pulse" />
+            <div className="flex items-center justify-center w-4 h-4 rounded-full bg-brand-50">
+              <HiOutlineCheck className="w-2.5 h-2.5 text-brand-500 animate-pulse" />
             </div>
           ) : isPending ? (
             <div className="w-2 h-2 rounded-full bg-neutral-500 animate-pulse ml-1" />
@@ -135,7 +135,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
           ) : skipped ? (
             <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest">Skipped</span>
           ) : responded ? (
-            <span className="text-green-600 text-[10px] uppercase font-bold tracking-widest">Responded</span>
+            <span className="text-brand-600 text-[10px] uppercase font-bold tracking-widest">Responded</span>
           ) : isAwaiting ? (
             <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">Pending</span>
           ) : null}
@@ -303,7 +303,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
           {/* Answer */}
           {(status === 'done' || responded) && result && (
             <div className="flex items-start gap-2 text-sm text-neutral-600 animate-in fade-in duration-300">
-              <HiOutlineCheck className="w-4 h-4 text-green-600 shrink-0 mt-0.5" />
+              <HiOutlineCheck className="w-4 h-4 text-brand-600 shrink-0 mt-0.5" />
               <span className="whitespace-pre-wrap leading-relaxed">{result}</span>
             </div>
           )}

--- a/components/chat/messages/tools/background-card.tsx
+++ b/components/chat/messages/tools/background-card.tsx
@@ -127,7 +127,7 @@ export function BackgroundCard({ toolCall, pendingApproval, onApprovalResponse }
           {result && (
             <div className="mt-3">
               <div className="flex items-center gap-1.5 mb-1.5">
-                <HiOutlineCheck className="w-3.5 h-3.5 text-green-500" />
+                <HiOutlineCheck className="w-3.5 h-3.5 text-brand-500" />
                 <span className="text-xs font-medium text-neutral-500">Result</span>
               </div>
               <div className="bg-[#1e1e1e] rounded-lg overflow-hidden">

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -271,7 +271,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
             className="absolute top-2 right-2 text-neutral-600 hover:text-neutral-300 transition-all p-1 rounded opacity-100 lg:opacity-0 lg:group-hover/terminal:opacity-100 focus-visible:opacity-100"
             title="Copy command"
           >
-            {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-green-500" /> : <HiOutlineClipboardCopy className="w-3.5 h-3.5" />}
+            {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-brand-500" /> : <HiOutlineClipboardCopy className="w-3.5 h-3.5" />}
           </button>
         </div>
       </div>

--- a/components/chat/messages/tools/file-card.tsx
+++ b/components/chat/messages/tools/file-card.tsx
@@ -65,7 +65,7 @@ export function FileCard({ toolCall, pendingApproval, onApprovalResponse }: File
               className="p-1.5 bg-neutral-900/80 hover:bg-neutral-900 text-white rounded-lg shadow-lg border border-white/10 transition-all"
               title="Copy content"
             >
-              {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-green-400" /> : <HiOutlineClipboard className="w-3.5 h-3.5" />}
+              {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-brand-400" /> : <HiOutlineClipboard className="w-3.5 h-3.5" />}
             </button>
           </div>
         )}

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -96,7 +96,7 @@ export function FileCodePeek({ content, filePath, isDiff, maxLines = 4, onClick 
               const isDel = isDiff && lineContent.trimStart().startsWith('-')
               
               const lineProps = getLineProps({ line })
-              if (isAdd) lineProps.className = cn(lineProps.className, "bg-green-900/20 block w-full")
+              if (isAdd) lineProps.className = cn(lineProps.className, "bg-brand-900/20 block w-full")
               else if (isDel) lineProps.className = cn(lineProps.className, "bg-red-900/20 block w-full")
               else lineProps.className = cn(lineProps.className, "block w-full")
 
@@ -147,7 +147,7 @@ export function FileFullView({ content, filePath, isDiff }: { content: string, f
               const isDel = isDiff && lineContent.trimStart().startsWith('-')
               
               const lineProps = getLineProps({ line })
-              if (isAdd) lineProps.className = cn(lineProps.className, "bg-green-900/30 block w-full")
+              if (isAdd) lineProps.className = cn(lineProps.className, "bg-brand-900/30 block w-full")
               else if (isDel) lineProps.className = cn(lineProps.className, "bg-red-900/30 block w-full")
               else lineProps.className = cn(lineProps.className, "block w-full")
 
@@ -204,7 +204,7 @@ export function FileDiffSideBySideView({ oldContent, newContent, filePath }: { o
           {({ tokens, getLineProps, getTokenProps }) => (
             <pre className="text-[12px] font-mono m-0 p-6 leading-relaxed min-w-full">
               {tokens.map((line, i) => (
-                <div key={i} {...getLineProps({ line })} className="block w-full bg-green-900/10">
+                <div key={i} {...getLineProps({ line })} className="block w-full bg-brand-900/10">
                   <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[10px] opacity-40">
                     {i + 1}
                   </span>

--- a/components/chat/messages/tools/file-diff-card.tsx
+++ b/components/chat/messages/tools/file-diff-card.tsx
@@ -66,7 +66,7 @@ export function FileDiffCard({ toolCall, pendingApproval, onApprovalResponse }: 
               className="p-1.5 bg-neutral-900/80 hover:bg-neutral-900 text-white rounded-lg shadow-lg border border-white/10 transition-all"
               title="Copy diff"
             >
-              {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-green-400" /> : <HiOutlineClipboard className="w-3.5 h-3.5" />}
+              {copied ? <HiOutlineCheck className="w-3.5 h-3.5 text-brand-400" /> : <HiOutlineClipboard className="w-3.5 h-3.5" />}
             </button>
           </div>
         )}

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -143,7 +143,7 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
           ) : approvalSent === 'stopped' ? (
             <span className="ml-auto shrink-0 text-[11px] font-medium text-red-600">stopped</span>
           ) : (
-            <span className="text-green-600 text-xs font-medium">approved — running...</span>
+            <span className="text-brand-600 text-xs font-medium">approved — running...</span>
           )
         ) : needsApproval ? (
           <span className="text-neutral-500 text-xs font-medium">awaiting approval</span>

--- a/components/chat/messages/tools/login-card.tsx
+++ b/components/chat/messages/tools/login-card.tsx
@@ -64,11 +64,11 @@ export function LoginCard({ toolCall, pendingAskUser, onAskUserResponse }: Login
         className={`flex items-center gap-2 py-2 text-sm ${isPending && dismissed ? 'cursor-pointer' : ''}`}
         onClick={isPending && dismissed ? () => setDismissed(false) : undefined}
       >
-        <div className={`flex items-center justify-center w-5 h-5 rounded-full ${done && !skipped ? 'bg-green-100/60' : 'bg-neutral-100'}`}>
+        <div className={`flex items-center justify-center w-5 h-5 rounded-full ${done && !skipped ? 'bg-brand-100/60' : 'bg-neutral-100'}`}>
           {skipped
             ? <HiOutlineX className="w-3 h-3 text-neutral-500" />
             : done
-              ? <HiOutlineCheck className="w-3 h-3 text-green-600" />
+              ? <HiOutlineCheck className="w-3 h-3 text-brand-600" />
               : <HiOutlineLockClosed className="w-3 h-3 text-neutral-500" />}
         </div>
         <span className="font-medium text-neutral-600">

--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -167,7 +167,7 @@ export function ModeStatusBar({ mode, onModeChange, disabled, sessionState, conn
           ) : sessionState === 'active' ? (
             <div className="flex items-center gap-1.5">
               <span className="w-1.5 h-1.5 rounded-full bg-brand-400" />
-              <span className="text-[11px] text-green-600">live</span>
+              <span className="text-[11px] text-brand-600">live</span>
             </div>
           ) : sessionState === 'connected' ? (
             <div className="flex items-center gap-1.5">

--- a/e2e/design-system.spec.ts
+++ b/e2e/design-system.spec.ts
@@ -40,6 +40,23 @@ test('the live dot is the brand token, not a hand-picked green', async ({ page }
   expect(colours, 'the live indicator is not on the brand ramp').toContain(BRAND_500)
 })
 
+test('no component in the chat tree ships a raw Tailwind green', async () => {
+  // Source-level on purpose. I first wrote this as a computed-colour check over a
+  // rendered transcript and it passed against the unfixed code — the greens live
+  // on states that transcript never renders (a copy tick appears only after you
+  // click, and the eval, login and diff cards were not in the scenario). A guard
+  // that cannot see the thing it guards is worse than none.
+  //
+  // "No raw green in the source" is a source fact, and the class name is what a
+  // reviewer would actually type. The rendered counterpart — that the live dot
+  // resolves to the token — is the test above.
+  const { execSync } = await import('node:child_process')
+  const hits = execSync('grep -rn "green-[0-9]" components/chat || true', { encoding: 'utf8' })
+    .split('\n')
+    .filter(l => l.trim())
+  expect(hits, 'these should go through --color-brand-* so the ramp is one place').toEqual([])
+})
+
 test('no component ships its own violet', async () => {
   // Context compaction was the only violet in the app, spent on a housekeeping
   // event the reader never asked about. The palette is neutral plus one green.


### PR DESCRIPTION
Finishes the thread #68 started. That one routed the five *"this agent is live"* greens through the token and deliberately left the rest; this is the rest.

## 21 raw greens, one meaning

| where | what it was saying |
|---|---|
| `file-card`, `bash-card`, `file-diff-card`, `background-card` | copy tick |
| `grep-card` | "approved — running" |
| `mode-indicator` | the `live` pill |
| `eval` | pass border + mark |
| `login-card` | credential accepted |
| `ask-user-card` | ×6, answered / responded |
| `file-components` | ×3, diff addition backgrounds |

Every one of them means *good / succeeded / added* — the statement the accent already makes. They now resolve through `--color-brand-*`, so the ramp is one place and changing the brand changes all of it.

The ramp already had every step these needed (`50 / 100 / 200 / 400 / 500 / 600 / 900`), so this is a substitution, not a palette extension.

## The guard is on its second attempt

I first wrote it as a **computed-colour** check over a rendered busy transcript — same instrument that works for the live dot, where Tailwind v4's `lab()` and the token's `rgb()` genuinely distinguish the two.

It passed against the unfixed code.

The greens live on states that transcript never renders: a copy tick only appears after you click, and the eval, login and diff cards were not in the scenario. The detector never saw a single one of them. **A guard that cannot see the thing it guards is worse than none** — it reads as coverage and is not.

So it greps the source now. "No component ships a raw green" is a source fact, and the class name is what a reviewer would actually type:

```
Error: these should go through --color-brand-* so the ramp is one place
+ Received  + 23
+   "components/chat/messages/eval.tsx:58: … 'border-green-200' …",
+   "components/chat/messages/eval.tsx:65: … 'text-green-500' …",
```

The rendered check remains for the live dot, where it works.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    29 passed, 8 flaky, 0 failed
```

The flakiness is all in `chat.spec.ts` and is local: `CI=1` runs a production build with full parallelism, and this machine was also building oo-frontend at the time. Every one passed on retry, and none of them touches colour. The runner's own result is the one that counts — I'll hold the merge on it rather than on my laptop's.

## Deliberately left

`components/chat/messages/tools/` still has the two-column-of-dark-blocks problem the audit ranked #4: `Read_file` renders a light bordered box, `grep` a dark full-bleed panel with a left accent rail, `bash` a dark inset one, and the agent's own code block sits at a third width. Three dark surfaces, three geometries, in one viewport. That is the next visible one, and it needs a shared `ToolBody` rather than a find-and-replace.