### PR TITLE
Cover the transcript following a reply, and letting go

### DIFF
--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -176,6 +176,36 @@ export async function mockAgent(
           result: 'Read the page, rebuilt the site, and updated the layout.\n\n```ts\nexport default function Layout({ children }: { children: React.ReactNode }) {\n  return <html><body>{children}</body></html>\n}\n```\n\nThe build finished in 4.2 seconds.',
           session: { session_id: 'e2e-session' },
         })
+        return
+      }
+
+      // Content that arrives in stages and ends up several viewports tall. The
+      // stick-to-bottom logic watches content height rather than item count, so a
+      // reply that lands in one frame would never exercise it — it has to grow
+      // while the reader is sitting there.
+      if (scenario === 'long-reply') {
+        for (let i = 1; i <= 24; i++) {
+          setTimeout(() => send(ws, {
+            type: 'tool_call',
+            id: `long-${i}`,
+            name: 'read_file',
+            args: { file_path: `src/step-${i}.ts` },
+            status: 'running',
+          }), i * 120)
+          setTimeout(() => send(ws, {
+            type: 'tool_result',
+            id: `long-${i}`,
+            name: 'read_file',
+            status: 'done',
+            result: Array.from({ length: 6 }, (_, n) => `step ${i} line ${n + 1}`).join('\n'),
+            timing_ms: 40,
+          }), i * 120 + 40)
+        }
+        setTimeout(() => send(ws, {
+          type: 'OUTPUT',
+          result: 'Walked every step. The last line is the one that matters.',
+          session: { session_id: 'e2e-session' },
+        }), 3400)
         return
       }
 

--- a/e2e/scroll-follow.spec.ts
+++ b/e2e/scroll-follow.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Following a reply as it arrives, and being left alone while reading back.
+ *
+ * `ChatMessages` keeps a `stickToBottomRef` and a ResizeObserver on the content:
+ * grow the content and it follows, unless the reader has scrolled away from the
+ * bottom. Streamed tokens grow items in place rather than appending to `ui`, so
+ * the observer watches height, not item count. None of it had a test.
+ *
+ * Both directions matter and they fail differently. If following breaks, the
+ * answer scrolls past below the fold and the reader watches a stale screen. If
+ * the release breaks, the transcript rips itself back down every time a token
+ * lands and reading back during a run becomes impossible — which on a phone is
+ * most of the transcript, most of the time.
+ *
+ * ---
+ *
+ * Use a real gesture. `el.scrollTop = 0` does NOT prove anything here: the
+ * assignment fires its `scroll` event asynchronously, and with content arriving
+ * every ~120ms the ResizeObserver gets there first, slams the position back to
+ * the bottom, and the scroll event then reports "at bottom" and re-arms the
+ * stick. Measured that way the reader appears unable to scroll up at all — I
+ * had it diagnosed as a broken transcript before checking with `mouse.wheel`,
+ * where it behaves correctly. The artifact looks exactly like the bug.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** The messages viewport. The only scrolling box in the chat tree. */
+const SCROLLER = 'div.overflow-y-auto.overflow-x-hidden'
+
+function distanceFromBottom(page: import('@playwright/test').Page) {
+  return page.locator(SCROLLER).first().evaluate(
+    el => Math.round(el.scrollHeight - el.scrollTop - el.clientHeight)
+  )
+}
+
+/** Send, then let the staged reply start arriving. */
+async function startLongReply(page: import('@playwright/test').Page) {
+  await mockAgent(page, 'long-reply')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('step-1.ts')).toBeVisible({ timeout: 20_000 })
+}
+
+/** A real wheel gesture, which is what produces synchronous scroll events.
+ *  Waits for something to actually scroll first: wheeling a box that still fits
+ *  its content moves nothing, and the assertion that follows then fails for a
+ *  reason that has nothing to do with the behaviour under test. */
+async function wheelUp(page: import('@playwright/test').Page) {
+  await expect
+    .poll(() => page.locator(SCROLLER).first().evaluate(el => el.scrollHeight - el.clientHeight), { timeout: 15_000 })
+    .toBeGreaterThan(200)
+
+  await page.mouse.move(187, 300)
+  for (let i = 0; i < 6; i++) {
+    await page.mouse.wheel(0, -120)
+    await page.waitForTimeout(60)
+  }
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a reply that outgrows the screen stays followed to its last line', async ({ page, shot }) => {
+    await startLongReply(page)
+
+    // The sentence the agent ends on. If following breaks this is below the fold
+    // and the reader is looking at the middle of a finished answer.
+    await expect(page.getByText('The last line is the one that matters.')).toBeVisible({ timeout: 20_000 })
+    expect(await distanceFromBottom(page), 'the transcript stopped following the reply').toBeLessThanOrEqual(4)
+
+    await shot('followed')
+  })
+
+  test('scrolling back does not get undone by the next token', async ({ page, shot }) => {
+    await startLongReply(page)
+    await wheelUp(page)
+
+    const parked = await distanceFromBottom(page)
+    expect(parked, 'the wheel gesture did not move the transcript').toBeGreaterThan(40)
+
+    // The run keeps producing while the reader reads. Nothing may pull them down.
+    await page.waitForTimeout(2500)
+    const after = await distanceFromBottom(page)
+    expect(after, 'new content dragged the reader back to the bottom').toBeGreaterThanOrEqual(parked)
+
+    await shot('parked')
+  })
+
+  test('a way back down appears, and only while it is needed', async ({ page }) => {
+    await startLongReply(page)
+
+    const button = page.getByRole('button', { name: /scroll to bottom/i })
+    // Nothing to go back to while already there — a permanent button is clutter.
+    await expect(button).toHaveCount(0)
+
+    await wheelUp(page)
+
+    // toBeVisible() alone is not enough and would have passed on a button that
+    // had drifted out of the transcript's visible box: an element scrolled out of
+    // an overflow container still has a box and still counts as visible. The
+    // button is positioned `absolute bottom-4` against an ancestor, so where it
+    // lands is worth measuring rather than assuming.
+    await expect(button).toBeInViewport()
+
+    const box = await button.boundingBox()
+    const pane = await page.locator(SCROLLER).first().boundingBox()
+    expect(box!.y, 'the way back down sits above the transcript').toBeGreaterThanOrEqual(pane!.y)
+    expect(box!.y + box!.height, 'the way back down has drifted below the transcript').toBeLessThanOrEqual(pane!.y + pane!.height)
+    expect(Math.min(box!.width, box!.height), `the button is ${box!.width}x${box!.height}`).toBeGreaterThanOrEqual(24)
+
+    await button.click()
+    await expect(button).toHaveCount(0)
+    // And it re-arms the follow, rather than dropping the reader at the bottom
+    // once and letting the next token scroll away from them again.
+    await expect.poll(() => distanceFromBottom(page), { timeout: 10_000 }).toBeLessThanOrEqual(4)
+  })
+})


