### PR TITLE
Tell the reader on Home that the run has stopped for them

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -139,6 +139,13 @@ export default function ChatSessionPage() {
   // said on this connection, while the cache can be a page-load and a spend old.
   const balanceUsd = profile?.balance_usd ?? agentInfoMap[address]?.balance_usd
 
+  // Every frame that parks the run until a human answers. On a phone Home and
+  // Chat are exclusive, so a reader looking at the dashboard has no way to know
+  // the agent stopped and is waiting on them — the run just never proceeds.
+  const awaitsReader = Boolean(
+    pendingApproval || pendingAskUser || pendingUlwTurnsReached || pendingPlanReview || pendingOnboard
+  )
+
   // Consume pending message and apply initial mode from URL
   const consumedRef = useRef<string | null>(null)
 
@@ -282,6 +289,7 @@ export default function ChatSessionPage() {
     <WorkspaceShell
       chat={chatPane}
       hasDashboard={dashboardHtml !== null}
+      chatAwaitsReader={awaitsReader}
       dashboard={
         <DashboardPane
           html={dashboardHtml}

--- a/components/dashboard/view-switch.tsx
+++ b/components/dashboard/view-switch.tsx
@@ -34,10 +34,14 @@ const SEGMENTS = [
 ]
 
 export function ViewSwitch({
-  view, onChange,
+  view, onChange, attention,
 }: {
   view: MobileView
   onChange: (v: MobileView) => void
+  /** The pane holding something the reader has to answer. On a phone the panes
+   *  are exclusive, so without this a run that parks for an approval is invisible
+   *  from the other side and simply never proceeds. */
+  attention?: MobileView | null
 }) {
   return (
     // role=tablist, because the panes are two views of one agent. Without this a
@@ -48,7 +52,11 @@ export function ViewSwitch({
       aria-label="Agent view"
       className="lg:hidden flex shrink-0 items-center gap-0.5 rounded-lg bg-neutral-200/70 p-0.5"
     >
-      {SEGMENTS.map(({ key, label, Icon }) => (
+      {SEGMENTS.map(({ key, label, Icon }) => {
+        // Only on the side you are not looking at: a dot on the pane already in
+        // front of you points at something you can see, which is noise.
+        const waiting = attention === key && view !== key
+        return (
         <button
           key={key}
           role="tab"
@@ -65,8 +73,29 @@ export function ViewSwitch({
         >
           <Icon className="h-4 w-4" aria-hidden />
           {label}
+          {waiting && (
+            <>
+              {/* neutral-400 and pulsing, which is exactly what ToolStatus draws
+                  on a tool row parked on the reader. The app already spends
+                  brand-500 on two other things in this same header row — the
+                  online dot beside the agent's name, and a running tool — so a
+                  third green dot here would have said "the agent is working"
+                  while meaning the opposite. The pulse is what carries the eye.
+
+                  The dot carries nothing for a screen reader, so the accessible
+                  name has to say it too — otherwise the one reader who cannot see
+                  the marker is the one left waiting on a run waiting on them. */}
+              <span
+                data-attention
+                aria-hidden
+                className="ml-0.5 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-neutral-400"
+              />
+              <span className="sr-only">, waiting for you</span>
+            </>
+          )}
         </button>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -24,6 +24,8 @@ interface WorkspaceShellProps {
   chat: React.ReactNode
   dashboard: React.ReactNode
   defaultMobileView?: 'chat' | 'home'
+  /** True while the chat is holding a prompt the run cannot continue without. */
+  chatAwaitsReader?: boolean
   /** False until the agent's dashboard actually arrives; hides the pane until then. */
   hasDashboard?: boolean
 }
@@ -33,6 +35,7 @@ export function WorkspaceShell({
   dashboard,
   defaultMobileView = 'chat',
   hasDashboard = false,
+  chatAwaitsReader = false,
 }: WorkspaceShellProps) {
   // Null until the reader picks a side; their choice then outranks the default forever.
   const [chosenView, chooseView] = useState<'chat' | 'home' | null>(null)
@@ -60,7 +63,7 @@ export function WorkspaceShell({
           divided from the first by one hairline, read as a seam. Rendered from
           here because this is the component that knows hasDashboard. */}
       {hasDashboard && slot && createPortal(
-        <ViewSwitch view={mobileView} onChange={chooseView} />, slot,
+        <ViewSwitch view={mobileView} onChange={chooseView} attention={chatAwaitsReader ? 'chat' : null} />, slot,
       )}
 
       <div className="flex-1 flex min-h-0">

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -79,3 +79,84 @@ test.describe('desktop', () => {
     await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
   })
 })
+
+test.describe('a run that stops while the reader is on Home', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  /** Settle on the session page, then move to Home before the approval lands. */
+  async function waitOnHome(page: import('@playwright/test').Page) {
+    await mockAgent(page, 'dashboard-approval')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    // The tool card means the session page has mounted and the socket is live —
+    // switching before this races the navigation and silently tests the landing page.
+    await expect(page.getByText('check the kernel')).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('tab', { name: 'Home' }).click()
+    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+  }
+
+  test('the Chat tab says the agent is waiting', async ({ page, shot }) => {
+    await waitOnHome(page)
+
+    // On a phone the two panes are exclusive, so a reader on Home cannot see that
+    // the run has parked. The agent is blocked until they answer, and the only
+    // thing on screen is a dashboard that does not change. Without a marker here
+    // the run simply never proceeds.
+    const chatTab = page.getByRole('tab', { name: /Chat/ })
+    await expect(
+      chatTab.locator('[data-attention]'),
+      'nothing on Home says the run has stopped and is waiting for an answer',
+    ).toBeVisible({ timeout: 15_000 })
+
+    await shot('waiting')
+  })
+
+  test('the marker speaks the same status language as the transcript', async ({ page }) => {
+    await waitOnHome(page)
+    const dot = page.getByRole('tab', { name: /Chat/ }).locator('[data-attention]')
+    await expect(dot).toBeVisible({ timeout: 15_000 })
+
+    // ToolStatus draws brand-500 for "the agent is working" and neutral-400 for
+    // "parked on the reader". This dot means the second, and the header already
+    // spends brand-500 on the online indicator two elements to the left — so a
+    // green dot here would have read as a third meaning for the same mark.
+    const colour = await dot.evaluate(el => getComputedStyle(el).backgroundColor)
+    expect(colour, 'the waiting marker is drawn in the colour that means "running"').not.toBe('rgb(34, 197, 94)')
+  })
+
+  test('it is announced, not only drawn', async ({ page }) => {
+    await waitOnHome(page)
+
+    // A dot is invisible to a screen reader. The tab's accessible name has to
+    // carry it, or the one reader who cannot see the marker is the one left
+    // waiting on a run that is waiting on them.
+    await expect(page.getByRole('tab', { name: /Chat.*waiting/i })).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('answering it clears the marker', async ({ page }) => {
+    await waitOnHome(page)
+    const chatTab = page.getByRole('tab', { name: /Chat/ })
+    await expect(chatTab.locator('[data-attention]')).toBeVisible({ timeout: 15_000 })
+
+    await chatTab.click()
+    await page.getByRole('button', { name: /allow once/i }).first().click()
+
+    // A marker that outlives the thing it marks trains the reader to ignore it.
+    await expect(chatTab.locator('[data-attention]')).toHaveCount(0)
+  })
+
+  test('a run that needs nothing shows no marker', async ({ page }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('tab', { name: 'Home' }).click()
+
+    // The marker earns its meaning by being absent the rest of the time.
+    await expect(page.getByRole('tab', { name: /Chat/ }).locator('[data-attention]')).toHaveCount(0)
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'busy' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -90,7 +90,7 @@ export async function mockAgent(
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
-        if (scenario === 'dashboard') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
+        if (scenario === 'dashboard' || scenario === 'dashboard-approval') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
         return
       }
 
@@ -124,7 +124,7 @@ export async function mockAgent(
 
       send(ws, { type: 'thinking', id: 't1', status: 'running' })
 
-      if (scenario === 'tools' || scenario === 'approval') {
+      if (scenario === 'tools' || scenario === 'approval' || scenario === 'dashboard-approval') {
         send(ws, {
           type: 'tool_call',
           id: 'call-1',
@@ -132,6 +132,19 @@ export async function mockAgent(
           args: { command: 'uname -a', description: 'check the kernel' },
           status: 'running',
         })
+      }
+
+      if (scenario === 'dashboard-approval') {
+        // Delayed on purpose: the case worth testing is an approval that arrives
+        // while the reader is looking at Home, which means the test needs time to
+        // switch panes before it lands. An approval that is already on screen when
+        // you get there proves nothing about being told.
+        setTimeout(() => send(ws, {
+          type: 'approval_needed',
+          tool: 'bash:uname',
+          description: 'Run `uname -a`',
+        }), 5000)
+        return
       }
 
       if (scenario === 'approval') {


### PR DESCRIPTION
Priority 4 — where one pane hides the other. (Reopened from #87, which I opened against a stale branch of the same name; the code is identical.)

## The stall

On a phone Home and Chat are exclusive: one is `hidden` while the other shows. So if the run parks while the reader is on Home, **nothing tells them.** The agent is blocked, the reader is looking at a dashboard that does not change, and the run simply never proceeds.

I reproduced it before changing anything. Settled on the session page, switched to Home, let the approval land:

```
tabs: ["Home:true", "Chat:false"]
body: "Scriptbot Home Chat"
```

That is the whole screen. The run is parked on `approval_needed` and the only visible difference is none.

Covers `approval_needed`, `ask_user`, plan review, the onboard gate and `ulw_turns_reached` — every frame that stops the run pending a human.

## The fix

A marker on the tab you are *not* looking at, cleared the moment the prompt is answered, and carried in the tab's **accessible name** — a dot is nothing to a screen reader, and that reader is exactly the one who would be left waiting.

## The colour was the interesting part

My first version used `bg-brand-500`. It looked fine, and it was wrong twice over:

- the header already spends brand-500 on the **online dot** beside the agent's name, two elements to the left — the same mark now carried two meanings in one row
- in the transcript `ToolStatus` draws brand-500 for *the agent is working* and neutral-400 for *parked on the reader*. A green dot here said "working" while meaning the opposite

It is now `neutral-400` and pulsing — identical to what a parked tool row already draws. Same colour, size, pulse, meaning. The pulse carries the eye without inventing a hue. **A test pins it**, so the collision cannot come back.

This is the "status representation is not unified" complaint in miniature: the inconsistency was one autocomplete away, and only reading the existing component caught it.

## Verification

Written first, failed for the right reasons:

| | before | after |
|---|---|---|
| the Chat tab says the agent is waiting | ✗ nothing there | ✓ |
| announced, not only drawn | ✗ | ✓ |
| answering clears it | ✗ | ✓ |
| a run needing nothing shows no marker | ✓ guards the other way | ✓ |
| the marker is not the "running" colour | — added after the finding | ✓ |

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 70 passed**.

## Two things the probes corrected

**A false positive I nearly shipped.** An early probe showed the view flipping from Home to Chat when the approval landed, which looked like a deliberate auto-switch. It was a race with the landing-page → session-page navigation: my "switch to Home" click was landing on the page about to be replaced. Waiting on the tool card first made it reproducible and showed the real behaviour — the reader stays on Home and is told nothing. Had I trusted the first reading I would have "fixed" something that was not happening.

**`mockAgent` needed a delayed approval.** An approval already on screen when you arrive proves nothing about being *told*, so `dashboard-approval` sends it 5s after the input — long enough for the test to settle and switch panes first.

## Left alone

Settings turned out to be well covered on a phone already — 375px specs for the agent row, address, tool-chip layout, balance and tap targets. I had it listed as a gap from a grep that matched the wrong literal width; it is not one.