### PR TITLE
Tell the reader on Home that the run has stopped for them

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -263,7 +263,13 @@ export default function SettingsPage() {
                   {agents.map(address => {
                     const info = infoMap[address]
                     return (
-                      <div key={address} className="flex items-center gap-4 px-8 py-5 group">
+                      // Stacked on a phone. In one row the fixed parts — 64px of
+                      // padding, three gaps, the status dot, the top-up pill and the
+                      // delete button — left about 96px for the agent, so the address
+                      // collapsed to "0…" and the tool chips wrapped one per line into
+                      // a tall column. Side by side again from sm up.
+                      <div key={address} className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-8 sm:py-5 group">
+                        <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
                         {/* Online indicator */}
                         <div className="shrink-0">
                           {info?.online !== undefined ? (
@@ -295,7 +301,7 @@ export default function SettingsPage() {
                             </span>
                             <button
                               onClick={() => copyToClipboard(address, `agent-${address}`)}
-                              className="shrink-0 p-1 text-neutral-300 hover:text-neutral-600 transition-colors"
+                              className="inline-flex min-h-6 min-w-6 shrink-0 items-center justify-center rounded text-neutral-300 hover:text-neutral-600 transition-colors"
                               title="Copy agent address"
                               aria-label="Copy agent address"
                             >
@@ -320,24 +326,24 @@ export default function SettingsPage() {
                             </div>
                           )}
                         </div>
+                        </div>
 
-                        {/* Agent balance — the account that actually spends credits.
-                            Only co/* managed-key agents publish it (see AgentInfo). */}
-                        {typeof info?.balance_usd === 'number' && (
-                          <div className="shrink-0">
+                        {/* Balance and delete travel together: on a phone they are their
+                            own row under the agent, on desktop they sit at the end of it.
+                            Only co/* managed-key agents publish a balance (see AgentInfo). */}
+                        <div className="flex shrink-0 items-center justify-end gap-3 sm:gap-4">
+                          {typeof info?.balance_usd === 'number' && (
                             <TopUp address={address} balanceUsd={info.balance_usd} />
-                          </div>
-                        )}
-
-                        {/* Delete */}
-                        <button
-                          onClick={() => setPendingRemove(address)}
-                          className="shrink-0 p-2 text-neutral-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
-                          title="Remove agent"
-                          aria-label="Remove agent"
-                        >
-                          <HiOutlineTrash className="w-4 h-4" />
-                        </button>
+                          )}
+                          <button
+                            onClick={() => setPendingRemove(address)}
+                            className="shrink-0 p-2 text-neutral-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
+                            title="Remove agent"
+                            aria-label="Remove agent"
+                          >
+                            <HiOutlineTrash className="w-4 h-4" />
+                          </button>
+                        </div>
                       </div>
                     )
                   })}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Settings, where an agent's balance lives and where its address is copied from.
+ *
+ * The agent row is the part that had never been looked at on a phone. In one
+ * horizontal row the fixed parts left about 96px for the agent itself, so the
+ * address rendered as "0…" and the tool chips stacked one per line into a tall
+ * column — the row was legible on a laptop and nonsense on the device most
+ * people open it on.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** Settings only lists agents the browser has already talked to. */
+async function settingsWithAnAgent(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+  await page.goto('/settings')
+  await expect(page.getByRole('heading', { name: /agents/i }).first()).toBeVisible()
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('the agent row shows a real address and lays its tools out sideways', async ({ page, shot }) => {
+    await settingsWithAnAgent(page)
+
+    const address = page.locator('main').getByText(AGENT_ADDRESS, { exact: true }).first()
+    await expect(address).toBeVisible()
+
+    // "0…" is what the squeezed column produced. Anything under a third of the
+    // width means the row has collapsed again.
+    const box = await address.boundingBox()
+    expect(box!.width, 'the address collapsed — the row is being squeezed').toBeGreaterThan(120)
+
+    // Tool chips belong on a line, not in a column: with six of them stacking, the
+    // row grew past the height of the phone.
+    const chips = page.getByText('read_file', { exact: true }).first()
+    if (await chips.count()) {
+      const first = await page.getByText('bash', { exact: true }).first().boundingBox()
+      const second = await chips.boundingBox()
+      expect(second!.y, 'tool chips are stacking one per line').toBeLessThan(first!.y + first!.height)
+    }
+
+    await shot('agents')
+  })
+
+  test('balance and top-up are reachable here too, at a tappable size', async ({ page }) => {
+    await settingsWithAnAgent(page)
+
+    const topUp = page.getByRole('link', { name: /top up/i })
+    await expect(topUp).toHaveAttribute('href', `https://o.openonion.ai/purchase?key=${AGENT_ADDRESS}`)
+    await expect(page.getByText(`$${PROFILE.balance_usd.toFixed(2)}`)).toBeVisible()
+
+    const box = await topUp.boundingBox()
+    expect(box!.height).toBeGreaterThanOrEqual(24)
+  })
+
+  test('every control is big enough to hit, and nothing scrolls sideways', async ({ page }) => {
+    await settingsWithAnAgent(page)
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'settings scrolls sideways on a phone').toBeLessThanOrEqual(0)
+
+    const small: string[] = []
+    for (const el of await page.locator('button:visible, a:visible').all()) {
+      const box = await el.boundingBox()
+      if (!box) continue
+      if (box.width < 24 || box.height < 24) {
+        const label = (await el.getAttribute('aria-label')) || (await el.innerText())
+        small.push(`${label.replace(/\s+/g, ' ').trim().slice(0, 30)} — ${Math.round(box.width)}x${Math.round(box.height)}`)
+      }
+    }
+    expect(small, 'targets below the 24px floor').toEqual([])
+  })
+})
+
+test.describe('desktop', () => {
+  test('the agent row is still one line', async ({ page, shot }) => {
+    await settingsWithAnAgent(page)
+
+    // The stacking is a phone concession; on a laptop the balance still sits at
+    // the end of the agent's own row rather than under it.
+    // Scoped to main: the sidebar lists the same agent, 547px up the page.
+    const name = await page.locator('main').getByText(PROFILE.name).first().boundingBox()
+    const topUp = await page.getByRole('link', { name: /top up/i }).boundingBox()
+    expect(topUp!.x, 'top-up dropped below the agent instead of beside it').toBeGreaterThan(name!.x)
+    expect(Math.abs(topUp!.y - name!.y), 'top-up is on a different line').toBeLessThan(80)
+
+    await shot('agents')
+  })
+})


### PR DESCRIPTION
Priority 4 — where one pane hides the other.

## The stall

On a phone Home and Chat are exclusive: one is `hidden` while the other shows. So if the run parks while the reader is on Home, **nothing tells them.** The agent is blocked, the reader is looking at a dashboard that does not change, and the run simply never proceeds.

I reproduced it before changing anything. Settled on the session page, switched to Home, let the approval land:

```
tabs: ["Home:true", "Chat:false"]
body: "Scriptbot Home Chat"
```

That is the whole screen. The run is parked on `approval_needed` and the only visible difference is none.

This covers `approval_needed`, `ask_user`, plan review, the onboard gate and `ulw_turns_reached` — every frame that stops the run pending a human.

## The fix

A marker on the tab you are *not* looking at, cleared the moment the prompt is answered, and carried in the tab's **accessible name** — a dot is nothing to a screen reader, and the reader who cannot see it is exactly the one who would be left waiting.

## The colour was the interesting part

My first version used `bg-brand-500`. It looked fine, and it was wrong twice over:

- the header already spends brand-500 on the **online dot** beside the agent's name, two elements to the left — so the same mark now carried two meanings in one row
- in the transcript `ToolStatus` draws brand-500 for *the agent is working* and neutral-400 for *parked on the reader*. A green dot here said "working" while meaning the opposite

It is now `neutral-400` and pulsing — identical to what a parked tool row already draws. Same colour, same size, same pulse, same meaning. The pulse is what carries the eye without inventing a hue. **A test pins it**, so the collision cannot come back.

This is the "status representation is not unified" complaint in miniature: the inconsistency was one autocomplete away, and only reading the existing component caught it.

## Verification

Written first, failed for the right reasons:

| | before | after |
|---|---|---|
| the Chat tab says the agent is waiting | ✗ nothing there | ✓ |
| announced, not only drawn | ✗ | ✓ |
| answering clears it | ✗ | ✓ |
| a run needing nothing shows no marker | ✓ guards the other way | ✓ |
| the marker is not the "running" colour | — added after the finding | ✓ |

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 70 passed**.

## Two things the probes corrected

**A false positive I nearly shipped.** An early probe showed the view flipping from Home to Chat when the approval landed, which looked like a deliberate auto-switch. It was a race with the landing-page → session-page navigation; my "switch to Home" click was landing on the page about to be replaced. Waiting on the tool card before switching made it reproducible and showed the real behaviour: the reader stays on Home and is told nothing. Had I trusted the first reading I would have "fixed" something that was not happening.

**`mockAgent` needed a delayed approval.** An approval already on screen when you arrive proves nothing about being *told*, so `dashboard-approval` sends it 5s after the input — long enough for the test to settle and switch panes first.

## Left alone

Settings turned out to be well covered on a phone already — 375px specs for the agent row, the address, tool-chip layout, balance and tap targets. I had it listed as a gap from a grep that matched the wrong literal width; it is not one.