### PR TITLE
The invite gate loses its top when the keyboard opens

### DIFF
--- a/components/chat/onboard-gate.tsx
+++ b/components/chat/onboard-gate.tsx
@@ -98,8 +98,14 @@ export const OnboardGate = forwardRef<HTMLInputElement, OnboardGateProps>(functi
     // is its own frustration, and half-hiding an agent's skills says "look at what
     // you may not have" — which is the opposite of what the line at the bottom is
     // trying to do for someone who has no code.
+    // items-center-safe, not items-center: once the panel is taller than this box,
+    // plain centring pushes its top to a negative offset that no scroll position
+    // can reach — scrollTop is already 0 there. On an iPhone SE with the keyboard
+    // open the viewport is about 360px tall, and the top 65px — the agent's name
+    // and the sentence saying why there is a gate at all — is simply gone. The
+    // landing page hit the same thing and uses the same fix.
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto
+      className="fixed inset-0 z-50 flex items-center-safe justify-center overflow-y-auto
                  bg-neutral-50 px-5 py-8 dark:bg-neutral-950"
     >
       <div

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -44,3 +44,80 @@ test.describe('a gate that asks for payment', () => {
     await expect(page.getByRole('textbox').first()).toBeVisible()
   })
 })
+
+test.describe('phone', () => {
+  // An iPhone SE — the shortest screen still in real use.
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('the code field and its submit are usable', async ({ page, shot }) => {
+    await mockAgent(page, 'onboard-payment')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 20_000 })
+
+    const field = page.getByRole('textbox').first()
+    await field.fill('DEMO-1234')
+
+    // 16px or larger, or iOS zooms the page on focus and leaves the reader in a
+    // viewport they then have to pinch back out of.
+    const size = await field.evaluate(el => parseFloat(getComputedStyle(el).fontSize))
+    expect(size, `the code field is ${size}px, so iOS will zoom on focus`).toBeGreaterThanOrEqual(16)
+
+    const submit = page.getByRole('button', { name: /continue/i }).first()
+    const box = await submit.boundingBox()
+    expect(box!.height, `submit is ${box!.height}px tall`).toBeGreaterThanOrEqual(40)
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'the gate pushes the page sideways').toBeLessThanOrEqual(0)
+
+    await shot('code')
+  })
+
+  test('the payee address can be reached — it is the whole point of this branch', async ({ page, shot }) => {
+    await mockAgent(page, 'onboard-payment')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 20_000 })
+
+    const copy = page.getByRole('button', { name: /copy agent address/i }).last()
+    await copy.scrollIntoViewIfNeeded()
+    await expect(copy).toBeInViewport()
+
+    await shot('payment')
+  })
+})
+
+test.describe('phone, keyboard open', () => {
+  // Tapping the code field is the first thing anyone does here, and on an SE the
+  // keyboard leaves roughly this much visual viewport. The gate is taller than
+  // that, which is the case plain centring gets wrong.
+  test.use({ viewport: { width: 375, height: 360 } })
+
+  test('the top of the gate is still reachable', async ({ page, shot }) => {
+    await mockAgent(page, 'onboard-payment')
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    const panel = page.getByRole('dialog')
+    await expect(panel).toBeVisible({ timeout: 20_000 })
+
+    // Measured on the unfixed code: top = -65 with scrollTop already 0, and
+    // setting scrollTop = 0 changed nothing — the overflow is above the scroll
+    // origin, so those 65px are not merely off-screen, they are unreachable.
+    const before = await panel.evaluate(el => {
+      el.parentElement!.scrollTop = 0
+      return el.getBoundingClientRect().top
+    })
+    expect(before, `the top of the gate sits at ${Math.round(before)}px and cannot be scrolled to`).toBeGreaterThanOrEqual(0)
+
+    // The two things living up there: whose gate this is, and why there is one.
+    await expect(page.locator('#onboard-gate-title')).toBeInViewport()
+
+    // And the rest must still be reachable by scrolling, or the fix has only
+    // moved the unreachable part to the other end.
+    const copy = page.getByRole('button', { name: /copy agent address/i }).last()
+    await copy.scrollIntoViewIfNeeded()
+    await expect(copy).toBeInViewport()
+
+    await shot('keyboard')
+  })
+})


### PR DESCRIPTION
Priority 1 — walking the flow on a phone. The invite gate is the first thing anyone opening a shared link hits, and it had no phone coverage at all.

## The break

Tapping the code field is the first thing anyone does here. On an iPhone SE the keyboard leaves roughly **360px** of visual viewport, and the gate is taller than that.

`items-center` inside an `overflow-y-auto` box centres the overflow *around the scroll origin*, so the excess goes above it:

```
panel top     -65px
scrollTop       0      ← already at the top
scrollHeight  457      ← less than the panel's own 490
```

Setting `scrollTop = 0` changed nothing. Those 65px are not off-screen, they are **unreachable** — and what lives up there is the agent's name and the one sentence explaining why there is a gate at all. The reader gets a bare code field with no idea whose it is.

`items-center-safe` — the same fix the landing page already uses for the same reason, one line.

## I was wrong about where it broke

I opened this expecting the gate to overflow at normal phone height. It does not: at 375×667 the payment branch fits comfortably, and the assertion I wrote for it passed on unfixed code. The break only appears once the keyboard is up. Worth saying because the fix would have looked identical either way and the wrong test would have proved nothing.

## Verification

The keyboard-height test on the unfixed component:

```
Error: the top of the gate sits at -65px and cannot be scrolled to
1 failed
```

With the fix: **5 passed**. I reverted the one-line change, confirmed red, and restored it.

Then `tsc --noEmit` clean · `npm run lint` 0 findings · `vitest` 56 passed · **full Playwright suite 65 passed**.

## Also added, since there was nothing

- the code field is ≥16px, or iOS zooms the page on focus and the reader has to pinch back out
- the submit clears 40px
- the gate does not push the page sideways
- the **payee address is reachable** — that branch asks for money, so a payee you cannot scroll to makes it unanswerable

Screenshots at both heights; I looked at them. At keyboard height the title and field now sit at the top with the payment box below, scrollable.

## Swept, and deliberately not changed

Eight other centred `fixed inset-0` overlays. The shared `components/ui/modal.tsx` — the one wrapping diffs, plans and file previews, where this would hurt most — turns out to be `h-full` with a scrolling body, so centring is a no-op there. The rest hold fixed-size content. I could not demonstrate a break in any of them, so I left them alone rather than change eight components on a theory.