### PR TITLE
Cover the two prompts that stop a run, and fix what they showed

### DIFF
--- a/components/chat/chat-ulw-checkpoint.tsx
+++ b/components/chat/chat-ulw-checkpoint.tsx
@@ -40,7 +40,12 @@ export function ChatUlwCheckpoint({ checkpoint, onResponse, className }: ChatUlw
               Ultra work mode checkpoint
             </p>
             <p className="text-xs text-neutral-600 mt-1">
-              Completed {turns_used} of {max_turns} turns
+              {/* A host that omits max_turns produced "Completed 20 of 0 turns" —
+                  an impossible sentence at the moment someone decides whether to
+                  grant another hundred. State what is known. */}
+              {max_turns > 0
+                ? `Completed ${turns_used} of ${max_turns} turns`
+                : `Completed ${turns_used} turns`}
             </p>
           </div>
         </div>

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -48,6 +48,11 @@ export function Chat({
   agentName,
 }: ChatProps & { agentName?: string }) {
   const offers = useMemo(() => bestOffers(skills ?? []), [skills])
+  // The ULW checkpoint counts too: an autonomous run has stopped and is asking
+  // for more rope, which is the most consequential thing the composer can be
+  // waiting on. Without it the placeholder still read "Send a message…" while
+  // the run was parked.
+  const awaitingYou = Boolean(pendingApproval || pendingAskUser || pendingUlwTurnsReached)
   const isUlwActive = mode === 'ulw'
   const [ulwFullscreen, setUlwFullscreen] = useState(false)
 
@@ -122,7 +127,7 @@ export function Chat({
         // is where "it is your move" has to be said. Everything else — the spinner,
         // the token counter, the status chip on the card — was either lying or
         // off-screen while the run sat blocked (#59).
-        awaitingYou={Boolean(pendingApproval || pendingAskUser)}
+        awaitingYou={awaitingYou}
         onJumpToPending={jumpToPending}
       />
     )

--- a/e2e/blocking-prompts.spec.ts
+++ b/e2e/blocking-prompts.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * The two moments a run stops and waits for the reader.
+ *
+ * Both had no coverage at all. They are the states where the agent has taken
+ * itself as far as it can and needs a human — so if either is hard to see, hard
+ * to reach on a phone, or silent to a screen reader, the run simply stalls and
+ * nothing explains why.
+ *
+ * `ulw_turns_reached` is the higher-stakes of the two: a fully autonomous run
+ * has hit its turn limit and is asking for more rope.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+async function run(page: import('@playwright/test').Page, scenario: 'ask-user' | 'ulw-turns') {
+  await mockAgent(page, scenario)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+}
+
+test.describe('the agent asks a question', () => {
+  test('the question and its options are on screen and answerable', async ({ page, shot }) => {
+    await run(page, 'ask-user')
+
+    await expect(page.getByText('Which environment should I deploy to?')).toBeVisible({ timeout: 20_000 })
+    for (const option of ['staging', 'production']) {
+      const button = page.getByRole('button', { name: option, exact: true })
+      await expect(button).toBeVisible()
+      const box = await button.boundingBox()
+      expect(Math.min(box!.width, box!.height), `${option} is too small to tap`).toBeGreaterThanOrEqual(24)
+    }
+
+    await shot('question')
+  })
+
+  test('a blocked run says so in the composer', async ({ page }) => {
+    await run(page, 'ask-user')
+    await expect(page.getByText('Which environment should I deploy to?')).toBeVisible({ timeout: 20_000 })
+
+    // The transcript can be scrolled away from; the composer is always in view,
+    // so it is what tells a reader the run is waiting on them.
+    await expect(page.getByPlaceholder(/answer above/i)).toBeVisible()
+  })
+})
+
+test.describe('an autonomous run hits its limit', () => {
+  test('says how far it got and offers a way to continue', async ({ page, shot }) => {
+    await run(page, 'ulw-turns')
+
+    // How far it got, against what it was allowed — the fact the reader needs
+    // before granting more. A missing max_turns used to render "20 of 0 turns".
+    await expect(page.getByText('Completed 20 of 100 turns')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('button', { name: /continue/i }).first()).toBeVisible()
+
+    // And the composer has to say the run is parked. It only knew about approvals
+    // and questions, so it still read "Send a message…" here — the one prompt of
+    // the three where the agent has been working unattended.
+    await expect(page.getByPlaceholder(/answer above/i)).toBeVisible()
+
+    await shot('ulw-limit')
+  })
+
+  test('the prompt is announced, not just drawn', async ({ page }) => {
+    await run(page, 'ulw-turns')
+    await expect(page.getByText(/20/).first()).toBeVisible({ timeout: 20_000 })
+
+    // The transcript is role="log" aria-live="polite", so an appended card is
+    // announced. Without that a screen-reader user waits on a run that has
+    // already stopped and asked them something.
+    const live = page.locator('[role="log"][aria-live]')
+    await expect(live).toHaveCount(1)
+    await expect(live).toContainText(/20/)
+  })
+})
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('a question fits and does not push the page sideways', async ({ page, shot }) => {
+    await run(page, 'ask-user')
+    await expect(page.getByText('Which environment should I deploy to?')).toBeVisible({ timeout: 20_000 })
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'the question card pushes the page sideways').toBeLessThanOrEqual(0)
+
+    for (const option of ['staging', 'production']) {
+      await expect(page.getByRole('button', { name: option, exact: true })).toBeInViewport()
+    }
+
+    await shot('question')
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'busy' | 'onboard-payment'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'busy' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -90,6 +90,27 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
 
       if (scenario === 'error') {
         send(ws, { type: 'ERROR', message: 'the agent ran out of credits' })
+        return
+      }
+
+      // The agent stops and puts a question to the reader. The run parks here —
+      // nothing else arrives until they answer — which is the whole point of the
+      // card, and why it needs to be reachable and obvious.
+      if (scenario === 'ask-user') {
+        send(ws, {
+          type: 'ask_user',
+          id: 'q1',
+          text: 'Which environment should I deploy to?',
+          options: ['staging', 'production'],
+        })
+        return
+      }
+
+      // A fully autonomous run hitting its turn limit. The agent has been working
+      // unattended and is now asking for more rope — the highest-stakes prompt in
+      // the app, and the one with no coverage at all.
+      if (scenario === 'ulw-turns') {
+        send(ws, { type: 'ulw_turns_reached', turns_used: 20, max_turns: 100 })
         return
       }
 


### PR DESCRIPTION
Picked by **coverage** rather than by hunch. Listing components that appear nowhere in `e2e/`:

```
ulw-fullscreen  ulw-monitor-panel  ulw-setup-panel  ulw-toggle
ask-user  chat-ask-user  chat-ulw-checkpoint  …
```

The ULW surfaces and the `ask_user` card had **no coverage at all**, and they are the two states where the agent has gone as far as it can and needs a human. If either is hard to see, hard to reach, or silent, the run stalls and nothing explains why.

## Both render well. The problems were next to them.

The question card is genuinely good on a phone — options, a custom-answer field, a skip, and "Waiting on your answer" above it.

**The composer did not know the run was parked.**

```jsx
awaitingYou={Boolean(pendingApproval || pendingAskUser)}
```

An approval or a question flips it. A **ULW checkpoint does not** — so when a fully autonomous run hit its turn limit, the composer still read `Send a message…`. That is the one of the three where the agent has been working unattended, and the composer is the part of the screen always in view.

**The checkpoint printed an impossible number.**

```
Ultra work mode checkpoint
Completed 20 of 0 turns          ← host omitted max_turns
```

At the moment someone decides whether to grant another hundred turns. It states what it knows now — `Completed 20 turns` when there is no limit to compare against.

The mock also sends `max_turns` now, so the fixture matches the wire rather than accidentally exercising the missing-field path.

## Verified

```
npx tsc --noEmit   clean
npm run lint       clean
npx vitest run     55 passed
CI=1 playwright    47 passed, 9 flaky, 0 failed
```

The composer fix verified by removing it — `waiting for getByPlaceholder(/answer above/i)`.

Flakiness is the usual local contention; the runner has been 0-flaky on every one of these. Holding the merge on it.

## Deliberately left

`ulw-setup-panel` and `ulw-fullscreen` still have no coverage — reaching them needs a mode switch and a live run, which is a longer fixture than this pass. They are next if this direction is right.

`chat-error`, `files-received` and `tool-blocked` are also uncovered, but each is a single card with no interaction, unlike these two which block the run.