### PR TITLE
Give the two empty screens something to say

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -12,48 +12,9 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
+import { bestOffers } from '@/components/chat/skill-offers'
 import { AgentAddress, TopUp } from '@/components/agent-address'
 
-/** A chip is a speech act — it must complete "Help me ___". Extract a short
- *  imperative from the skill description's opening (cutting at the first
- *  clause boundary), or return null so command-named skills stay off the
- *  chip row entirely rather than leaking identifiers into it. */
-function chipOffer(skill: { name: string; description?: string }): string | null {
-  const first = (skill.description || '').split(/(?<=[.!?])\s/)[0]
-  if (!first) return null
-  let cut = first
-  for (const b of [', ', '; ', ' — ', ' - ', ' in the ', ' through ', ' via ', ' using ', ' by ', ' from ', ' so ', ' and then ']) {
-    const idx = cut.indexOf(b)
-    if (idx > 0 && cut.slice(0, idx).split(' ').length >= 4) cut = cut.slice(0, idx)
-  }
-  cut = cut.replace(/[.!?,;:]\s*$/, '').trim()
-  const words = cut.split(' ')
-  // A clean offer, or no chip at all: reject over-long cuts and dangling endings
-  if (cut.length > 48 || words.length < 2) return null
-  if (/^(a|an|the|to|of|in|into|on|or|and|for|with|by|from)$/i.test(words[words.length - 1])) return null
-  return fixBrandCase(cut)
-}
-
-function fixBrandCase(text: string): string {
-  return text.replace(/linkedin/gi, 'LinkedIn').replace(/github/gi, 'GitHub').replace(/youtube/gi, 'YouTube')
-}
-
-// Chips are the agent's three BEST offers, not its three most parseable ones:
-// internal/debug utilities never make the handshake row, and offers that lead
-// with a payoff verb outrank ones that lead with mechanism.
-const INTERNAL_SKILL = /debug|capture|not for direct|called by other skills|internal/i
-const GOAL_VERB = /^(publish|post|submit|send|create|write|draft|schedule|generate|search|find|reply|engage|react|comment|log|translate|summarize|analyze|review|build|make|plan|book)\b/i
-
-function bestOffers(skills: { name: string; description?: string }[]) {
-  return skills
-    .filter(s => !INTERNAL_SKILL.test(s.name) && !INTERNAL_SKILL.test(s.description || ''))
-    .map(skill => ({ skill, offer: chipOffer(skill) }))
-    .filter((x): x is { skill: (typeof skills)[number]; offer: string } => x.offer !== null)
-    .sort((a, b) =>
-      Number(!GOAL_VERB.test(a.offer)) - Number(!GOAL_VERB.test(b.offer)) ||
-      a.offer.length - b.offer.length)
-    .slice(0, 3)
-}
 
 export default function AgentLandingPage() {
   const params = useParams()

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -350,7 +350,13 @@ export default function SettingsPage() {
                 </div>
               ) : (
                 <div className="px-8 py-12 text-center">
-                  <p className="text-sm text-neutral-500 font-medium">No agents added yet</p>
+                  {/* A sentence with no way out. Someone reaching this screen has
+                      nothing in the app yet, so it should say what to do next
+                      rather than only what is absent. */}
+                  <p className="text-sm text-neutral-600">No agents yet</p>
+                  <p className="mt-1 text-xs text-neutral-500">
+                    Paste an agent&apos;s address below, or open a link someone shared with you.
+                  </p>
                 </div>
               )}
 

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -9,6 +9,7 @@ import { StatusBar } from './messages'
 import { UlwSetupPanel } from './ulw-setup-panel'
 import { UlwMonitorPanel } from './ulw-monitor-panel'
 import { UlwFullscreen } from './ulw-fullscreen'
