### PR TITLE
Say disconnected when the socket is gone

### DIFF
--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -101,7 +101,10 @@ export function ModeStatusBar({ mode, onModeChange, disabled, sessionState, conn
               <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
               <span className="text-[11px] text-red-600">error</span>
               {onRetry && (
-                <button onClick={onRetry} className="text-[11px] text-red-600 hover:text-red-700 underline">
+                <button
+                  onClick={onRetry}
+                  className="-my-1.5 inline-flex min-h-6 items-center py-1.5 text-[11px] text-red-600 underline hover:text-red-700"
+                >
                   retry
                 </button>
               )}
@@ -111,7 +114,10 @@ export function ModeStatusBar({ mode, onModeChange, disabled, sessionState, conn
               <span className="w-1.5 h-1.5 rounded-full bg-neutral-400" />
               <span className="text-[11px] text-neutral-500">disconnected</span>
               {onReconnect && (
-                <button onClick={onReconnect} className="text-[11px] text-neutral-500 hover:text-neutral-700 underline">
+                <button
+                  onClick={onReconnect}
+                  className="-my-1.5 inline-flex min-h-6 items-center py-1.5 text-[11px] text-neutral-500 underline hover:text-neutral-700"
+                >
                   reconnect
                 </button>
               )}

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -384,7 +384,14 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     pendingPlanReview,
     sessionState: connectionState === 'reconnecting' ? 'reconnecting' as const
       : connectionState === 'connected' || isLoading ? 'active' as const
-      : serverSessionAlive ? 'disconnected' as const
+      // The transport's own word counts, not only the server poll. That poll
+      // reports true while the *server* still has a run in flight, so a socket
+      // dropped while the agent was idle fell through to 'connected' below — the
+      // reader was told everything was fine and typed into a dead socket. Gated on
+      // there being a conversation, because before the first send the transport is
+      // legitimately not connected yet and saying so would put an error state on
+      // every first impression.
+      : serverSessionAlive || (connectionState === 'disconnected' && cleanUI.length > 0) ? 'disconnected' as const
       : cleanUI.length > 0 ? 'connected' as const
       : 'idle' as const,
     currentSession,

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -91,10 +91,28 @@ export async function mockAgent(
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
         if (scenario === 'dashboard' || scenario === 'dashboard-approval') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
+
+        // The connection goes away after it was working: a tunnel, a handover
+        // between wifi and cellular, the screen locking. Closed here rather than
+        // on INPUT because sending from the landing page navigates to the session
+        // page, which opens a *fresh* socket — an INPUT-triggered close lands on
+        // the socket already being torn down and the session never notices.
         return
       }
 
       if (msg.type !== 'INPUT') return
+
+      // The connection goes away mid-run: a tunnel, a wifi/cellular handover, the
+      // screen locking. Dropped on INPUT rather than on CONNECT because both the
+      // landing page and the session page open a socket, and only the one that has
+      // received an INPUT is certainly the session's — closing on CONNECT can kill
+      // the landing page's socket, which is about to be discarded anyway, and the
+      // session then sits there perfectly connected.
+      if (scenario === 'drop') {
+        send(ws, { type: 'thinking', id: 't1', status: 'done' })
+        setTimeout(() => ws.close({ code: 1006, reason: 'connection lost' }), 800)
+        return
+      }
 
       if (scenario === 'error') {
         send(ws, { type: 'ERROR', message: 'the agent ran out of credits' })

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * What the reader is told when the connection goes away.
+ *
+ * This is the ordinary phone failure — a tunnel, a handover between wifi and
+ * cellular, the screen locking long enough for the socket to be reaped. The
+ * agent stops being reachable and the reader is left looking at a status line.
+ *
+ * `ModeStatusBar` has a `disconnected` branch with a `reconnect` link, and it was
+ * effectively never shown: the state was derived from an HTTP poll that only
+ * reports true while the *server* still has a run in flight, so a socket that
+ * dropped while the agent was idle fell through to "connected". The reader is
+ * told everything is fine, types into a dead socket, and waits.
+ *
+ * ---
+ *
+ * Dropping the socket is fiddly and the ways to get it wrong all look like
+ * findings. Two that cost real time here:
+ *
+ *   - Closing on CONNECT can close the *landing page's* socket. Sending a message
+ *     navigates to the session page, which opens a fresh one, so the session is
+ *     left perfectly connected and the test proves nothing. The drop happens on
+ *     INPUT, which only the session's socket receives.
+ *   - Reading `readyState` through a `window.WebSocket` shim is not evidence. The
+ *     shim caught one of the two sockets, so it reported OPEN for a connection
+ *     that had genuinely closed. `console.log` from inside the route handler is
+ *     the reliable witness that the close actually ran.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** Send a message, then let the mock close the session's socket underneath it. */
+async function dropMidRun(page: import('@playwright/test').Page) {
+  await mockAgent(page, 'drop')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('What can you do?').first()).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a dropped connection is not reported as connected', async ({ page, shot }) => {
+    await dropMidRun(page)
+
+    // "connected" beside a socket that is gone is the worst of the options: it is
+    // the one state that tells the reader to keep waiting.
+    await expect(page.getByText('disconnected', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('connected', { exact: true })).toHaveCount(0)
+
+    await shot('dropped')
+  })
+
+  test('and offers a way back, at a size a thumb can hit', async ({ page }) => {
+    await dropMidRun(page)
+
+    const reconnect = page.getByRole('button', { name: /reconnect/i })
+    await expect(reconnect, 'no way back from a dead connection').toBeVisible({ timeout: 15_000 })
+
+    // It was an 11px underlined word. This is the control someone reaches for
+    // one-handed, on a train, having just come out of a tunnel.
+    const box = await reconnect.boundingBox()
+    expect(box!.height, `reconnect is ${Math.round(box!.width)}x${Math.round(box!.height)}`).toBeGreaterThanOrEqual(24)
+  })
+
+  test('a fresh landing page is not accused of being disconnected', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+    // Before anything is sent the transport is legitimately not connected yet.
+    // Saying so would put an error state on every first impression.
+    await expect(page.getByText('disconnected', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /reconnect/i })).toHaveCount(0)
+  })
+
+  test('a healthy conversation still reads as live', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // The other direction: the fix must not start calling working sockets dead.
+    await expect(page.getByText('live', { exact: true })).toBeVisible()
+    await expect(page.getByText('disconnected', { exact: true })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Priority 1 — the ordinary phone failure. A tunnel, a wifi/cellular handover, the screen locking long enough for the socket to be reaped.

## What happened

**The UI reported `connected` for a socket that was gone.**

`sessionState` only reached `disconnected` through `serverSessionAlive`, an HTTP poll that reports true while the **server** still has a run in flight. A socket that dropped while the agent was idle — which is most of the time — left that false, and the derivation fell through to:

```js
: cleanUI.length > 0 ? 'connected'
```

So the reader is told everything is fine, types into a dead socket, and waits. The `disconnected` branch in `ModeStatusBar` and its `reconnect` link exist for precisely this moment and were effectively never shown.

The transport has said `disconnected` all along — `ConnectionState = 'disconnected' | 'connected' | 'reconnecting'` — the derivation just never asked it.

## The fix

One clause: trust the transport's own word, gated on there being a conversation, so a fresh landing page is not accused of being disconnected before its first send. The poll keeps its narrower job rather than being ripped out.

And **`reconnect` and `retry` were 11px underlined words.** These are the controls someone reaches for one-handed, on a train, having just come out of a tunnel. Both now clear 24px, via negative margin so the status bar's height is unchanged.

## Verification

| | before | after |
|---|---|---|
| a dropped connection is not reported as connected | ✗ element not found | ✓ |
| offers a way back, at a thumb-sized target | ✗ *no way back from a dead connection* | ✓ |
| a fresh landing page is not accused | ✓ guards the other way | ✓ |
| a healthy conversation still reads as live | ✓ guards the other way | ✓ |

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 81 passed**. Screenshot checked: `disconnected · reconnect` sits bottom-left, underlined, tappable.

## Two dead ends, both of which looked like findings

**Closing on CONNECT proves nothing.** Sending from the landing page navigates to the session page, which opens a *fresh* socket — so an early close kills the socket already being discarded and the session sits there perfectly connected. The drop now happens on INPUT, which only the session's socket receives.

**`readyState` read through a `window.WebSocket` shim is not evidence.** The shim caught only one of the two sockets and reported `OPEN` for a connection that had genuinely closed, which sent me looking for a bug in the wrong place twice. `console.log` from inside the route handler is the reliable witness that the close actually ran. Both traps are written into the spec header.

## Left alone

With the connection dropped, the header still shows the agent's green online dot beside its name. That is a different fact — the agent *is* online per `/info`; it is this socket that died — so collapsing the two would be wrong. Noting it rather than changing it, since a reader could reasonably read the pair as contradictory and that is a product call about which fact the header should carry.