### PR TITLE
Warn before an agent runs out of credits

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -47,6 +47,7 @@ import { dedupeUI } from '@/components/chat/dedupe-ui'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { LowBalanceNotice, isLowBalance } from '@/components/agent-address'
 
 export default function ChatSessionPage() {
   const params = useParams()
@@ -129,6 +130,14 @@ export default function ChatSessionPage() {
   // Default to empty, not undefined: the dashboard's skill allowlist fails closed, so
   // an absent list must mean "nothing is invocable yet", never "anything goes".
   const skills = profile?.skills ?? agentInfoMap[address]?.skills ?? []
+  // Credit is spent here, but until now the balance was only ever shown on the
+  // landing page and in Settings — both passed through once, before any of it is
+  // used. An agent could go from working to refusing mid-thread with no warning
+  // and nowhere on this page to pay.
+  //
+  // The live AGENT_PROFILE frame wins over the cached map: it is what the agent
+  // said on this connection, while the cache can be a page-load and a spend old.
+  const balanceUsd = profile?.balance_usd ?? agentInfoMap[address]?.balance_usd
 
   // Consume pending message and apply initial mode from URL
   const consumedRef = useRef<string | null>(null)
@@ -260,6 +269,11 @@ export default function ChatSessionPage() {
           onDismissError={() => setConnectionError(null)}
           skills={skills}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
+          notice={
+            typeof balanceUsd === 'number' && isLowBalance(balanceUsd)
+              ? <LowBalanceNotice address={address} balanceUsd={balanceUsd} />
+              : null
+          }
         />
       </div>
   )

--- a/components/agent-address.test.tsx
+++ b/components/agent-address.test.tsx
@@ -14,7 +14,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { act } from 'react'
-import { AgentAddress, TopUp } from './agent-address'
+import { AgentAddress, TopUp, isLowBalance } from './agent-address'
 
 const ADDRESS = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
 
@@ -68,5 +68,16 @@ describe('AgentAddress', () => {
     const el = render(<AgentAddress address={ADDRESS} />)
     act(() => el.querySelector('button')!.click())
     expect(el.textContent).toContain(ADDRESS)
+  })
+})
+
+describe('isLowBalance', () => {
+  // The boundary, because < and <= are one keystroke apart and the difference is
+  // whether an agent sitting on exactly a dollar gets warned or gets silence.
+  it('warns below a dollar and not at it', () => {
+    expect(isLowBalance(0)).toBe(true)
+    expect(isLowBalance(0.99)).toBe(true)
+    expect(isLowBalance(1)).toBe(false)
+    expect(isLowBalance(12)).toBe(false)
   })
 })

