### PR TITLE
Name, size and untangle the drawer's controls

### DIFF
--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -119,30 +119,40 @@ export function SessionList({
         {sessions.map(session => {
           const isActive = session.sessionId === activeSessionId
           return (
-            <Link
+            // Siblings, not a button inside the anchor. Interactive content inside
+            // an <a> is invalid HTML and assistive technology resolves the pair
+            // ambiguously — the link ends up announcing the button's label as part
+            // of its own name. With a destructive control inside a navigation link
+            // it is the worst version of that: the two things a thumb can land on
+            // are "open this chat" and "delete it forever".
+            <div
               key={session.sessionId}
-              href={`/${agentAddress}/${session.sessionId}`}
-              onClick={onSelect}
-              className={`group relative flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all ${
+              className={`group relative flex items-center rounded-lg text-sm transition-all ${
                 isActive
                   ? 'bg-neutral-100 text-neutral-900 font-medium'
                   : 'text-neutral-600 hover:bg-neutral-100/70'
               }`}
             >
-              <HiOutlineChat className={`w-3.5 h-3.5 shrink-0 ${
-                isActive ? 'text-neutral-700' : 'text-neutral-400'
-              }`} />
-              <span className="truncate flex-1">{cleanTitle(session.title)}</span>
+              <Link
+                href={`/${agentAddress}/${session.sessionId}`}
+                onClick={onSelect}
+                className="flex min-w-0 flex-1 items-center gap-2 py-2 pl-3 pr-1"
+              >
+                <HiOutlineChat className={`w-3.5 h-3.5 shrink-0 ${
+                  isActive ? 'text-neutral-700' : 'text-neutral-400'
+                }`} />
+                <span className="truncate">{cleanTitle(session.title)}</span>
+              </Link>
               {onDelete && (
                 <button
                   onClick={(e) => handleDelete(session.sessionId, e)}
                   aria-label="Delete chat"
-                  className="opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus-visible:opacity-100 p-1 text-neutral-400 hover:text-red-500 rounded transition-opacity"
+                  className="mr-1.5 shrink-0 rounded p-1.5 text-neutral-400 opacity-100 transition-opacity hover:text-red-500 focus-visible:opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
                 >
-                  <HiOutlineTrash className="w-3 h-3" />
+                  <HiOutlineTrash className="h-3.5 w-3.5" />
                 </button>
               )}
-            </Link>
+            </div>
           )
         })}
         {confirmDialog}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -146,6 +146,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           </div>
           <button
             onClick={onClose}
+            aria-label="Close menu"
             className="lg:hidden p-1.5 -mr-1.5 text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 rounded-md transition-colors"
           >
             <HiOutlineX className="w-5 h-5" />

--- a/e2e/drawer.spec.ts
+++ b/e2e/drawer.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * The drawer, control by control.
+ *
+ * The existing coverage checks two specific controls — New chat and Remove agent —
+ * and the gap between them. Everything else in there had never been measured, and
+ * three things were wrong: the close button, which on a phone is the drawer's only
+ * labelled way out, announced as "button" with no name at all; Delete chat was a
+ * 20px destructive target under the app's own 24px floor; and that same delete
+ * button sat *inside* the session's `<Link>`, which is invalid HTML and resolves
+ * ambiguously — the same defect AgentAddress was already fixed for.
+ *
+ * Enumerating every control rather than naming them one at a time, because the
+ * ones nobody thought to name are exactly the ones that were broken.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** A drawer with an agent and one session in it — the state with the most controls. */
+async function openDrawer(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+  await page.getByRole('button', { name: /menu/i }).first().click()
+  const drawer = page.locator('aside')
+  await expect(drawer).toHaveCSS('visibility', 'visible')
+  return drawer
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('every control in the drawer has a name', async ({ page, shot }) => {
+    const drawer = await openDrawer(page)
+
+    // An icon-only control with no text and no aria-label is announced as
+    // "button" — the reader is told a control exists and nothing about it.
+    const unnamed = await drawer.locator('a:visible, button:visible').evaluateAll(els =>
+      els
+        .filter(el => {
+          const name = (el as HTMLElement).innerText.trim()
+            || el.getAttribute('aria-label')
+            || el.getAttribute('title')
+          return !name
+        })
+        .map(el => `${el.tagName} ${el.className.toString().slice(0, 60)}`)
+    )
+    expect(unnamed, 'these announce as bare "button" / "link"').toEqual([])
+
+    await shot('drawer')
+  })
+
+  test('every control clears the touch floor', async ({ page }) => {
+    const drawer = await openDrawer(page)
+
+    const small: string[] = []
+    for (const el of await drawer.locator('a:visible, button:visible').all()) {
+      const box = await el.boundingBox()
+      if (!box) continue
+      if (box.width < 24 || box.height < 24) {
+        const name = (await el.getAttribute('aria-label')) || (await el.innerText())
+        small.push(`${name.replace(/\s+/g, ' ').trim().slice(0, 24)} — ${Math.round(box.width)}x${Math.round(box.height)}`)
+      }
+    }
+    // Delete chat was 20x20. It is the one control here that destroys something,
+    // and it was the smallest thing in the drawer.
+    expect(small, 'targets below the 24px floor').toEqual([])
+  })
+
+  test('deleting a chat is not nested inside opening it', async ({ page }) => {
+    const drawer = await openDrawer(page)
+
+    const del = drawer.getByRole('button', { name: /delete chat/i }).first()
+    await expect(del).toBeVisible()
+
+    // A button inside an anchor is invalid HTML and assistive technology resolves
+    // the pair ambiguously — the outer control ends up announcing the inner one's
+    // label as part of its own name. Doing it with a destructive control inside a
+    // navigation link is the worst version: the two things a thumb can land on are
+    // "open this chat" and "delete it".
+    const nested = await del.evaluate(el => Boolean(el.closest('a')))
+    expect(nested, 'the delete button is inside the session link').toBe(false)
+  })
+
+  test('delete asks first, and the chat survives a cancel', async ({ page, shot }) => {
+    const drawer = await openDrawer(page)
+
+    await drawer.getByRole('button', { name: /delete chat/i }).first().click()
+
+    // Destroying a conversation is confirmed, not immediate.
+    const cancel = page.getByRole('button', { name: /cancel/i }).first()
+    await expect(cancel).toBeVisible()
+    await shot('confirm')
+
+    await cancel.click()
+    await expect(page.getByRole('link', { name: /what can you do/i }).first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
Priorities 1 and 3 — the sidebar drawer on a phone.

## Why enumerate instead of naming

The existing drawer coverage checks two controls by name — New chat and Remove agent — and the gap between them. I listed *every* control in an open drawer instead, and the three that were wrong were all ones nobody had thought to name.

## What was wrong

**The close button had no accessible name.** `<button>` with an icon, no text, no `aria-label`. It announces as "button". On a phone this is the drawer's only labelled way out — the alternative is knowing to tap the scrim.

**Delete chat was 20×20.** `p-1` plus a `w-3` icon. The rest of the app holds a 24px floor, and this is the one control in the drawer that destroys something — it was the smallest thing in there.

**And that delete button was inside the session `<Link>`.** Interactive content inside an anchor is invalid HTML and assistive technology resolves the pair ambiguously — the link ends up announcing the button's label as part of its own name. With a *destructive* control inside a *navigation* link it is the worst version: the two things a thumb can land on are "open this chat" and "delete it forever".

That last one is the same defect `AgentAddress` was already fixed for, with the same fix — siblings in a flex row, not one inside the other.

## Verification

Written first, and each failed with the actual measurement:

```
every control has a name    →  BUTTON lg:hidden p-1.5 -mr-1.5 text-neutral-400…
clears the touch floor      →  Delete chat — 20x20
delete is not nested        →  Received: true
delete asks first           →  passed already (guards the other direction)
```

After: **10 passed** across the new spec and the existing mobile drawer tests, so the restructured row did not break the tap-target spacing rule that was already there.

Then `tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 74 passed**.

I looked at the drawer screenshot after the restructure — title, trash icon and alignment are unchanged.

## A false failure worth recording

The first full-suite run came back with 3 failures in `dashboard`, `safe-area` and `transcript` — none of them anywhere near this change. They were all `ENOSPC: no space left on device`. The machine was at 1.2G free, largely from my own accumulated worktrees across previous passes; Playwright reported them as ordinary assertion failures with screenshots that could not be written.

Cleaned up eight merged worktrees (~8G reclaimed, checked each for uncommitted work first — `git worktree remove` without `--force`) and re-ran: **74 passed, 0 failed**. Worth knowing that a full disk surfaces as scattered unrelated test failures rather than as a disk error.

## Left alone

Tapping an agent or a session in the drawer already closes it on a phone — I probed that first expecting a bug and there is not one.