### PR TITLE
Say when a code block has more to the right

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,3 +167,31 @@ textarea:focus-visible {
 .animation-delay-200 {
   animation-delay: 200ms;
 }
+
+/* A code block wider than the phone scrolls, and nothing said so.
+ *
+ * On a 390px screen an agent's fenced code is 635px of content in a 304px box:
+ * overflow-x is auto, so it does scroll — but the line ends flush at the edge
+ * and a reader has no reason to think there is more of it.
+ *
+ * A light edge, not a shadow: the usual scroll-shadow recipe paints a dark
+ * gradient, which on an already near-black block is invisible — I shipped that
+ * first and the screenshot looked identical.
+ *
+ * background-attachment: local makes the masking layers scroll with the content,
+ * so each edge shows only while there is something past it and clears when you
+ * reach the end. It is a position indicator rather than permanent decoration,
+ * with no JavaScript and no extra element.
+ */
+.prose pre {
+  background-color: #1e1e1e;
+  background-image:
+    linear-gradient(to right, #1e1e1e 40%, rgba(30, 30, 30, 0)),
+    linear-gradient(to left,  #1e1e1e 40%, rgba(30, 30, 30, 0)),
+    linear-gradient(to right, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0)),
+    linear-gradient(to left,  rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-size: 28px 100%, 28px 100%, 18px 100%, 18px 100%;
+  background-attachment: local, local, scroll, scroll;
+}

--- a/e2e/code-scroll.spec.ts
+++ b/e2e/code-scroll.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Long code in an agent reply, on a phone.
+ *
+ * A fenced block is 635px of content in a 304px box at 390px wide. overflow-x is
+ * auto so it scrolls, but the line ended flush at the edge and nothing said there
+ * was more of it.
+ *
+ * Asserted by sampling pixels, because I could not judge this by eye: the first
+ * attempt painted the conventional dark scroll-shadow, which on a near-black
+ * block is invisible, and the screenshot looked identical to the broken version.
+ * A colour reading is the only honest check here.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('a code block that scrolls says so, at the end that has more', async ({ page, shot }) => {
+  test.setTimeout(60_000)
+  await mockAgent(page, 'busy')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText(/build finished in 4\.2 seconds/)).toBeVisible({ timeout: 20_000 })
+
+  const pre = page.locator('[role="log"] pre').first()
+  const box = (await pre.boundingBox())!
+
+  // Only meaningful while the content really is wider than the box.
+  const overflows = await pre.evaluate(el => el.scrollWidth > el.clientWidth + 8)
+  expect(overflows, 'the sample block no longer overflows — pick a longer line').toBe(true)
+
+  const shot1 = (await page.screenshot({ clip: box })).toString('base64')
+  const sample = await page.evaluate(async (b64: string) => {
+    const img = new Image()
+    img.src = 'data:image/png;base64,' + b64
+    await img.decode()
+    const c = document.createElement('canvas')
+    c.width = img.width
+    c.height = img.height
+    const ctx = c.getContext('2d')!
+    ctx.drawImage(img, 0, 0)
+    const at = (x: number) => {
+      const d = ctx.getImageData(Math.round(x), Math.round(img.height / 2), 1, 1).data
+      return d[0]
+    }
+    return { left: at(2), mid: at(img.width / 2), right: at(img.width - 3) }
+  }, shot1)
+
+  // Scrolled to the start: the right edge has content past it and lifts; the
+  // left edge does not and stays flat. background-attachment: local is what
+  // ties each fade to whether there is anything behind it.
+  expect(sample.right - sample.mid, `no edge indicator: ${JSON.stringify(sample)}`).toBeGreaterThan(12)
+  expect(Math.abs(sample.left - sample.mid), 'the start edge is fading with nothing behind it').toBeLessThan(12)
+
+  await shot('code-block')
+})


### PR DESCRIPTION
The last item I had flagged twice and never fixed.

## The problem

At 390px an agent's fenced code is **635px of content in a 304px box**. `overflow-x` is `auto`, so it does scroll — but the line ends flush at the edge and nothing indicates there is more. A reader has no reason to try.

## The fix

A light edge on each side, painted with `background-attachment: local` so the masking layers scroll with the content. Each fade appears only while there is something past that edge and clears when you reach it — a position indicator rather than permanent decoration. No JavaScript, no extra element.

## Two things I got wrong first, both worth recording

**The conventional recipe is invisible here.** Scroll-shadows are normally a dark gradient. On a `#1e1e1e` block a dark gradient is invisible by construction — I shipped it, took a screenshot, and it was identical to the broken version. Light edge instead.

**And I could not judge it by eye either way.** At phone size, in a screenshot, a 16%-white edge on near-black is not something I can reliably see. So the spec samples pixels:

```
with the fix      left 30   mid 30   right 67
without           left 30   mid 30   right 37     ← that 37 is the text itself
```

Both readings look the same in a thumbnail. The numbers do not. When the thing being verified is a subtle rendering difference, "the screenshot looks fine" is not a check — this is the one place in this work where reading colour beats looking at the frame.

The assertion also checks the *start* edge stays flat, which is what proves the fade is tied to scroll position rather than always drawn.

## Also this pass

**Production health check**, since a lot has shipped:

```
desktop  /  /settings  /0x…      200, overflow 0, 0 console errors
phone    /  /settings  /0x…      200, overflow 0, 0 console errors
```

**Closed #3** (example prompts to reduce cold-start friction). All four requirements are met — up to three chips derived from the agent's own skills, clicking sends rather than fills, hidden once `ui.length > 0` — across the landing page and, since #78, the empty session.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    47 passed, 2 flaky, 0 failed
```

## Deliberately left

Whether long code should **wrap** on a phone rather than scroll at all is a different question, and a real one — horizontal reading is poor on a small screen regardless of how well the edge is signposted. That changes how all code is presented, so it wants a decision rather than a patch.

#38 (dashboard bridge components) is the only substantial open item left, and it is a feature rather than a fix. #57 remains a product judgement.