### PR TITLE
One rail for tool bodies, not three

### DIFF
--- a/components/chat/messages/intent.tsx
+++ b/components/chat/messages/intent.tsx
@@ -45,7 +45,7 @@ export function Intent({ intent }: { intent: IntentUI }) {
   if (isAnalyzing) {
     return (
       <div className="py-1.5">
-        <div className="flex items-center gap-2 text-xs text-neutral-500 font-mono ml-5">
+        <div className="flex items-center gap-2 text-xs text-neutral-500 font-mono ml-[60px]">
           <span className="w-2 h-2 rounded-full bg-neutral-400 animate-pulse" />
           <span>understanding</span>
           <span className="text-neutral-300">·</span>

--- a/components/chat/messages/thinking.tsx
+++ b/components/chat/messages/thinking.tsx
@@ -76,7 +76,7 @@ export function Thinking({ thinking, isLast = true, blocked = false }: {
     // says "busy" and a job that never finishes (#59).
     if (blocked) {
       return (
-        <div className="py-1.5 ml-5 flex items-center gap-1.5 text-xs">
+        <div className="py-1.5 ml-[60px] flex items-center gap-1.5 text-xs">
           <span className="w-1.5 h-1.5 rounded-full bg-neutral-900 shrink-0" />
           <span className="font-medium text-neutral-700">Waiting on your answer</span>
         </div>
@@ -85,7 +85,7 @@ export function Thinking({ thinking, isLast = true, blocked = false }: {
 
     return (
       <div className="py-1.5">
-        <div className="flex items-center gap-1.5 text-xs font-mono ml-5">
+        <div className="flex items-center gap-1.5 text-xs font-mono ml-[60px]">
           <span className="inline-block w-3 text-center text-sm leading-none text-neutral-400">{SPINNER_FRAMES[frame]}</span>
           <span className="font-medium text-neutral-500">{GERUNDS[word]}…</span>
           <span className="tabular-nums text-neutral-400">({seconds > 0 ? formatTime(seconds) : '0s'})</span>
@@ -97,7 +97,7 @@ export function Thinking({ thinking, isLast = true, blocked = false }: {
   // Content state (e.g. detailed thoughts)
   if (thinking.content) {
     return (
-      <div className="py-2 ml-5">
+      <div className="py-2 ml-[60px]">
         <div className="relative pl-4 border-l-2 border-neutral-200">
           <div className="text-[13px] text-neutral-600 leading-relaxed italic">
             {thinking.content}
@@ -119,7 +119,7 @@ export function Thinking({ thinking, isLast = true, blocked = false }: {
     return (
       <div className="py-1.5">
         {/* Stats stay one line — the model name truncates first on narrow screens */}
-        <div className="flex items-center gap-2 overflow-hidden whitespace-nowrap text-xs text-neutral-400 font-mono ml-5">
+        <div className="flex items-center gap-2 overflow-hidden whitespace-nowrap text-xs text-neutral-400 font-mono ml-[60px]">
           <span className="w-1.5 h-1.5 shrink-0 rounded-full bg-neutral-300" />
           <span className="min-w-0 truncate">{model || 'done'}</span>
           <span className="text-neutral-300">·</span>

--- a/components/chat/messages/tools/ask-user-card.tsx
+++ b/components/chat/messages/tools/ask-user-card.tsx
@@ -144,7 +144,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
 
       {/* Content */}
       {isExpanded && (
-        <div className="mt-3 ml-5 space-y-4">
+        <div className="mt-3 ml-[60px] space-y-4">
           {/* Question */}
           <div className="text-[15px] text-neutral-800 whitespace-pre-wrap leading-relaxed">
             {question}

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -223,7 +223,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
 
       {/* Terminal Block — Claude Code style: only rendered when expanded; collapsed = header row only */}
       {isExpanded && (
-      <div className="ml-5">
+      <div className="ml-[60px]">
         <div className="bg-[#1e1e1e] rounded-lg overflow-hidden relative group/terminal">
           <div
             className="cursor-pointer"
@@ -279,7 +279,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
 
       {/* Approval Buttons */}
       {needsApproval && status === 'running' && (
-        <div className="mt-4 ml-5 animate-in fade-in slide-in-from-top-2 duration-400">
+        <div className="mt-4 ml-[60px] animate-in fade-in slide-in-from-top-2 duration-400">
           <ApprovalButtons approvalSent={approvalSent} onApproval={handleApproval} toolName={commandName} description={pendingApproval?.description} batchRemaining={pendingApproval?.batch_remaining} />
         </div>
       )}

--- a/components/chat/messages/tools/browser-card.tsx
+++ b/components/chat/messages/tools/browser-card.tsx
@@ -172,17 +172,17 @@ export function BrowserCard({ toolCall, pendingApproval, onApprovalResponse }: B
 
       {/* Collapsed error rows surface the failure reason inline — one truncated line */}
       {isError && hasOutput && !isExpanded && (
-        <div className="ml-7 mb-1 truncate text-xs text-red-600/80">{result.split('\n')[0]}</div>
+        <div className="ml-[60px] mb-1 truncate text-xs text-red-600/80">{result.split('\n')[0]}</div>
       )}
 
       {needsApproval && status === 'running' && (
-        <div className="mt-2 ml-5 mb-2">
+        <div className="mt-2 ml-[60px] mb-2">
           <ApprovalButtons approvalSent={approvalSent} onApproval={handleApproval} toolName={name} description={pendingApproval?.description} batchRemaining={pendingApproval?.batch_remaining} />
         </div>
       )}
 
       {isExpanded && (hasArgs || hasOutput) && (
-        <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
+        <div className="animate-in mb-1 ml-[60px] overflow-hidden rounded-md border border-neutral-200 bg-white">
           {hasArgs && (
             <div className={`px-3 py-2.5 ${hasOutput ? 'border-b border-neutral-100' : ''}`}>
               <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Arguments</div>

--- a/components/chat/messages/tools/enter-plan-mode-card.tsx
+++ b/components/chat/messages/tools/enter-plan-mode-card.tsx
@@ -29,7 +29,7 @@ export function EnterPlanModeCard({ toolCall }: EnterPlanModeCardProps) {
       </div>
 
       {/* Info Card */}
-      <div className="ml-5 mt-2">
+      <div className="ml-[60px] mt-2">
         <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4">
           <div className="flex gap-3">
             <div className="shrink-0 mt-0.5">

--- a/components/chat/messages/tools/file-diff-card.tsx
+++ b/components/chat/messages/tools/file-diff-card.tsx
@@ -55,7 +55,7 @@ export function FileDiffCard({ toolCall, pendingApproval, onApprovalResponse }: 
         needsApproval={!!pendingApproval}
       />
       
-      <div className="ml-5 relative group/card">
+      <div className="ml-[60px] relative group/card">
         <FileCodePeek content={diffContent} filePath={filePath} isDiff onClick={() => setIsFullscreen(true)} />
         
         {/* Quick actions */}
@@ -77,7 +77,7 @@ export function FileDiffCard({ toolCall, pendingApproval, onApprovalResponse }: 
       </Modal>
 
       {!!pendingApproval && status === 'running' && (
-        <div className="mt-4 ml-5">
+        <div className="mt-4 ml-[60px]">
           <ApprovalButtons 
             approvalSent={approvalSent} onApproval={handleApproval} 
             toolName={name} description={pendingApproval.description} 

--- a/components/chat/messages/tools/generic-card.tsx
+++ b/components/chat/messages/tools/generic-card.tsx
@@ -106,19 +106,19 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
 
       {/* Collapsed error rows surface the failure reason inline — one truncated line */}
       {isError && hasOutput && !isExpanded && (
-        <div className="ml-7 mb-1 truncate text-xs text-red-600/80">{result.split('\n')[0]}</div>
+        <div className="ml-[60px] mb-1 truncate text-xs text-red-600/80">{result.split('\n')[0]}</div>
       )}
 
       {/* Approval - separate from tool display */}
       {needsApproval && status === 'running' && (
-        <div className="mt-2 ml-5 mb-2">
+        <div className="mt-2 ml-[60px] mb-2">
           <ApprovalButtons approvalSent={approvalSent} onApproval={handleApproval} toolName={name} description={pendingApproval?.description} batchRemaining={pendingApproval?.batch_remaining} />
         </div>
       )}
 
       {/* Arguments — inspectable while awaiting approval, so users can see what they're approving */}
       {needsApproval && hasArgs && isExpanded && (
-        <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
+        <div className="animate-in mb-1 ml-[60px] overflow-hidden rounded-md border border-neutral-200 bg-white">
           <div className="px-3 py-2.5">
             <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Arguments</div>
             <KVRows data={args} />
@@ -128,7 +128,7 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
 
       {/* Output */}
       {!needsApproval && hasOutput && isExpanded && (
-        <div className="animate-in mb-1 ml-7 overflow-hidden rounded-md border border-neutral-200 bg-white">
+        <div className="animate-in mb-1 ml-[60px] overflow-hidden rounded-md border border-neutral-200 bg-white">
           <div className={`px-3 py-2.5 ${isError ? 'bg-red-50/50' : ''}`}>
             <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500">Result</div>
             {typeof parsedResult === 'string' ? (

--- a/components/chat/messages/tools/grep-card.tsx
+++ b/components/chat/messages/tools/grep-card.tsx
@@ -157,7 +157,7 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
           preview and the chevron stopped meaning anything. The collapsed summary
           it was duplicating already lives in the header meta ("0.1s · 3 files"). */}
       {isExpanded && hasOutput && (
-        <div className="mt-2 ml-5 bg-[#272822] rounded-lg overflow-hidden">
+        <div className="mt-2 ml-[60px] bg-[#272822] rounded-lg overflow-hidden">
           <div
             className="cursor-pointer"
             onClick={() => setIsExpanded(!isExpanded)}
@@ -179,14 +179,14 @@ export function GrepCard({ toolCall, pendingApproval, onApprovalResponse }: Grep
 
       {/* Approval - separate from terminal block */}
       {needsApproval && status === 'running' && (
-        <div className="mt-2 ml-5">
+        <div className="mt-2 ml-[60px]">
           <ApprovalButtons approvalSent={approvalSent} onApproval={handleApproval} toolName="Grep" description={pendingApproval?.description} batchRemaining={pendingApproval?.batch_remaining} />
         </div>
       )}
 
       {/* No output state */}
       {!hasOutput && status === 'done' && (
-        <div className="mt-2 ml-5 bg-[#272822] rounded-lg p-3">
+        <div className="mt-2 ml-[60px] bg-[#272822] rounded-lg p-3">
           <span className="text-[#75715E] text-xs font-mono">(no matches found)</span>
         </div>
       )}

--- a/components/chat/messages/tools/guide-card.tsx
+++ b/components/chat/messages/tools/guide-card.tsx
@@ -101,7 +101,7 @@ export function GuideCard({ toolCall }: GuideCardProps) {
       {!isExpanded && content && (
         <button
           onClick={() => setIsExpanded(true)}
-          className="ml-5 mt-1.5 text-left w-full"
+          className="ml-[60px] mt-1.5 text-left w-full"
         >
           <div className="text-xs text-neutral-600 truncate max-w-md">
             {firstHeading && <span className="font-medium">{firstHeading}</span>}
@@ -113,7 +113,7 @@ export function GuideCard({ toolCall }: GuideCardProps) {
 
       {/* Expanded Content */}
       {isExpanded && content && (
-        <div className="ml-5 mt-2 relative group/card">
+        <div className="ml-[60px] mt-2 relative group/card">
           <div
             onClick={() => setIsFullscreen(true)}
             className="cursor-pointer rounded-lg border border-neutral-200 bg-neutral-50 overflow-hidden hover:border-neutral-300 transition-colors"

--- a/components/chat/messages/tools/plan-card.tsx
+++ b/components/chat/messages/tools/plan-card.tsx
@@ -265,7 +265,7 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
       </div>
 
       {/* Plan Preview */}
-      <div className="ml-5 mt-2 relative group/card">
+      <div className="ml-[60px] mt-2 relative group/card">
         <div
           onClick={() => setIsFullscreen(true)}
           className="cursor-pointer rounded-lg border border-neutral-200 bg-neutral-50 overflow-hidden hover:border-neutral-300 transition-colors"
@@ -527,7 +527,7 @@ export function PlanCard({ toolCall, pendingPlanReview, onPlanReviewResponse }: 
 
       {/* Approve / Reject Buttons */}
       {!!pendingPlanReview && status === 'running' && !approvalSent && (
-        <div className="mt-4 ml-5 flex items-center gap-3">
+        <div className="mt-4 ml-[60px] flex items-center gap-3">
           <button
             onClick={handleApprove}
             className="px-4 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-semibold transition-colors"

--- a/e2e/transcript.spec.ts
+++ b/e2e/transcript.spec.ts
@@ -158,6 +158,44 @@ test('one status mark, drawn one way', async ({ page }) => {
   }
 })
 
+test('every tool body hangs off the same rail as its title', async ({ page, shot }) => {
+  // Waits for a full run, opens four cards, then screenshots twice — past the
+  // 30s default once the fixture's own capture is counted.
+  test.setTimeout(90_000)
+  await busyTranscript(page)
+
+  for (const button of await page.getByRole('button').filter({ hasText: /Read_file|Bash|grep|write_file/ }).all()) {
+    await button.click().catch(() => {})
+  }
+  await page.waitForTimeout(500)
+
+  // Bodies used to sit on three different rails — ml-5 (20px), ml-7 (28px) and
+  // ml-[60px] — so a card's output started somewhere its own title did not,
+  // and two adjacent cards indented differently for no reason a reader could see.
+  const edges = await page.evaluate(() => {
+    const log = document.querySelector('[role="log"]')!
+    const out: number[] = []
+    for (const el of log.querySelectorAll('div, pre')) {
+      const style = getComputedStyle(el)
+      const r = el.getBoundingClientRect()
+      // Panels only: something with its own surface, big enough to be a body.
+      if (r.height > 40 && r.width > 200 && style.backgroundColor !== 'rgba(0, 0, 0, 0)') out.push(Math.round(r.x))
+    }
+    return [...new Set(out)].sort((a, b) => a - b)
+  })
+
+  // Two rails are correct: one for tool bodies, one for the agent's own prose
+  // column, which is avatar-aligned and deliberately narrower. Three means the
+  // tool bodies disagree with each other — which they did, at 428 and 460.
+  //
+  // Counting distinct edges rather than measuring a spread, because a spread
+  // over a filtered set was my first attempt and it passed on the broken code:
+  // the filter I used to exclude the prose column also excluded the disagreement.
+  expect(edges.length, `expected two rails, got ${edges.join(', ')}`).toBeLessThanOrEqual(2)
+
+  await shot('expanded')
+})
+
 test('desktop keeps the same grammar', async ({ page, shot }) => {
   await busyTranscript(page)
   await expect(page.getByText('exit 0 · 4.2s')).toBeVisible()


### PR DESCRIPTION
Measured before touching anything. On an expanded transcript the output panels started at **three different x positions**:

```
428   generic-card    (ml-7)
444   agent prose     (avatar-aligned)
460   file-card       (ml-[60px])
```

`ml-5`, `ml-7` and `ml-[60px]` were being used interchangeably — 25 occurrences across 14 files — so a card's own output began somewhere its title did not, and two adjacent cards indented differently for no reason a reader could see.

All tool bodies now hang off the same **60px rail the titles already use**, so a body lines up under the name it belongs to.

## What I deliberately did *not* change

The agent's prose column stays at 444.

It is avatar-aligned and `max-w-[85%]`, which is why its code block ends 89px short of the tool panels. That looked like a fourth inconsistency, and it is not one: it is a **reading measure**, symmetric with the user bubble on the other side. Widening it to match the tool bodies would make prose harder to read — the opposite of the point.

Two rails is the right answer here, not one. The spec encodes exactly that.

## The spec is on its second attempt, again

First version measured the *spread* of body left-edges and passed against the broken code. The filter I wrote to exclude the prose column — "keep only the rightmost group" — also excluded the disagreement I was looking for. Two PRs in a row now where my first instrument could not see the thing it was guarding.

It counts **distinct** edges instead:

```
Error: expected two rails, got 428, 444, 460
```

Also needed `test.setTimeout(90_000)` — the test waits for a full run, opens four cards and screenshots twice, and the fixture's own capture counts toward the same budget. It was timing out at 30s and reporting that as a failure, which is not the failure I wanted it to be capable of.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    32 passed, 6 flaky, 0 failed
```

Flakiness is the same local contention as #73 — `CI=1` builds and runs fully parallel on a machine that is also doing other work; the runner reported 37/0 there. Holding the merge on the runner, not on this.

## Deliberately left

The three dark surfaces still have three radii (4px, 6px, 8px) and the grep panel keeps its left accent rail, which is a fifth device doing a job the shared inset now does. Those want the shared `ToolBody` component rather than another find-and-replace — this PR fixed the geometry that was measurable and visible; the surface treatment is a component change.