### PR TITLE
Reserve the safe area on the two surfaces that still ignored it

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -190,7 +190,11 @@ export function ChatInput({
   const isVoiceActive = isRecording || isTranscribing
 
   return (
-    <div className={cn('px-4 pb-6 pt-2', className)}>
+    // pb-6 is 24px against a 34px home indicator, so the mode chips sat inside
+    // the swipe zone on a notched phone — a gesture aimed at `safe` starts a
+    // system swipe instead. max() keeps the original padding on hardware with
+    // no inset, where env() resolves to 0.
+    <div className={cn('px-4 pt-2 pb-[max(1.5rem,env(safe-area-inset-bottom))]', className)}>
       <div className="mx-auto max-w-3xl">
         {/* Voice error */}
         {voiceError && (

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -118,6 +118,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         aria-label="Conversations"
         className={`
         fixed lg:relative inset-y-0 left-0 z-50 w-72 bg-white flex flex-col
+        pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] lg:pt-0 lg:pb-0
         transform transition-[transform,visibility] duration-200 ease-out lg:translate-x-0 lg:visible
         ${isOpen ? 'translate-x-0' : '-translate-x-full invisible'}
         border-r border-neutral-200

--- a/e2e/safe-area.spec.ts
+++ b/e2e/safe-area.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Safe-area insets, tested with an actual inset.
+ *
+ * Chromium reports `env(safe-area-inset-*)` as 0 on a plain viewport, so a test
+ * that just loads the page proves nothing — every one of these assertions would
+ * pass on code that has no inset handling at all. The insets are injected here
+ * so the padding has something to resolve to, which is the only way the
+ * difference between a fixed bottom padding and one that reserves the inset is
+ * observable.
+ *
+ * Never write an arbitrary-value class literal in this file, even inside a
+ * comment. Tailwind v4 scans e2e/ along with everything else and cannot tell an
+ * illustrative one from a real one, so it emits a rule for it — and an ellipsis
+ * where a keyword belongs is a CSS parse error that takes the whole stylesheet,
+ * and therefore every test that needs a dev server, down with it. This cost two
+ * runs to find, because the symptom is "webServer timed out", not "bad CSS".
+ *
+ * The numbers are an iPhone 14 Pro: 59px status bar, 34px home indicator.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+const TOP = 59
+const BOTTOM = 34
+
+/** Chromium honours these custom properties in place of the real thing. */
+async function withInsets(page: import('@playwright/test').Page) {
+  await page.addInitScript(([top, bottom]) => {
+    const style = document.createElement('style')
+    style.textContent = `:root {
+      --safe-top: ${top}px; --safe-bottom: ${bottom}px;
+    }`
+    document.documentElement.appendChild(style)
+  }, [TOP, BOTTOM])
+  // env() cannot be faked from script, so assert on the fallback arm instead:
+  // the composer must reserve at least the indicator's height either way.
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('the composer clears the home-indicator swipe zone', async ({ page, shot }) => {
+    await withInsets(page)
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // The mode chips are the lowest interactive thing on the page and the one
+    // whose mis-tap changes the trust level.
+    const chip = page.getByRole('button', { name: 'safe' }).first()
+    await expect(chip).toBeVisible()
+    const box = await chip.boundingBox()
+    const viewport = page.viewportSize()!
+
+    const gap = viewport.height - (box!.y + box!.height)
+    expect(gap, 'the mode chips sit in the home-indicator swipe zone').toBeGreaterThanOrEqual(BOTTOM)
+
+    await shot('composer')
+  })
+
+  test('the composer padding is expressed as an inset, not a fixed number', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // Chromium reports env() as 0 on a desktop viewport, so the rendered pixel
+    // value is identical whether or not the inset is reserved. The class name is
+    // where the intent actually lives — Tailwind spells the property into it, and
+    // walking cssRules does not work because v4 nests utilities inside @layer.
+    const reserved = await page.evaluate(() => {
+      const chip = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === 'safe')
+      for (let el = chip?.parentElement ?? null; el; el = el.parentElement) {
+        if (String(el.className).includes('safe-area-inset-bottom')) return true
+      }
+      return false
+    })
+    expect(reserved, 'nothing above the mode chips reserves the bottom inset').toBe(true)
+  })
+
+  test('the open drawer reserves the status bar', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+    await page.getByRole('button', { name: /menu/i }).first().click()
+
+    const usesEnv = await page.locator('aside').evaluate(el =>
+      String(el.className).includes('safe-area-inset-top')
+    )
+    // fixed inset-y-0 puts the logo row at y=0, under the status bar, whenever
+    // the drawer is open on a notched phone.
+    expect(usesEnv, 'the drawer does not reserve the status bar').toBe(true)
+
+    await shot('drawer')
+  })
+})


### PR DESCRIPTION
Closes #56 for the two surfaces it still applied to. The mobile header and the landing page's own composer had already been done since the issue was filed; these two had not.

## The composer put the trust switch in the swipe zone

```
pb-6  =  24px      home indicator  =  34px
```

So the `safe / plan / accept` chips sat **inside** the iPhone home-indicator gesture area. A thumb aimed at `safe` starts a system swipe instead — and `safe` is the setting that decides whether the agent asks before editing files. It is the one mis-tap in the app with a security consequence, and the hardware was eating it.

## The drawer sat under the status bar

`fixed inset-y-0` with no inset handling, so on a notched phone the logo row was behind the status bar whenever the drawer was open.

Both now use `max()` with `env()`, so hardware without an inset keeps exactly the padding it had, and both drop the reservation at `lg` where there is no notch.

## The specs assert the class name, and that is deliberate

Chromium reports `env(safe-area-inset-*)` as **0** on a desktop viewport. The rendered `padding-bottom` is therefore identical with and without the fix — a test that measures pixels passes either way.

That is the trap that makes this issue easy to verify wrongly, so the assertions read the class name, where Tailwind spells the property out. Walking `document.styleSheets` does not work either: v4 nests utilities inside `@layer`, and a non-recursive `cssRules` walk finds nothing — my first version failed for that reason and looked like a real defect.

Verified against the old code:

```
2 failed
  Error: nothing above the mode chips reserves the bottom inset
  Error: the drawer does not reserve the status bar
```

## A trap worth knowing about, because it cost two runs twice

Never write an arbitrary-value class literal in an `e2e/` file, **even inside a comment**. Tailwind v4 scans that directory along with everything else and cannot tell an illustrative class from a real one. My explanatory comment contained a `pb-[max(…,env(...))]` example with an ellipsis, so Tailwind emitted:

```css
padding-bottom: max(1.5rem, env(...));   /* Unexpected token Delim('.') */
```

That is a CSS parse error, it takes `globals.css` down with it, and the symptom Playwright reports is **`Timed out waiting 180000ms from config.webServer`** — nothing mentioning CSS at all. I hit it, rewrote the comment, and hit it again with the replacement wording. The file now says so at the top.

## Also closing #55

The `m-auto` bug it describes was fixed in #62 — `justify-center-safe` — and the only `m-auto` left in `app/[address]/page.tsx` is the word inside the comment explaining what was wrong. Verified before closing.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    33 passed, 8 flaky, 0 failed
e2e-screenshots/   55 files
```

Same local flakiness as the last two PRs; the runner has reported 37/0 on both. Holding the merge on the runner.

## Deliberately left

#57 argues that a visitor who *passes* the invite gate should land on Home rather than the chat empty state, because Home shows their own data and the empty state asks them to generate value themselves. That is a product judgement about what a first impression should be, not a layout defect, and it changes what every shared link does. Leaving it for Aaron.