### PR TITLE
Delete the Chats row, keep attachments inside the composer, and let CI run lint

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,19 @@ jobs:
       # Vercel" possible twice in this repo.
       - run: npm ci
 
+      # Static checks first: they take seconds and they are the ones that were
+      # slipping through. main shipped a lint error because a local run was
+      # inspected with `tail -1`, which shows a blank line when there are
+      # findings above it, and nothing in CI looked at all.
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npx vitest run
+
       - name: Install Chromium
         run: npx playwright install chromium --with-deps
 

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -232,88 +232,91 @@ export function ChatInput({
           </div>
         )}
 
-        {/* Image previews */}
-        {images.length > 0 && (
-          <div className="mb-3 flex gap-2 flex-wrap">
-            {images.map((img, i) => (
-              <div key={i} className="relative group">
-                {/* Attachments arrive as base64 data: URLs in the event stream. next/image
-                    cannot optimise those — it needs a routable URL or a static import — so
-                    plain <img> is correct here, not a shortcut. */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={img}
-                  alt={`Upload ${i + 1}`}
-                  className="h-20 w-20 object-cover rounded-xl shadow-sm"
-                />
-                <button
-                  onClick={() => removeImage(i)}
-                  className="absolute -top-2 -right-2 h-6 w-6 rounded-full bg-neutral-800 text-white flex items-center justify-center opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity shadow-md hover:bg-neutral-700"
-                  aria-label="Remove image"
-                >
-                  <HiX className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* File previews */}
-        {files.length > 0 && (
-          <div className="mb-3 flex gap-2 flex-wrap">
-            {files.map((file, i) => (
-              <div key={i} className="relative group flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 shadow-sm">
-                <HiOutlineDocument className="h-4 w-4 text-neutral-400 shrink-0" />
-                <div className="min-w-0">
-                  <div className="text-sm font-medium text-neutral-700 truncate max-w-[150px]">{file.name}</div>
-                  <div className="text-[11px] text-neutral-400">{formatFileSize(file.size)}</div>
-                </div>
-                <button
-                  onClick={() => removeFile(i)}
-                  className="ml-1 h-5 w-5 rounded-full bg-neutral-100 text-neutral-400 flex items-center justify-center opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-neutral-200 hover:text-neutral-600"
-                  aria-label="Remove file"
-                >
-                  <HiX className="h-3 w-3" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Skill command palette */}
-        {filteredSkills.length > 0 && (
-          <div className="mb-2 rounded-xl border border-neutral-200 bg-white shadow-md overflow-hidden max-h-60 overflow-y-auto">
-            {filteredSkills.map((skill, i) => (
-              <button
-                key={skill.name}
-                ref={el => { skillRefs.current[i] = el }}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault()
-                  selectSkill(skill)
-                }}
-                onMouseEnter={() => setSelectedSkillIndex(i)}
-                className={cn(
-                  'flex w-full items-center gap-2.5 px-4 py-2 text-left transition-colors',
-                  i === activeSkillIndex ? 'bg-neutral-100' : 'hover:bg-neutral-50'
-                )}
-              >
-                <span className="shrink-0 whitespace-nowrap font-medium text-[13px] text-neutral-900">/{skill.name}</span>
-                <span className="min-w-0 flex-1 truncate text-xs text-neutral-500">{skill.description}</span>
-              </button>
-            ))}
-            <div className="border-t border-neutral-100 px-4 py-1.5 text-[11px] text-neutral-400">
-              <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">↑↓</kbd> navigate · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Tab</kbd> complete · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Esc</kbd> dismiss
-            </div>
-          </div>
-        )}
-
         <div className={cn(
           'rounded-2xl border transition-all duration-200',
           isRecording
             ? 'border-red-300 bg-red-50'
             : 'border-neutral-200 bg-neutral-50 focus-within:border-neutral-300 focus-within:bg-white focus-within:shadow-sm'
         )}>
+          {/* Attachments live inside the composer card, not above it. Outside, the
+              thumbnails sat flush against the page padding and each remove button —
+              absolutely positioned at -top-2 -right-2 — hung outside the container
+              and was clipped on a phone. */}
+        {/* Image previews */}
+          {images.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-4 pt-3">
+              {images.map((img, i) => (
+                <div key={i} className="relative group">
+                  {/* Attachments arrive as base64 data: URLs in the event stream. next/image
+                      cannot optimise those — it needs a routable URL or a static import — so
+                      plain <img> is correct here, not a shortcut. */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={img}
+                    alt={`Upload ${i + 1}`}
+                    className="h-20 w-20 object-cover rounded-xl shadow-sm"
+                  />
+                  <button
+                    onClick={() => removeImage(i)}
+                    className="absolute -top-2 -right-2 h-6 w-6 rounded-full bg-neutral-800 text-white flex items-center justify-center opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity shadow-md hover:bg-neutral-700"
+                    aria-label="Remove image"
+                  >
+                    <HiX className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* File previews */}
+          {files.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-4 pt-3">
+              {files.map((file, i) => (
+                <div key={i} className="relative group flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 shadow-sm">
+                  <HiOutlineDocument className="h-4 w-4 text-neutral-400 shrink-0" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-neutral-700 truncate max-w-[150px]">{file.name}</div>
+                    <div className="text-[11px] text-neutral-400">{formatFileSize(file.size)}</div>
+                  </div>
+                  <button
+                    onClick={() => removeFile(i)}
+                    className="ml-1 h-5 w-5 rounded-full bg-neutral-100 text-neutral-400 flex items-center justify-center opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-neutral-200 hover:text-neutral-600"
+                    aria-label="Remove file"
+                  >
+                    <HiX className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Skill command palette */}
+          {filteredSkills.length > 0 && (
+            <div className="mb-2 rounded-xl border border-neutral-200 bg-white shadow-md overflow-hidden max-h-60 overflow-y-auto">
+              {filteredSkills.map((skill, i) => (
+                <button
+                  key={skill.name}
+                  ref={el => { skillRefs.current[i] = el }}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    selectSkill(skill)
+                  }}
+                  onMouseEnter={() => setSelectedSkillIndex(i)}
+                  className={cn(
+                    'flex w-full items-center gap-2.5 px-4 py-2 text-left transition-colors',
+                    i === activeSkillIndex ? 'bg-neutral-100' : 'hover:bg-neutral-50'
+                  )}
+                >
+                  <span className="shrink-0 whitespace-nowrap font-medium text-[13px] text-neutral-900">/{skill.name}</span>
+                  <span className="min-w-0 flex-1 truncate text-xs text-neutral-500">{skill.description}</span>
+                </button>
+              ))}
+              <div className="border-t border-neutral-100 px-4 py-1.5 text-[11px] text-neutral-400">
+                <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">↑↓</kbd> navigate · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Tab</kbd> complete · <kbd className="rounded border border-neutral-200 bg-neutral-50 px-1">Esc</kbd> dismiss
+              </div>
+            </div>
+          )}
           {/* Input row */}
           <div className="flex items-end gap-3 px-4 py-3">
             {/* Hidden file input */}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -11,7 +11,6 @@ import {
   HiOutlineChevronDown,
   HiOutlineChevronRight,
   HiOutlineSparkles,
-  HiOutlineChatAlt2,
 } from 'react-icons/hi'
 import { useChatStore } from '@/store/chat-store'
 import { useAgentInfo } from '@/hooks/use-agent-info'
@@ -94,7 +93,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   }
 
   const isSettingsActive = pathname === '/settings'
-  const isChatsActive = !isSettingsActive
 
   return (
     <>
@@ -170,25 +168,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               : 'all agents offline'}
           </span>
         </div>
-
-        {/* One destination. Automation and Schedule used to sit here as disabled
-            SOON rows; automation belongs to an agent, not to the app, so a global
-            rail advertising it was pointing at the wrong place — and two dead rows
-            were taking the most valuable space in a phone drawer. */}
-        <nav className="px-2 pt-2 pb-1">
-          <Link
-            href="/"
-            onClick={onClose}
-            className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
-              isChatsActive
-                ? 'bg-neutral-100 text-neutral-900 font-medium'
-                : 'text-neutral-600 hover:bg-neutral-100/70'
-            }`}
-          >
-            <HiOutlineChatAlt2 className="w-4 h-4 shrink-0" />
-            <span>Chats</span>
-          </Link>
-        </nav>
 
         {/* Agents section label */}
         <div className="px-4 pt-3 pb-1 flex items-center justify-between shrink-0">

--- a/e2e/composer.spec.ts
+++ b/e2e/composer.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * The composer on a phone, with something attached.
+ *
+ * Attaching is a flow nothing had walked. The controls all cleared the 24px
+ * floor, so measuring them said everything was fine — but the preview row sat
+ * *outside* the composer card, flush against the page padding, and each remove
+ * button is absolutely positioned at -top-2 -right-2, so it hung outside its
+ * container and was clipped. Numbers passed; the screenshot did not.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { deflateSync } from 'node:zlib'
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** A real 64x64 PNG. A 1x1 transparent one renders as nothing, which is how the
+ *  first run of this produced a blank thumbnail and a false alarm. */
+function swatch(path: string) {
+  const [w, h] = [64, 64]
+  const raw = Buffer.concat(
+    Array.from({ length: h }, () => Buffer.concat([Buffer.from([0]), Buffer.alloc(w * 3, 0).fill(0xdc)]))
+  )
+  const chunk = (type: string, data: Buffer) => {
+    const body = Buffer.concat([Buffer.from(type), data])
+    const len = Buffer.alloc(4); len.writeUInt32BE(data.length)
+    const crcTable = (n: number) => { let c = n; for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1; return c >>> 0 }
+    let crc = 0xffffffff
+    for (const b of body) crc = crcTable((crc ^ b) & 0xff) ^ (crc >>> 8)
+    const crcBuf = Buffer.alloc(4); crcBuf.writeUInt32BE((crc ^ 0xffffffff) >>> 0)
+    return Buffer.concat([len, body, crcBuf])
+  }
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(w, 0); ihdr.writeUInt32BE(h, 4)
+  ihdr[8] = 8; ihdr[9] = 2
+  writeFileSync(path, Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr), chunk('IDAT', deflateSync(raw)), chunk('IEND', Buffer.alloc(0)),
+  ]))
+}
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('an attached image and its remove button stay inside the composer', async ({ page, shot }) => {
+  const file = '/tmp/e2e-swatch.png'
+  swatch(file)
+
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}/attach`)
+  await expect(page.getByRole('button', { name: 'Attach file' })).toBeVisible({ timeout: 20_000 })
+
+  await page.locator('input[type=file]').first().setInputFiles({
+    name: 'swatch.png', mimeType: 'image/png', buffer: readFileSync(file),
+  })
+
+  const remove = page.getByRole('button', { name: 'Remove image' })
+  await expect(remove).toBeVisible()
+
+  // The thumbnail is the anchor, not a class-name guess: the button is pinned to
+  // its top-right corner, so it belongs *inside* the composer's own padding.
+  // Measuring against the card by class matched a different rounded element on
+  // the old markup and passed either way — the first version of this assertion
+  // proved nothing.
+  const thumb = (await page.locator('img[alt^="Upload"]').first().boundingBox())!
+  const btn = (await remove.boundingBox())!
+
+  // Outside the card the thumbnail sat flush at the page's 16px padding, so the
+  // button's -8px offset put it at x=8 with nothing behind it. Inside, the card's
+  // own px-4 gives it room.
+  expect(thumb.x, `the thumbnail is flush against the page edge (x=${thumb.x})`).toBeGreaterThanOrEqual(28)
+  expect(btn.x, `the remove button hangs off the left (x=${btn.x})`).toBeGreaterThanOrEqual(20)
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow, 'attaching pushed the page sideways').toBeLessThanOrEqual(0)
+
+  await shot('with-attachment')
+})
+
+test('every composer control clears the touch floor', async ({ page }) => {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}/touch`)
+  await expect(page.getByRole('button', { name: 'Attach file' })).toBeVisible({ timeout: 20_000 })
+
+  for (const name of ['Attach file', 'Start recording', 'Send message']) {
+    const box = await page.getByRole('button', { name }).first().boundingBox()
+    expect(box, `${name} is not rendered`).not.toBeNull()
+    expect(Math.min(box!.width, box!.height), `${name} is ${box!.width}x${box!.height}`).toBeGreaterThanOrEqual(24)
+  }
+})

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -9,7 +9,7 @@
  */
 
 import { test, expect } from './fixtures'
-import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
 test('a fresh session offers the same openers the landing page does', async ({ page, shot }) => {
   await mockAgent(page)

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -22,7 +22,9 @@ test.describe('a gate that asks for payment', () => {
     // The amount, and the address it goes to. Without the payee this branch asks
     // for money and gives the reader nowhere to send it.
     await expect(page.getByText(/\$12\.00/)).toBeVisible()
-    await expect(page.getByRole('button', { name: /copy agent address/i }).last()).toBeVisible()
+    // The payee itself, by value: a copy button proves a control exists, not that
+    // it carries the address the host actually published.
+    await expect(page.getByTitle(PAYEE_ADDRESS)).toBeVisible()
 
     // Nothing may read as an in-app checkout: submitting only signs an assertion
     // that a payment happened, which the agent then decides whether to believe.


### PR DESCRIPTION
## Chats was a link to where the logo already goes

Aaron asked what it was for. Checking:

```jsx
<Link href="/">              ← the logo, line 129
<Link href="/">  Chats       ← the nav row, line 180
```

Same destination. And its active state was `!isSettingsActive`, so it was highlighted on every screen except Settings — a "you are here" that is always on says nothing.

It was the last of three rows above the agent list. Automation and Schedule went earlier for the same reason: a row that does not take you anywhere new is taking the most valuable space in a phone drawer.

The agent list now starts directly under the logo.

## Attachments hung outside the composer

Every control cleared the 24px floor — Attach 32×32, mic 36×36, Send 36×36, Remove 24×24 — so measuring said the flow was fine.

The screenshot said otherwise. The preview row sat **outside** the composer card, flush against the page's `px-4`, and each remove button is positioned `-top-2 -right-2`. On a phone that put it at x=8 with nothing behind it, clipped.

Moved inside the card, where its own `px-4` gives the thumbnails room.

The assertion is anchored to the thumbnail, not to a class-name guess — my first version measured against `[class*="rounded-2xl"]` and **passed on the broken markup**, because that matched a different rounded element. It now fails with `the thumbnail is flush against the page edge (x=16)`.

## main was failing lint, and CI never looked

```
✖ 2 problems (2 errors, 0 warnings)
```

I introduced these in #78 and missed them because I checked the run with `npm run lint | tail -1` — which prints a blank line when the findings are above it. And the workflow went straight from `npm ci` to Playwright with no static checks at all, so nothing else was looking either.

The workflow now runs `tsc --noEmit`, `npm run lint` and `vitest` before the browser tests. They take seconds, and they are precisely the checks that were slipping through.

One of the two errors was a genuinely weak test rather than a stray import: `onboard.spec.ts` imported `PAYEE_ADDRESS`, then stopped using it when I switched to asserting *a copy button exists*. A control existing does not prove it carries the address the host published. It asserts the value now.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean          ← for the first time in three PRs
npx vitest run     55 passed
CI=1 playwright    51 passed, 0 flaky
```

## Deliberately left

`Add Agent` and `Settings` at the bottom of the drawer both stay — unlike Chats, they go somewhere the logo does not.