### PR DESCRIPTION
Priority 1 — the reading half of the mobile flow. `ChatMessages`'s stick-to-bottom had **zero coverage**, and it is the subtlest thing in the chat tree: a ref, a ResizeObserver, and an 80px threshold.

It fails two ways, and they are opposite:

- **follow breaks** → the answer scrolls past below the fold and the reader watches a stale screen while the agent finishes
- **release breaks** → the transcript rips itself back down on every token, and reading back during a run becomes impossible. On a phone that is most of the transcript, most of the time

## What the tests pin

Following a reply to its last line · staying parked where the reader left it while content keeps arriving · the way back down appearing only while it is needed, sized, positioned inside the transcript, and re-arming the follow when used.

## Verified by breaking it

A test that has never failed proves nothing, so I broke each direction against the real component:

| change | result |
|---|---|
| `if (false) el.scrollTop = …` in the observer | ✗ *the transcript stopped following the reply* |
| `stickToBottomRef.current = true` always | ✗ *new content dragged the reader back to the bottom* |

Restored, and `git status` confirms this PR touches **test files only**.

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 77 passed**.

## Three things that would have made this test lie

**`el.scrollTop = 0` proves nothing.** The assignment fires its `scroll` event asynchronously; with content arriving every ~120ms the ResizeObserver gets there first, slams the position back to the bottom, and the scroll event then reports "at bottom" and re-arms the stick. Measured that way **the reader appears unable to scroll up at all** — I had this diagnosed as a broken transcript and was ready to fix it. `mouse.wheel` produces synchronous scroll events and shows the behaviour is correct. The artifact is indistinguishable from the bug it imitates.

**A gesture needs something to scroll.** After I changed a wait anchor the spec began wheeling a box that still fit its content; nothing moved and the assertion failed for a reason unrelated to the behaviour. The precondition is now asserted (`scrollHeight - clientHeight > 200`) rather than waited for.

**`toBeVisible()` is not "on screen" inside an overflow container.** An element scrolled out of a scroller still has a box and still passes. Since the button is `absolute bottom-4` against an ancestor, the spec now uses `toBeInViewport()` and asserts it lands within the transcript's visible box.

## A correction

I read the parked screenshot as missing the scroll-down button and started looking for a positioning bug. Measurement says otherwise — the button sits at y 471–507 inside a pane spanning 56–523, correctly placed. I had misread a low-contrast control against a dense list. No bug; the stronger assertion above is what came out of checking.

## Left alone

A phone-wide sweep for unnamed and undersized controls across landing, transcript, approval, settings and the invite gate came back **0 and 0** on all five. The drawer fixed in #89 was the only offender, so there is nothing to chase there — worth recording as a measured result rather than an untested assumption.