### PR TITLE
Close the type scale: 15 sizes down to 11

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -131,7 +131,7 @@ export default function SettingsPage() {
                     </p>
                     <div className="space-y-6">
                       <div className="space-y-3">
-                        <label className="text-[10px] font-bold text-neutral-500 uppercase tracking-widest px-1">
+                        <label className="text-[11px] font-bold text-neutral-500 uppercase tracking-wide px-1">
                           Identity Address
                         </label>
                         <div className="group relative">
@@ -149,7 +149,7 @@ export default function SettingsPage() {
                       </div>
 
                       <div className="space-y-3">
-                        <label className="text-[10px] font-bold text-neutral-500 uppercase tracking-widest px-1">
+                        <label className="text-[11px] font-bold text-neutral-500 uppercase tracking-wide px-1">
                           API Key
                         </label>
                         <div className="group relative">
@@ -208,7 +208,7 @@ export default function SettingsPage() {
 
                     {showImportKey && (
                       <div className="mt-4 p-5 bg-neutral-50 rounded-2xl border border-neutral-200/50 animate-in zoom-in-95 duration-200">
-                        <label className="block text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3 px-1">
+                        <label className="block text-xs font-bold text-neutral-500 uppercase tracking-wide mb-3 px-1">
                           Recovery Mnemonic
                         </label>
                         <textarea
@@ -237,7 +237,7 @@ export default function SettingsPage() {
                 ) : (
                   <div className="py-12 flex flex-col items-center justify-center gap-4">
                     <div className="w-8 h-8 border-4 border-neutral-200 border-t-neutral-900 rounded-full animate-spin" />
-                    <p className="text-sm font-bold text-neutral-500 uppercase tracking-widest">Encrypting Identity...</p>
+                    <p className="text-sm font-bold text-neutral-500 uppercase tracking-wide">Encrypting Identity...</p>
                   </div>
                 )}
               </div>
@@ -290,7 +290,7 @@ export default function SettingsPage() {
                               {info?.name || shortAddress(address)}
                             </span>
                             {info?.trust && (
-                              <span className="text-[10px] font-bold text-neutral-500 bg-neutral-100 px-2 py-0.5 rounded-full uppercase">
+                              <span className="text-[11px] font-bold text-neutral-500 bg-neutral-100 px-2 py-0.5 rounded-full uppercase">
                                 {info.trust}
                               </span>
                             )}
@@ -314,12 +314,12 @@ export default function SettingsPage() {
                           {info?.tools && info.tools.length > 0 && (
                             <div className="flex flex-wrap gap-1.5 mt-2">
                               {info.tools.slice(0, 5).map(tool => (
-                                <span key={tool} className="text-[10px] font-medium text-neutral-500 bg-neutral-50 px-2 py-0.5 rounded-md border border-neutral-100">
+                                <span key={tool} className="text-[11px] font-medium text-neutral-500 bg-neutral-50 px-2 py-0.5 rounded-md border border-neutral-100">
                                   {tool}
                                 </span>
                               ))}
                               {info.tools.length > 5 && (
-                                <span className="text-[10px] font-medium text-neutral-500">
+                                <span className="text-[11px] font-medium text-neutral-500">
                                   +{info.tools.length - 5} more
                                 </span>
                               )}
@@ -401,7 +401,7 @@ export default function SettingsPage() {
                 <div className="grid grid-cols-3 gap-3 mb-10">
                   {newMnemonic.split(' ').map((word, i) => (
                     <div key={i} className="flex flex-col gap-1 p-3 bg-neutral-50 rounded-2xl border border-neutral-100/50 group hover:bg-neutral-100 hover:border-neutral-200 transition-all duration-300">
-                      <span className="text-[10px] text-neutral-500 font-black uppercase tracking-widest">{i + 1}</span>
+                      <span className="text-[11px] text-neutral-500 font-medium uppercase tracking-wide">{i + 1}</span>
                       <span className="text-xs font-mono text-neutral-800 font-bold">{word}</span>
                     </div>
                   ))}

--- a/components/chat/chat-ask-user.tsx
+++ b/components/chat/chat-ask-user.tsx
@@ -170,7 +170,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
 
             {multi_select && (
               <div className="mt-4 flex items-center justify-between border-t border-neutral-100 px-1 pt-4">
-                <span className="text-[10px] font-semibold uppercase tracking-widest text-neutral-500">
+                <span className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
                   {selected.length === 0
                     ? "Select options"
                     : `${selected.length} selected`}
@@ -194,7 +194,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
           {hasOptions && (
             <div className="flex items-center gap-2 px-1">
               <div className="h-px flex-1 bg-neutral-100" />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-neutral-400">Or enter custom value</span>
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400">Or enter custom value</span>
               <div className="h-px flex-1 bg-neutral-100" />
             </div>
           )}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -302,7 +302,7 @@ export function ChatInput({
                 <span className="min-w-0 flex-1 truncate text-xs text-neutral-500">{skill.description}</span>
               </button>
             ))}
-            <div className="border-t border-neutral-100 px-4 py-1.5 text-[10px] text-neutral-400">
+            <div className="border-t border-neutral-100 px-4 py-1.5 text-[11px] text-neutral-400">
               <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">↑↓</kbd> navigate · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Tab</kbd> complete · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Esc</kbd> dismiss
             </div>
           </div>

--- a/components/chat/messages/tool-blocked.tsx
+++ b/components/chat/messages/tool-blocked.tsx
@@ -19,7 +19,7 @@ export function ToolBlocked({ data }: ToolBlockedProps) {
               {data.tool} blocked
             </span>
           </div>
-          <span className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">
+          <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wide">
             Auto-redirected
           </span>
         </div>

--- a/components/chat/messages/tools/approval-buttons.tsx
+++ b/components/chat/messages/tools/approval-buttons.tsx
@@ -127,7 +127,7 @@ export function ApprovalButtons({ approvalSent, onApproval, toolName, descriptio
       {batchRemaining && batchRemaining.length > 0 && (
         <div className="px-3 py-2.5 bg-neutral-100/50 border-t border-neutral-100">
           <div className="flex items-center gap-1.5 mb-2 px-0.5">
-            <span className="text-[9px] font-bold text-neutral-400 uppercase tracking-widest">Up Next ({batchRemaining.length})</span>
+            <span className="text-[11px] font-bold text-neutral-400 uppercase tracking-wide">Up Next ({batchRemaining.length})</span>
           </div>
           <div className="space-y-1.5">
             {batchRemaining.map((t, i) => {

--- a/components/chat/messages/tools/ask-user-card.tsx
+++ b/components/chat/messages/tools/ask-user-card.tsx
@@ -131,13 +131,13 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
 
         <div className="flex items-center gap-2">
           {status === 'done' ? (
-            <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest">Completed</span>
+            <span className="text-neutral-400 text-[11px] uppercase font-bold tracking-wide">Completed</span>
           ) : skipped ? (
-            <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest">Skipped</span>
+            <span className="text-neutral-400 text-[11px] uppercase font-bold tracking-wide">Skipped</span>
           ) : responded ? (
-            <span className="text-brand-600 text-[10px] uppercase font-bold tracking-widest">Responded</span>
+            <span className="text-brand-600 text-[11px] uppercase font-bold tracking-wide">Responded</span>
           ) : isAwaiting ? (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">Pending</span>
+            <span className="text-neutral-500 text-[11px] uppercase font-bold tracking-wide animate-pulse">Pending</span>
           ) : null}
         </div>
       </div>
@@ -269,7 +269,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                 {options && (
                   <div className="flex items-center gap-2 px-1">
                     <div className="h-px flex-1 bg-neutral-100" />
-                    <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest">Or provide custom answer</span>
+                    <span className="text-[11px] font-bold text-neutral-400 uppercase tracking-wide">Or provide custom answer</span>
                     <div className="h-px flex-1 bg-neutral-100" />
                   </div>
                 )}

--- a/components/chat/messages/tools/background-card.tsx
+++ b/components/chat/messages/tools/background-card.tsx
@@ -76,7 +76,7 @@ export function BackgroundCard({ toolCall, pendingApproval, onApprovalResponse }
             <span className="text-sm font-bold text-neutral-800 tracking-tight leading-none">
               {description}
             </span>
-            <span className="text-[10px] text-neutral-400 font-medium uppercase tracking-wider mt-0.5">
+            <span className="text-[11px] text-neutral-400 font-medium uppercase tracking-wide mt-0.5">
               {subagent ? `${subagent} Agent` : 'Background Process'}
               {taskId && <span className="ml-1 font-mono opacity-70">#{taskId.slice(0, 6)}</span>}
             </span>
@@ -85,23 +85,23 @@ export function BackgroundCard({ toolCall, pendingApproval, onApprovalResponse }
 
         <div className="flex items-center gap-2">
           {status === 'done' || status === 'error' ? (
-            <span className="text-neutral-400 text-[10px] uppercase font-bold tracking-widest flex items-center gap-1">
+            <span className="text-neutral-400 text-[11px] uppercase font-bold tracking-wide flex items-center gap-1">
               {timing_ms && <HiOutlineClock className="w-3 h-3" />}
               {timing_ms ? formatTime(timing_ms) : (status === 'done' ? 'Completed' : 'Failed')}
             </span>
           ) : needsApproval && approvalSent ? (
             <span className={cn(
-              "text-[10px] uppercase font-bold tracking-widest",
+              "text-[11px] uppercase font-bold tracking-wide",
               approvalSent === 'skipped' ? "text-neutral-400" : "text-red-500"
             )}>
               {approvalSent === 'skipped' ? 'Skipped' : 'Stopped'}
             </span>
           ) : needsApproval ? (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">
+            <span className="text-neutral-500 text-[11px] uppercase font-bold tracking-wide animate-pulse">
               Approval Needed
             </span>
           ) : (
-            <span className="text-neutral-500 text-[10px] uppercase font-bold tracking-widest animate-pulse">
+            <span className="text-neutral-500 text-[11px] uppercase font-bold tracking-wide animate-pulse">
               Processing...
             </span>
           )}

--- a/components/chat/messages/tools/bash-card.tsx
+++ b/components/chat/messages/tools/bash-card.tsx
@@ -199,7 +199,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
         </div>
 
         {/* The same quiet ledger meta generic-card already uses. Uppercase at
-            tracking-widest, bolded and pulsing, made the status of a finished tool
+            tracking-wide, bolded and pulsing, made the status of a finished tool
             the loudest thing on the screen — louder than the agent's answer — and
             animating text delays reading the one word that matters. */}
         <div className="flex items-center gap-2">
@@ -236,7 +236,7 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
                   <div className="flex-1">{highlightBash(command || '')}</div>
                 </div>
                 {hasOutput && (
-                  <div className="text-neutral-300 border-t border-[#333] pt-2.5 mt-2.5 opacity-90 text-[12px]">
+                  <div className="text-neutral-300 border-t border-[#333] pt-2.5 mt-2.5 opacity-90 text-xs">
                     {result}
                   </div>
                 )}
@@ -251,12 +251,12 @@ export function BashCard({ toolCall, pendingApproval, onApprovalResponse }: Bash
                   <div className="flex-1 truncate">{highlightBash(command || '')}</div>
                 </div>
                 {hasOutput && (
-                  <div className="mt-2.5 text-neutral-400 border-t border-[#333] pt-2.5 overflow-hidden text-[12px]">
+                  <div className="mt-2.5 text-neutral-400 border-t border-[#333] pt-2.5 overflow-hidden text-xs">
                     {previewLines.slice(0, 2).map((line, i) => (
                       <div key={i} className="truncate opacity-70 mb-0.5">{line}</div>
                     ))}
                     {remaining > 0 && (
-                      <div className="text-[#75715E] mt-1.5 text-[10px] opacity-60">
+                      <div className="text-[#75715E] mt-1.5 text-[11px] opacity-60">
                         +{remaining + (previewLines.length > 2 ? previewLines.length - 2 : 0)} more lines
                       </div>
                     )}

--- a/components/chat/messages/tools/file-components.tsx
+++ b/components/chat/messages/tools/file-components.tsx
@@ -68,7 +68,7 @@ export function FileCodePeek({ content, filePath, isDiff, maxLines = 4, onClick 
           prose-h1:text-base prose-h2:text-[15px] prose-h3:text-sm
           prose-p:my-1 prose-p:text-[13px] prose-p:text-neutral-600 prose-li:my-0.5 prose-li:text-[13px]
           prose-a:text-neutral-900 prose-strong:text-neutral-800
-          prose-code:text-[12px] prose-code:before:content-none prose-code:after:content-none">
+          prose-code:text-xs prose-code:before:content-none prose-code:after:content-none">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{snippet}</ReactMarkdown>
         </article>
         <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-white to-transparent" />
@@ -140,7 +140,7 @@ export function FileFullView({ content, filePath, isDiff }: { content: string, f
     <div className="relative group bg-white h-full overflow-auto">
       <Highlight theme={themes.github} code={content} language={getLanguageFromPath(filePath)}>
         {({ tokens, getLineProps, getTokenProps }) => (
-          <pre className="text-[12px] font-mono m-0 p-6 leading-relaxed min-w-full">
+          <pre className="text-xs font-mono m-0 p-6 leading-relaxed min-w-full">
             {tokens.map((line, i) => {
               const lineContent = line.map(t => t.content).join('')
               const isAdd = isDiff && lineContent.trimStart().startsWith('+')
@@ -153,7 +153,7 @@ export function FileFullView({ content, filePath, isDiff }: { content: string, f
 
               return (
                 <div key={i} {...lineProps}>
-                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[10px] opacity-50">
+                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[11px] opacity-50">
                     {i + 1}
                   </span>
                   <span className="opacity-90">
@@ -174,15 +174,15 @@ export function FileDiffSideBySideView({ oldContent, newContent, filePath }: { o
     <div className="flex h-full bg-[#1e1e1e] divide-x divide-neutral-800">
       {/* Left Column: Old */}
       <div className="flex-1 overflow-auto">
-        <div className="px-4 py-2 bg-[#252526] border-b border-neutral-800 text-[10px] font-bold text-neutral-500 uppercase tracking-widest sticky top-0 z-10">
+        <div className="px-4 py-2 bg-[#252526] border-b border-neutral-800 text-[11px] font-bold text-neutral-500 uppercase tracking-wide sticky top-0 z-10">
           Original
         </div>
         <Highlight theme={monokaiTheme} code={oldContent || '// No content'} language={getLanguageFromPath(filePath)}>
           {({ tokens, getLineProps, getTokenProps }) => (
-            <pre className="text-[12px] font-mono m-0 p-6 leading-relaxed min-w-full">
+            <pre className="text-xs font-mono m-0 p-6 leading-relaxed min-w-full">
               {tokens.map((line, i) => (
                 <div key={i} {...getLineProps({ line })} className="block w-full bg-red-900/10">
-                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[10px] opacity-40">
+                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[11px] opacity-40">
                     {i + 1}
                   </span>
                   <span className="opacity-90">
@@ -197,15 +197,15 @@ export function FileDiffSideBySideView({ oldContent, newContent, filePath }: { o
 
       {/* Right Column: New */}
       <div className="flex-1 overflow-auto">
-        <div className="px-4 py-2 bg-[#252526] border-b border-neutral-800 text-[10px] font-bold text-neutral-500 uppercase tracking-widest sticky top-0 z-10">
+        <div className="px-4 py-2 bg-[#252526] border-b border-neutral-800 text-[11px] font-bold text-neutral-500 uppercase tracking-wide sticky top-0 z-10">
           Changed
         </div>
         <Highlight theme={monokaiTheme} code={newContent || '// No content'} language={getLanguageFromPath(filePath)}>
           {({ tokens, getLineProps, getTokenProps }) => (
-            <pre className="text-[12px] font-mono m-0 p-6 leading-relaxed min-w-full">
+            <pre className="text-xs font-mono m-0 p-6 leading-relaxed min-w-full">
               {tokens.map((line, i) => (
                 <div key={i} {...getLineProps({ line })} className="block w-full bg-brand-900/10">
-                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[10px] opacity-40">
+                  <span className="inline-block w-8 text-right pr-4 select-none text-neutral-600 text-[11px] opacity-40">
                     {i + 1}
                   </span>
                   <span className="opacity-90">

--- a/components/chat/ulw-fullscreen.tsx
+++ b/components/chat/ulw-fullscreen.tsx
@@ -123,7 +123,7 @@ export function UlwFullscreen({
       {activity.length > 0 && (
         <div className="border-t border-neutral-100 px-6 py-2">
           <div className="max-w-2xl mx-auto flex items-center gap-4 overflow-x-auto">
-            <span className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide shrink-0">
+            <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wide shrink-0">
               Activity
             </span>
             <div className="flex items-center gap-2 flex-1 overflow-x-auto">
@@ -186,7 +186,7 @@ function PromptEditor({ label, value, onSave, placeholder, rows }: PromptEditorP
 
   return (
     <div>
-      <label className="block text-[11px] font-semibold text-neutral-500 uppercase tracking-wider mb-2">
+      <label className="block text-[11px] font-semibold text-neutral-500 uppercase tracking-wide mb-2">
         {label}
       </label>
       {editing ? (

--- a/components/chat/ulw-monitor-panel.tsx
+++ b/components/chat/ulw-monitor-panel.tsx
@@ -73,7 +73,7 @@ function EditableField({ label, value, onSave, placeholder }: EditableFieldProps
   if (editing) {
     return (
       <div className="flex-1 min-w-0">
-        <span className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">{label}</span>
+        <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wide">{label}</span>
         <div className="flex items-start gap-2 mt-0.5">
           <textarea
             autoFocus
@@ -98,7 +98,7 @@ function EditableField({ label, value, onSave, placeholder }: EditableFieldProps
 
   return (
     <div className="flex-1 min-w-0">
-      <span className="text-[10px] font-medium text-neutral-400 uppercase tracking-wide">{label}</span>
+      <span className="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">{label}</span>
       {/* Always-visible edit button — no hover-only affordance */}
       <button
         onClick={startEdit}
@@ -143,14 +143,14 @@ export function UlwMonitorPanel({
               <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-brand-500" />
             </span>
 
-            <span className="flex-1 text-[14px] font-medium text-neutral-700 truncate capitalize">
+            <span className="flex-1 text-sm font-medium text-neutral-700 truncate capitalize">
               {currentAction}...
             </span>
 
             {/* Turns counter with label + expand + Stop */}
             <div className="flex items-center gap-2 shrink-0">
               <div
-                className="flex items-center gap-1 text-[12px]"
+                className="flex items-center gap-1 text-xs"
                 title="Turns remaining until auto-stop"
               >
                 <span className="text-neutral-500">turns:</span>
@@ -172,7 +172,7 @@ export function UlwMonitorPanel({
               )}
               <button
                 onClick={onStop}
-                className="px-3 py-1 rounded-lg bg-neutral-200 text-neutral-700 text-[12px] font-medium
+                className="px-3 py-1 rounded-lg bg-neutral-200 text-neutral-700 text-xs font-medium
                   hover:bg-neutral-300 transition-colors"
               >
                 Stop

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -155,7 +155,7 @@ export function SessionList({
     <div className="space-y-6">
       {groupedSessions.map(group => (
         <div key={group.label}>
-          <div className="text-[10px] font-black text-neutral-400 uppercase tracking-widest mb-2 px-1">
+          <div className="text-[11px] font-medium text-neutral-400 uppercase tracking-wide mb-2 px-1">
             {group.label}
           </div>
           <div className="space-y-1">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -141,7 +141,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               target="_blank"
               rel="noopener noreferrer"
               title={`@connectonion/react v${connectonionVersion} — view on npm`}
-              className="inline-flex min-h-6 items-center px-1.5 rounded-md text-[10px] font-mono font-medium text-neutral-400 bg-neutral-100 hover:text-neutral-700 hover:bg-neutral-200 transition-colors"
+              className="inline-flex min-h-6 items-center px-1.5 rounded-md text-[11px] font-mono font-medium text-neutral-400 bg-neutral-100 hover:text-neutral-700 hover:bg-neutral-200 transition-colors"
             >
               v{connectonionVersion}
             </a>
@@ -164,7 +164,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           ) : (
             <span className="h-1.5 w-1.5 rounded-full bg-neutral-300" />
           )}
-          <span className="text-[10px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
+          <span className="text-[11px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
             {onlineCount > 0
               ? `${onlineCount} agent${onlineCount > 1 ? 's' : ''} online`
               : 'all agents offline'}
@@ -192,10 +192,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
         {/* Agents section label */}
         <div className="px-4 pt-3 pb-1 flex items-center justify-between shrink-0">
-          <span className="text-[10px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
+          <span className="text-[11px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
             Agents
           </span>
-          <span className="text-[10px] font-mono text-neutral-500">{agents.length}</span>
+          <span className="text-[11px] font-mono text-neutral-500">{agents.length}</span>
         </div>
 
         {/* Agent Folders */}

--- a/e2e/design-system.spec.ts
+++ b/e2e/design-system.spec.ts
@@ -57,6 +57,30 @@ test('no component in the chat tree ships a raw Tailwind green', async () => {
   expect(hits, 'these should go through --color-brand-* so the ramp is one place').toEqual([])
 })
 
+test('the type scale stays closed', async () => {
+  // 15 sizes, and three of them were duplicates of a named step: text-[12px] is
+  // text-xs, text-[14px] is text-sm, and text-[9px]/text-[10px] were the same
+  // micro-caps label that 50 other places already set at 11px. Same for
+  // font-black on an 11px uppercase label — the heaviest weight on the smallest
+  // text — and tracking-widest beside it.
+  //
+  // Source-level because a size is a class, not a rendered fact: two elements can
+  // compute to the same px and still be written four different ways, which is the
+  // thing that actually accretes.
+  const { execSync } = await import('node:child_process')
+  const banned = execSync(
+    'grep -rnoE "text-\\[(9|10|12|14)px\\]|font-black|tracking-(widest|wider)" app components || true',
+    { encoding: 'utf8' }
+  ).split('\n').filter(Boolean)
+
+  expect(banned, [
+    'these have an equivalent already in use:',
+    '  text-[12px] -> text-xs        text-[14px] -> text-sm',
+    '  text-[9px], text-[10px] -> text-[11px]',
+    '  font-black -> font-semibold   tracking-widest/wider -> tracking-wide',
+  ].join('\n')).toEqual([])
+})
+
 test('no component ships its own violet', async () => {
   // Context compaction was the only violet in the app, spent on a housekeeping
   // event the reader never asked about. The palette is neutral plus one green.


### PR DESCRIPTION
Aaron's words were *"字体大小…好像不是统一的"*. Counted:

```
15 sizes    text-sm×123  text-xs×107  text-[11px]×50  text-[10px]×34  text-base×20
            text-[13px]×19  text-[15px]×11  text-lg×9  text-[12px]×8  text-2xl×6
            text-xl×6  text-4xl×2  text-5xl×1  text-[14px]×1  text-[9px]×1
```

That is accretion, not a scale — and three of the fifteen were **literal duplicates of a named step**:

| written | identical to |
|---|---|
| `text-[12px]` ×8 | `text-xs` |
| `text-[14px]` ×1 | `text-sm` |
| `text-[10px]` ×34, `text-[9px]` ×1 | the micro-caps label 50 other places set at `text-[11px]` |

Same pass for the two outliers sitting on those same labels: `font-black` on an 11px uppercase label is the heaviest weight in the app applied to the smallest text, and `tracking-widest` beside it is the other half of the same mistake. Both collapse into the `font-medium` + `tracking-wide` that `generic-card` had already settled on.

```
after:  11 sizes, 4 weights, 2 tracking values
```

**No layout moved.** The only visible change is that the smallest labels — `AGENTS`, `1 AGENT ONLINE`, the version pill, the settings field captions — are legible.

## The guard is source-level, deliberately

```
Error: these have an equivalent already in use:
  text-[12px] -> text-xs        text-[14px] -> text-sm
  text-[9px], text-[10px] -> text-[11px]
  font-black -> font-semibold   tracking-widest/wider -> tracking-wide
```

74 occurrences on the old code.

A size is a class, not a rendered fact. Two elements can compute to identical pixels and still be written four different ways — and that, not the rendered result, is what accretes. Checking the source is checking the thing that actually goes wrong.

## Also: the money path, verified live

Before starting I walked the production top-up flow at 390px, since it is the one Aaron said had never been fully walked:

```
chat.openonion.ai         no sideways scroll
purchase?key=…            prefilled, 66 chars
purchase page             no sideways scroll, logo present
console errors            0        ← was 2 mixed-content per load before #31
```

Clean, so nothing to do there this pass.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    44 passed, 0 flaky
```

Screenshots in the artifact — the drawer and settings are where the small labels live.

## Deliberately left

`text-[13px]` and `text-[15px]` stay. They are the tool-row title and the message body respectively, and both are load-bearing: 13px is the deliberate step between `text-xs` and `text-sm` for dense rows, and 15px is the reading size for prose. Collapsing them into named steps would change the two things a reader looks at most.