+import { bestOffers } from './skill-offers'
 import type { ChatProps, ThinkingUI, UserUI } from './types'
 
 export function Chat({
@@ -46,6 +47,7 @@ export function Chat({
   skills,
   agentName,
 }: ChatProps & { agentName?: string }) {
+  const offers = useMemo(() => bestOffers(skills ?? []), [skills])
   const isUlwActive = mode === 'ulw'
   const [ulwFullscreen, setUlwFullscreen] = useState(false)
 
@@ -159,6 +161,27 @@ export function Chat({
                 ? 'Connected — send a message'
                 : 'Send a message to start'}
             </p>
+
+            {/* The same three openers the landing page offers. This screen is what
+                every visitor sees after passing a gate, and it used to ask them to
+                think of something themselves in the first five seconds. Same chip
+                markup as the landing page so there is one definition of a chip. */}
+            {offers.length > 0 && (
+              <div
+                className="reveal mt-6 flex flex-wrap justify-center gap-2 px-6"
+                style={{ '--reveal-delay': '200ms' } as React.CSSProperties}
+              >
+                {offers.map(({ skill, offer }) => (
+                  <button
+                    key={skill.name}
+                    onClick={() => onSend('/' + skill.name)}
+                    className="rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-700 shadow-xs transition-all hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-sm active:translate-y-0"
+                  >
+                    {offer}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/components/chat/skill-offers.ts
+++ b/components/chat/skill-offers.ts
@@ -1,0 +1,49 @@
+/**
+ * Turning a skill's description into something worth tapping.
+ *
+ * Lived in app/[address]/page.tsx while the landing page was the only surface
+ * with an opening screen. The empty session needs the same three openers — it is
+ * the screen every visitor sees after passing a gate — so it moved here, beside
+ * the component that renders them, rather than being duplicated.
+ */
+
+/** A chip is a speech act — it must complete "Help me ___". Extract a short
+ *  imperative from the skill description's opening (cutting at the first
+ *  clause boundary), or return null so command-named skills stay off the
+ *  chip row entirely rather than leaking identifiers into it. */
+export function chipOffer(skill: { name: string; description?: string }): string | null {
+  const first = (skill.description || '').split(/(?<=[.!?])\s/)[0]
+  if (!first) return null
+  let cut = first
+  for (const b of [', ', '; ', ' — ', ' - ', ' in the ', ' through ', ' via ', ' using ', ' by ', ' from ', ' so ', ' and then ']) {
+    const idx = cut.indexOf(b)
+    if (idx > 0 && cut.slice(0, idx).split(' ').length >= 4) cut = cut.slice(0, idx)
+  }
+  cut = cut.replace(/[.!?,;:]\s*$/, '').trim()
+  const words = cut.split(' ')
+  // A clean offer, or no chip at all: reject over-long cuts and dangling endings
+  if (cut.length > 48 || words.length < 2) return null
+  if (/^(a|an|the|to|of|in|into|on|or|and|for|with|by|from)$/i.test(words[words.length - 1])) return null
+  return fixBrandCase(cut)
+}
+
+function fixBrandCase(text: string): string {
+  return text.replace(/linkedin/gi, 'LinkedIn').replace(/github/gi, 'GitHub').replace(/youtube/gi, 'YouTube')
+}
+
+// Chips are the agent's three BEST offers, not its three most parseable ones:
+// internal/debug utilities never make the handshake row, and offers that lead
+// with a payoff verb outrank ones that lead with mechanism.
+const INTERNAL_SKILL = /debug|capture|not for direct|called by other skills|internal/i
+const GOAL_VERB = /^(publish|post|submit|send|create|write|draft|schedule|generate|search|find|reply|engage|react|comment|log|translate|summarize|analyze|review|build|make|plan|book)\b/i
+
+export function bestOffers(skills: { name: string; description?: string }[]) {
+  return skills
+    .filter(s => !INTERNAL_SKILL.test(s.name) && !INTERNAL_SKILL.test(s.description || ''))
+    .map(skill => ({ skill, offer: chipOffer(skill) }))
+    .filter((x): x is { skill: (typeof skills)[number]; offer: string } => x.offer !== null)
+    .sort((a, b) =>
+      Number(!GOAL_VERB.test(a.offer)) - Number(!GOAL_VERB.test(b.offer)) ||
+      a.offer.length - b.offer.length)
+    .slice(0, 3)
+}

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * The two screens that show up when there is nothing yet.
+ *
+ * A fresh session is what every visitor sees immediately after passing an invite
+ * gate — the first thing the product says once it has let you in. It used to say
+ * "Connected — send a message" and stop, asking the reader to think of something
+ * themselves in the first five seconds, while the landing page one route away
+ * had already worked out three good openers from the agent's own skills.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+test('a fresh session offers the same openers the landing page does', async ({ page, shot }) => {
+  await mockAgent(page)
+
+  // Straight into a session with an empty transcript — the screen a visitor sees
+  // immediately after passing an invite gate.
+  await page.goto(`/${AGENT_ADDRESS}/fresh-session`)
+  await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
+
+  // The exact offer bestOffers() derives from Scriptbot's deploy skill, asserted
+  // by name. My first version compared button text between the two pages and
+  // passed on the unfixed code, because the sidebar's "Add Agent" appears on
+  // both — a comparison loose enough to match anything proves nothing.
+  const opener = page.locator('main').getByRole('button', { name: 'Ship the current branch to production' })
+  await expect(opener, 'the empty session offers nothing to say').toBeVisible()
+
+  await shot('fresh-session')
+})
+
+test('tapping an opener sends it', async ({ page }) => {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}/fresh-session-2`)
+  await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
+
+  await page.locator('main').getByRole('button', { name: 'Ship the current branch to production' }).click()
+  await expect(page.getByText(/You said:/)).toBeVisible({ timeout: 15_000 })
+})
+
+test('settings with no agents says what to do next', async ({ page, shot }) => {
+  // No mock: a browser that has never talked to an agent has an empty list.
+  await page.goto('/settings')
+  await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible()
+
+  // Scoped to main: the sidebar says "No agents yet" too.
+  const panel = page.locator('main')
+  await expect(panel.getByText(/no agents yet/i)).toBeVisible()
+  // "No agents added yet" on its own is a statement of absence with no exit.
+  await expect(panel.getByText(/paste an agent's address|open a link someone shared/i)).toBeVisible()
+
+  await shot('settings-empty')
+})


### PR DESCRIPTION
The last unshipped item from the round-2 audit.

## A fresh session had nothing to do

This is the screen a visitor sees **immediately after passing an invite gate** — the first thing the product says once it has let them in:

```
        (S)
      Scriptbot
  Send a message to start
```

An avatar, a name, and an instruction to think of something themselves in the first five seconds.

Meanwhile the landing page, one route away, had already worked out three good openers from the agent's own skills — `bestOffers()` filters out internal skills, extracts an imperative from each description, sorts goal-verbs first — and rendered them as chips.

The empty session offers the same three now, with the **same markup**, so there is one definition of a chip rather than two that will drift.

`bestOffers` / `chipOffer` / `fixBrandCase` moved from `app/[address]/page.tsx` into `components/chat/skill-offers.ts` — beside the components that render them, and next to the second one that needed them, rather than copied.

## Settings with no agents was a dead end

```jsx
<p>No agents added yet</p>
```

A statement of absence with no exit, on a screen reached by someone who has nothing in the app yet. It now says where to paste an address and that a shared link works too.

## The first spec is on its second attempt

Version one compared button text between the landing page and the session and asserted some overlap. It **passed against the unfixed code** — the sidebar's "Add Agent" appears on both pages and cleared my length filter. A comparison loose enough to match anything proves nothing.

It asserts the exact derived offer by name now:

```
Error: the empty session offers nothing to say
```

That is the third time in this run that my first instrument didn't measure what I meant — the others being a colour check over states the scenario never rendered, and a rail spread over a filtered set that excluded the disagreement. Worth saying plainly: writing the assertion is the easy half; proving it can fail is the half that counts.

## Also, a screenshot that lied

The `fresh-session` screenshot looked empty, and I went looking for a rendering bug that wasn't there — the fixture captures at teardown, by which point the second spec had navigated away. A probe showed the button was present all along. Fixed by asserting inside the test rather than trusting the frame.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    47 passed, 0 flaky
```

## Deliberately left

The transcript still has six vertical paddings in play (`py-0.5` through `py-3`, 76 occurrences). Unlike the indent rails, these mix card-internal spacing with between-item rhythm, and collapsing them blind would change how the whole transcript breathes. It needs the measure-then-change treatment the rails got, not a substitution.