--- a/components/agent-address.tsx
+++ b/components/agent-address.tsx
@@ -55,16 +55,72 @@ export function AgentAddress({ address }: { address: string }) {
  *  agents do. That is also the proof the address exists in the backend: checkout
  *  404s with "User not found" for an address that never authenticated. */
 export function TopUp({ address, balanceUsd }: { address: string; balanceUsd: number }) {
+  const empty = balanceUsd <= 0
+  const low = isLowBalance(balanceUsd)
+
   return (
     <a
-      href={`https://o.openonion.ai/purchase?key=${address}`}
+      href={purchaseUrl(address)}
       target="_blank"
       rel="noopener noreferrer"
       title="Add credits to this agent"
-      className="group inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
+      className={`group inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium transition-colors ${
+        low
+          ? 'border-red-200 bg-red-50 text-red-700 hover:border-red-300'
+          : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50'
+      }`}
     >
-      <span className="font-mono tabular-nums text-neutral-900">${balanceUsd.toFixed(2)}</span>
-      <span className="text-neutral-400 transition-colors group-hover:text-neutral-700">Top up →</span>
+      {/* At zero the number is the least useful thing on the pill — "$0.00" reads
+          as a balance like any other, and the reader has to know what it implies.
+          Say the implication instead. */}
+      {empty ? (
+        <span className="font-semibold">Out of credits</span>
+      ) : (
+        <span className={`font-mono tabular-nums ${low ? 'text-red-700' : 'text-neutral-900'}`}>
+          ${balanceUsd.toFixed(2)}
+        </span>
+      )}
+      <span className={low ? 'text-red-600' : 'text-neutral-400 transition-colors group-hover:text-neutral-700'}>
+        Top up →
+      </span>
     </a>
+  )
+}
+
+/** Below one dollar an agent is a turn or two from refusing, which is close
+ *  enough that the reader should hear about it before it happens rather than
+ *  after. Above it, silence — a balance nobody needs to act on is clutter. */
+export function isLowBalance(balanceUsd: number) {
+  return balanceUsd < 1
+}
+
+/** The purchase page reads the address from `?key=`; any other parameter name
+ *  lands the payer on an empty form with the address to paste themselves. */
+export function purchaseUrl(address: string) {
+  return `https://o.openonion.ai/purchase?key=${address}`
+}
+
+/** Shown with the composer, not in the transcript, because the transcript can be
+ *  scrolled away from and this is the one notice that has to still be there when
+ *  the reader looks back down to type. */
+export function LowBalanceNotice({ address, balanceUsd }: { address: string; balanceUsd: number }) {
+  const empty = balanceUsd <= 0
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 border-t border-red-100 bg-red-50 px-4 py-2 text-[11px] text-red-700">
+      <span>
+        {empty
+          ? 'This agent is out of credits and will stop responding.'
+          : `Running low — $${balanceUsd.toFixed(2)} left.`}
+      </span>
+      <a
+        href={purchaseUrl(address)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex min-h-6 items-center font-semibold underline underline-offset-2 hover:text-red-800"
+      >
+        Add credits
+      </a>
+    </div>
   )
 }

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -30,6 +30,7 @@ export function Chat({
   onPlanReviewResponse,
   className,
   statusBar,
+  notice,
   mode,
   ulwTurnsRemaining,
   ulwSetupActive,
@@ -218,6 +219,8 @@ export function Chat({
       )}
       {/* Status bar between messages and input */}
       <StatusBar thinkingItems={thinkingItems} sessionState={sessionState} />
+
+      {notice}
 
       {renderBottom()}
 

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -325,6 +325,10 @@ export interface ChatProps {
   onPlanReviewResponse?: (message: string) => void
   /** Custom status bar inside input (e.g., mode indicator) */
   statusBar?: React.ReactNode
+  /** Rendered directly above the composer. For the one thing that must still be
+   *  on screen when the reader scrolls back down to type — today, a balance that
+   *  is about to run out. */
+  notice?: React.ReactNode
   /** ULW state for 3-state bottom panel */
   mode?: ApprovalMode
   ulwTurnsRemaining?: number | null

--- a/e2e/balance.spec.ts
+++ b/e2e/balance.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Running out of credit, and finding out in time.
+ *
+ * The balance is shown on the landing page and in Settings — both places you
+ * pass through once, before you start working. The conversation, which is where
+ * the credit is actually spent, showed nothing at all: an agent could go from
+ * working to refusing mid-thread with no warning and no way to pay from the page
+ * the reader is on.
+ *
+ * The pill also rendered `$0.00` in exactly the same neutral grey as `$12.00`,
+ * so the one number that means "this is about to stop" looked like chrome.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** Below this the agent is one or two turns from refusing. */
+const LOW = 0.4
+
+async function landing(page: import('@playwright/test').Page, balance: number) {
+  await mockAgent(page, 'reply', { balance_usd: balance })
+  await page.goto(`/${AGENT_ADDRESS}`)
+}
+
+test.describe('the top-up pill', () => {
+  test('a healthy balance stays quiet', async ({ page }) => {
+    await landing(page, 12)
+
+    const pill = page.getByRole('link', { name: /top up/i })
+    await expect(pill).toBeVisible({ timeout: 20_000 })
+    await expect(pill).toContainText('$12.00')
+
+    // Nothing about a working agent should read as a problem.
+    await expect(pill).not.toContainText(/out of credits/i)
+    const colour = await pill.evaluate(el => getComputedStyle(el).borderTopColor)
+    expect(colour, 'a healthy balance is drawing attention to itself').not.toMatch(/rgb\(2[0-9][0-9], (1[0-9][0-9]|[0-9][0-9]), /)
+  })
+
+  test('an empty balance says so, and still points at the way to fix it', async ({ page, shot }) => {
+    await landing(page, 0)
+
+    const pill = page.getByRole('link', { name: /top up|out of credits/i })
+    await expect(pill).toBeVisible({ timeout: 20_000 })
+    await expect(pill, 'zero reads exactly like any other number').toContainText(/out of credits/i)
+
+    // The whole point of the pill: the address is prefilled, because the purchase
+    // page reads `?key=` and any other parameter lands the payer on a blank form.
+    await expect(pill).toHaveAttribute('href', `https://o.openonion.ai/purchase?key=${AGENT_ADDRESS}`)
+
+    await shot('empty')
+  })
+})
+
+test.describe('inside a conversation', () => {
+  test('a low balance warns before the credits run out', async ({ page, shot }) => {
+    await mockAgent(page, 'reply', { balance_usd: LOW })
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // The transcript can be scrolled away from, so the warning has to live with
+    // the composer — the part that is always on screen.
+    const warning = page.getByRole('link', { name: /add credits|top up/i }).last()
+    await expect(warning, 'a conversation gives no sign the credits are nearly gone').toBeVisible()
+    await expect(warning).toHaveAttribute('href', /purchase\?key=/)
+
+    await shot('low')
+  })
+
+  test('a healthy balance does not nag', async ({ page }) => {
+    await mockAgent(page, 'reply', { balance_usd: 12 })
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // A balance nobody needs to act on is clutter. The warning earns its place by
+    // being absent most of the time.
+    await expect(page.getByText(/running low/i)).toHaveCount(0)
+  })
+})
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('the warning fits, and the way to pay is tappable', async ({ page, shot }) => {
+    await mockAgent(page, 'reply', { balance_usd: LOW })
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    const link = page.getByRole('link', { name: /add credits|top up/i }).last()
+    await expect(link).toBeInViewport()
+
+    const box = await link.boundingBox()
+    expect(Math.min(box!.width, box!.height), `the link is ${box!.width}x${box!.height}`).toBeGreaterThanOrEqual(24)
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'the warning pushes the page sideways').toBeLessThanOrEqual(0)
+
+    await shot('warning')
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -57,7 +57,15 @@ const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
  * opens its socket against the real relay and the test silently becomes a live
  * integration test with none of the guarantees.
  */
-export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
+export async function mockAgent(
+  page: Page,
+  scenario: Scenario = 'reply',
+  // Fields the test wants to differ from PROFILE — `balance_usd` is the one that
+  // matters, since the whole point is what the UI does as the credit runs out.
+  overrides: Partial<typeof PROFILE> = {},
+) {
+  const profile = { ...PROFILE, ...overrides }
+
   // Every socket except Next's dev-mode hot reload. Which host the SDK dials
   // depends on what the relay record advertises — relay socket for a hosted agent,
   // the agent's own endpoint for a direct one — and the test should not care.
@@ -79,7 +87,7 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
           return
         }
         send(ws, { type: 'CONNECTED', session_id: 'e2e-session', status: 'idle' })
-        send(ws, { type: 'AGENT_PROFILE', ...PROFILE })
+        send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
         if (scenario === 'dashboard') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
@@ -197,7 +205,7 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
         endpoints: scenario === 'offline' ? [] : ['https://scriptbot.example'],
         relay: 'wss://oo.openonion.ai/ws',
         last_seen: new Date(0).toISOString(),
-        profile: PROFILE,
+        profile,
       }),
     })
   )
@@ -206,7 +214,7 @@ export async function mockAgent(page: Page, scenario: Scenario = 'reply') {
     route.fulfill({
       status: scenario === 'offline' ? 503 : 200,
       contentType: 'application/json',
-      body: JSON.stringify(PROFILE),
+      body: JSON.stringify(profile),
     })
   )
 


### PR DESCRIPTION
Priority 2 — the balance and top-up flow, on mobile as well as desktop.

## What was wrong

The balance was shown in exactly two places: the landing page, and Settings. **Both are passed through once, before any credit is spent.** The conversation — where it is actually spent — showed nothing at all.

So the failure mode was: an agent goes from working to refusing mid-thread, with no warning beforehand and nowhere on the page the reader is looking to pay. The fix is a phone call to you.

Second, smaller thing: `TopUp` rendered `$0.00` in the same neutral grey as `$12.00`. The one number that means *this is about to stop* looked like chrome.

## What ships

**A notice above the composer, below a dollar.** Not in the transcript — the transcript can be scrolled away from, and this is the one thing that has to still be there when the reader looks back down to type.

**The pill gets a low and an empty state.** Below a dollar it goes red; at zero it stops reporting the number and says `Out of credits`, because "$0.00" makes the reader derive the implication themselves.

**Silence above a dollar.** Both are absent for a healthy balance, and there is a test for that in each direction — a balance nobody needs to act on is clutter, and the warning earns its place by being rare.

The threshold is `< 1`: an agent below a dollar is a turn or two from refusing.

## Reading the balance

The session page prefers the live `AGENT_PROFILE` frame over the cached `useAgentInfo` map — the frame is what the agent said on *this* connection, while the cache can be a page-load and a spend old.

## Verification

Written before the fix, and it failed for the three right reasons:

| | before | after |
|---|---|---|
| empty balance says so | ✗ `toContainText(/out of credits/i)` | ✓ |
| a conversation warns | ✗ `toBeVisible()` — nothing there | ✓ |
| phone: warning fits and is tappable | ✗ `toBeInViewport()` | ✓ |
| healthy balance stays quiet | ✓ (guards the other direction) | ✓ |
| healthy balance does not nag | ✓ | ✓ |

Then: `tsc --noEmit` clean · `npm run lint` 0 findings · `vitest` 56 passed · **full Playwright suite 62 passed**.

The threshold boundary is pinned in a unit test, since `<` and `<=` are one keystroke apart and the difference is whether an agent sitting on exactly a dollar gets warned or gets silence.

## Screenshots

I looked at both before merging. On a 390px viewport the notice sits directly above the composer, does not push the page sideways, and `Add credits` clears the tap floor. On desktop the empty pill reads `Out of credits · Top up →` next to the address.

`mockAgent(page, scenario, overrides)` now takes profile overrides so a spec can set the balance; that is what made any of this testable.

## Left alone

A zero-balance agent still shows `online` and still offers its openers — you can send a message that will fail. Whether the landing page should pre-empt that is a product call about what an empty balance actually blocks, and I did not want to guess it into the UI.