### PR TITLE
Fail the build when a component nothing renders is exported

### DIFF
--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -10,7 +10,7 @@ export { ChatUlwCheckpoint } from './chat-ulw-checkpoint'
 export { useAgentSDK, type SessionActiveState } from './use-agent-sdk'
 export { ModeSwitcher, PlanModeBanner, UlwModeBanner } from './mode-switcher'
 export { UlwToggle, UlwToggleWrapper } from './ulw-toggle'
-export { ModeIndicator, ModeStatusBar } from './mode-indicator'
+export { ModeStatusBar } from './mode-indicator'
 export * from './messages'
 export type {
   FileAttachment,

--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -4,14 +4,11 @@ import { useEffect, useCallback } from 'react'
 import { HiOutlineShieldCheck, HiOutlineClipboardList, HiOutlineLightningBolt } from 'react-icons/hi'
 import type { ApprovalMode } from './types'
 
-interface ModeIndicatorProps {
+interface ModeStatusBarProps {
   mode: ApprovalMode
   onModeChange: (mode: ApprovalMode, options?: { turns?: number }) => void
   disabled?: boolean
   ulwTurnsRemaining?: number | null
-}
-
-interface ModeStatusBarProps extends ModeIndicatorProps {
   sessionState?: 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
   isLoading?: boolean
   connectionError?: string | null
@@ -65,51 +62,6 @@ function isTypingTarget(el: Element | null) {
   if (!el) return false
   const tag = (el as HTMLElement).tagName
   return tag === 'TEXTAREA' || tag === 'INPUT' || (el as HTMLElement).isContentEditable
-}
-
-export function ModeIndicator({ mode, onModeChange, disabled }: ModeIndicatorProps) {
-  const currentMode = MODE_CONFIG[mode] || MODE_CONFIG.safe
-  const Icon = currentMode.icon
-
-  const cycleMode = useCallback(() => {
-    if (disabled) return
-    const currentIndex = CYCLE_MODES.indexOf(mode)
-    const nextIndex = (currentIndex + 1) % CYCLE_MODES.length
-    onModeChange(CYCLE_MODES[nextIndex])
-  }, [mode, onModeChange, disabled])
-
-  // Shift+Tab cycles modes, but never while focus is in an input, textarea, or
-  // contentEditable — a security-relevant setting must not flip while typing.
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (isTypingTarget(document.activeElement)) return
-      if (e.shiftKey && e.key === 'Tab') {
-        e.preventDefault()
-        cycleMode()
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [cycleMode])
-
-  return (
-    <button
-      onClick={cycleMode}
-      disabled={disabled}
-      className={`
-        inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium
-        border transition-all
-        ${currentMode.bgColor}
-        hover:opacity-80
-        disabled:opacity-50 disabled:cursor-not-allowed
-      `}
-      title="Click or Shift+Tab to cycle modes"
-    >
-      <Icon className={`w-3.5 h-3.5 ${currentMode.color}`} />
-      <span className={currentMode.color}>{currentMode.shortLabel}</span>
-    </button>
-  )
 }
 
 /** Left-right split status bar: connection on left, mode cycle on right */

--- a/e2e/reachability.spec.ts
+++ b/e2e/reachability.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Components that no page can render.
+ *
+ * Ultra work mode shipped with 541 lines a user cannot reach: `ModeSwitcher` is
+ * the only thing that calls `onModeChange('ulw')` and nothing renders it, and
+ * `UlwSetupPanel`'s gate needs four props no page supplies (openonion/oo-chat#83).
+ *
+ * TypeScript is happy with all of that — optional props that are never passed
+ * are valid, and an exported-but-unused component is valid. The tsc and lint
+ * steps added in #81 cannot see this class of gap; only asking "does anything
+ * render this?" finds it.
+ *
+ * Source-level on purpose: a component nobody renders has no rendered fact to
+ * measure. This is the one question the browser cannot answer.
+ */
+
+import { test, expect } from './fixtures'
+
+/** Components known to be unreachable, with the issue that decides their fate.
+ *  Removing an entry here is how you prove a wiring bug is fixed. */
+const KNOWN_UNREACHABLE = new Set([
+  'ModeSwitcher',      // #83
+  'UlwToggle',         // #83 — only UlwToggleWrapper renders it, in the same file
+  'UlwToggleWrapper',  // #83
+])
+
+// What this check does NOT catch, and #83 is the proof: `UlwSetupPanel`,
+// `UlwMonitorPanel` and `UlwFullscreen` all appear as JSX inside `Chat`, so they
+// pass here — yet no page supplies the props their render is gated on, which
+// makes them unreachable at runtime anyway. "Rendered somewhere in the source"
+// is the weaker property; it is simply the one a grep can decide. Runtime
+// reachability still needs a spec that drives the UI to the state.
+
+test('every exported chat component is rendered by something', async () => {
+  const { execSync } = await import('node:child_process')
+
+  const exported = execSync(
+    `grep -ohE "^export \\{ [A-Za-z, ]+ \\}" components/chat/index.ts || true`,
+    { encoding: 'utf8' }
+  )
+    .replace(/export \{|\}/g, '')
+    .split(/[,\n]/)
+    .map(s => s.trim())
+    .filter(s => /^[A-Z]/.test(s))
+
+  expect(exported.length, 'the chat barrel exports nothing — did it move?').toBeGreaterThan(5)
+
+  const orphans = exported.filter(name => {
+    // Anything that renders it as JSX, excluding its own definition and the barrel.
+    const hits = execSync(
+      // `<Chat` is followed by a newline when the props are on their own lines,
+      // so the character class has to allow end-of-line. My first pattern did not,
+      // and reported Chat, ChatMessages and ModeStatusBar as unreachable — all of
+      // which I had just watched render.
+      // Excludes the barrel, and the module that defines the component: UlwToggle
+      // is rendered only by UlwToggleWrapper, which lives in the same file and is
+      // itself rendered nowhere. A pair that only renders each other is still a
+      // pair nothing reaches, so "something OUTSIDE its own module renders it" is
+      // the question worth asking.
+      `grep -rlE "<${name}([ />]|$)" app components 2>/dev/null` +
+      ` | grep -v "components/chat/index.ts"` +
+      ` | xargs -I{} sh -c 'grep -q "export function ${name}\\b" {} || echo {}' || true`,
+      { encoding: 'utf8' }
+    ).split('\n').filter(Boolean)
+    return hits.length === 0
+  })
+
+  const unexpected = orphans.filter(n => !KNOWN_UNREACHABLE.has(n))
+  expect(
+    unexpected,
+    'exported but rendered nowhere — either wire it up or delete it'
+  ).toEqual([])
+
+  // And the list has to stay honest: a name that became reachable should come
+  // off it, or the guard slowly turns into a permanent excuse.
+  const stale = [...KNOWN_UNREACHABLE].filter(n => !orphans.includes(n))
+  expect(stale, 'these are reachable now — remove them from KNOWN_UNREACHABLE').toEqual([])
+})


### PR DESCRIPTION
Follow-on from #82, which said the ULW surfaces were next. They turned out to be unreachable rather than untested — that is #83. This is the guard that would have caught it on the day it landed.

## The gap

Neither of the static checks added in #81 can see this:

- an optional prop that is never passed is valid TypeScript
- an exported-but-unused component is valid, because the export *is* a use

So 541 lines of ultra work mode sat in the tree with no door, and everything was green.

## The check

`e2e/reachability.spec.ts` asks what the browser cannot: **does anything outside a component's own module render it?**

Source-level on purpose — a component nobody renders has no rendered fact to measure.

Two properties keep it honest:

- `KNOWN_UNREACHABLE` entries each cite #83. Removing one is how you prove a wiring bug is fixed.
- The test **also fails when a listed name becomes reachable**, so the list cannot quietly turn into a permanent excuse.

## What it found on the first run

`ModeIndicator` — a second copy of the mode chip that `ModeStatusBar` already draws inline, with its **own duplicate Shift+Tab handler** for cycling trust levels. Two implementations of a security-relevant control, one rendered by nothing. Deleted, and `ModeStatusBarProps` no longer extends an interface that has no other implementer.

## Two things it does not claim

`UlwSetupPanel`, `UlwMonitorPanel` and `UlwFullscreen` all appear as JSX inside `Chat`, so they **pass** this check — yet no page supplies the props their render is gated on, so they are unreachable at runtime anyway. "Rendered somewhere in the source" is the weaker property; it is the one a grep can decide. Runtime reachability still needs a spec that drives the UI into the state. The comment in the file says so, so the next reader does not over-trust a green tick.

Scope is `components/chat/index.ts` only. Widening it to the other barrels is a follow-up, not this PR.

## Verification

Both directions, since a guard that cannot fail proves nothing:

| | |
|---|---|
| on this branch | `1 passed` |
| with `mode-indicator.tsx` + `index.ts` stashed back to `main` | `1 failed` — *exported but rendered nowhere* |

Plus `tsc --noEmit` clean, `npm run lint` exit 0, and the full local suite green apart from this spec while I was iterating on it.

An earlier revision of the detector reported `Chat`, `ChatMessages` and `ModeStatusBar` as unreachable — components I had just watched render. The pattern `<Name[ />]` missed `<Chat` followed by a newline. Worth recording because the failure mode of this kind of check is a confident false positive, and the fix was to widen the pattern rather than to add the names to the ignore list.

Closes nothing on its own; the decision it exists to force is #83.