### PR TITLE
Come back on their own when the connection returns

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -213,6 +213,29 @@ export default function ChatSessionPage() {
     reconnect()
   }, [reconnect, setConnectionError])
 
+  // Coming out of a tunnel, or unlocking a phone after the socket was reaped,
+  // should not require noticing a status line at the bottom of the screen and
+  // tapping a word in it. The reader's agent stopped working through no action of
+  // theirs; it should start working again the same way.
+  //
+  // Bound to the transitions the browser reports rather than a timer, and armed
+  // only while actually disconnected — so a working socket is never torn down
+  // mid-run just because the tab was switched to, and an agent that is genuinely
+  // gone is not hammered on an interval.
+  useEffect(() => {
+    if (sessionState !== 'disconnected') return
+
+    const recover = () => {
+      if (document.visibilityState === 'visible' && navigator.onLine) handleReconnect()
+    }
+    window.addEventListener('online', recover)
+    document.addEventListener('visibilitychange', recover)
+    return () => {
+      window.removeEventListener('online', recover)
+      document.removeEventListener('visibilitychange', recover)
+    }
+  }, [sessionState, handleReconnect])
+
   // Redirect to agent landing if no conversation and no pending messages
   // Only after store has hydrated from localStorage — avoids redirect on refresh
   const shouldRedirect = _hasHydrated && !conversation && hookUI.length === 0

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -65,6 +65,12 @@ export async function mockAgent(
   overrides: Partial<typeof PROFILE> = {},
 ) {
   const profile = { ...PROFILE, ...overrides }
+  /** Per-call, so the drop scenario interrupts one connection rather than all of them. */
+  let dropped = false
+  /** How many times a client has handshaked. The only way to see a socket torn
+   *  down and reopened behind the reader — the screen looks identical either way,
+   *  which is what makes a screen-level assertion about it vacuous. */
+  let connects = 0
 
   // Every socket except Next's dev-mode hot reload. Which host the SDK dials
   // depends on what the relay record advertises — relay socket for a hosted agent,
@@ -86,6 +92,7 @@ export async function mockAgent(
           })
           return
         }
+        connects += 1
         send(ws, { type: 'CONNECTED', session_id: 'e2e-session', status: 'idle' })
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
@@ -108,7 +115,11 @@ export async function mockAgent(
       // received an INPUT is certainly the session's — closing on CONNECT can kill
       // the landing page's socket, which is about to be discarded anyway, and the
       // session then sits there perfectly connected.
-      if (scenario === 'drop') {
+      // Once, then the tunnel ends. A scenario that drops every socket can show
+      // the disconnected state but never whether the way back out of it works —
+      // reconnect would reopen straight into another drop.
+      if (scenario === 'drop' && !dropped) {
+        dropped = true
         send(ws, { type: 'thinking', id: 't1', status: 'done' })
         setTimeout(() => ws.close({ code: 1006, reason: 'connection lost' }), 800)
         return
@@ -288,4 +299,9 @@ export async function mockAgent(
       body: JSON.stringify({ token: 'e2e-token', public_key: '0xe2e' }),
     })
   )
+
+  return {
+    /** Handshakes seen so far. */
+    connects: () => connects,
+  }
 }

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -85,3 +85,72 @@ test.describe('phone', () => {
     await expect(page.getByText('disconnected', { exact: true })).toHaveCount(0)
   })
 })
+
+test.describe('coming back', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('the reconnect link actually restores the session', async ({ page, shot }) => {
+    await dropMidRun(page)
+
+    const link = page.getByRole('button', { name: /reconnect/i })
+    await expect(link).toBeVisible({ timeout: 15_000 })
+    await link.click()
+
+    // Not just a status flipping back — the session has to carry a message again,
+    // which is the only thing the reader actually wanted.
+    await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(link).toHaveCount(0)
+
+    await page.getByPlaceholder(/message/i).fill('are you back?')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('You said: are you back?')).toBeVisible({ timeout: 20_000 })
+
+    await shot('recovered')
+  })
+
+  test('regaining connectivity reconnects without being asked', async ({ page }) => {
+    await dropMidRun(page)
+    await expect(page.getByRole('button', { name: /reconnect/i })).toBeVisible({ timeout: 15_000 })
+
+    // The browser's own event, the one that fires when a phone comes out of a
+    // tunnel. Nobody should have to notice a status line at the bottom of the
+    // screen and tap a word in it to get their agent back.
+    await page.evaluate(() => window.dispatchEvent(new Event('online')))
+
+    await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('button', { name: /reconnect/i })).toHaveCount(0)
+  })
+
+  test('returning to the tab reconnects without being asked', async ({ page }) => {
+    await dropMidRun(page)
+    await expect(page.getByRole('button', { name: /reconnect/i })).toBeVisible({ timeout: 15_000 })
+
+    // Locking a phone long enough for the socket to be reaped, then unlocking it.
+    await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('a healthy session is not reconnected behind the reader', async ({ page }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // Counting handshakes, not reading the screen. An earlier version of this test
+    // asserted the transcript still said "live" with the message intact, and it
+    // passed with the `sessionState !== 'disconnected'` guard deleted — a torn-down
+    // and reopened socket looks exactly like one that was never touched. The only
+    // thing that can tell them apart is the far end.
+    const before = agent.connects()
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('online'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await page.waitForTimeout(2000)
+
+    expect(agent.connects(), 'a working socket was torn down and reopened').toBe(before)
+    await expect(page.getByText('You said: What can you do?')).toBeVisible()
+  })
+})


### PR DESCRIPTION
Follow-on from #91, which made the disconnected state visible and gave it a `reconnect` link. Two things were still missing.

## The link was never proven to work

#91 tested that it *appears* and is big enough to tap. Not that tapping it does anything. It does — status returns to `live`, the transcript survives, and a new message gets a real reply — but that is now asserted rather than assumed.

## The link should rarely be needed

Coming out of a tunnel, or unlocking a phone after the socket was reaped, should not require noticing a small status line at the bottom of the screen and tapping a word inside it. **The reader's agent stopped working through no action of theirs; it should start working again the same way.**

Nothing in the app listened for connectivity or visibility returning. Now it does — bound to the browser's own `online` and `visibilitychange` events rather than a timer, and armed **only while actually disconnected**, so:

- a working socket is never torn down mid-run because the tab was switched to
- an agent that is genuinely gone is not hammered on an interval

## The guard test was worthless and I nearly shipped it

"A healthy session is not reconnected behind the reader" originally asserted that the transcript still said `live` with the message intact. I deleted the `sessionState !== 'disconnected'` guard to check it could fail — **it passed anyway**. A socket torn down and reopened looks exactly like one that was never touched; there is nothing on screen that distinguishes them.

`mockAgent` now counts handshakes and returns the count, so the test observes the far end instead:

```
expect(agent.connects(), 'a working socket was torn down and reopened').toBe(before)
```

Re-checked with the guard deleted: **fails**, with that message. That is the third time this pass series a screen-level assertion has been green against broken code, and the pattern is always the same — asserting the thing that looks like the bug rather than the thing that *is* it.

## Verification

| | before | after |
|---|---|---|
| the reconnect link actually restores the session | ✓ (never previously asserted) | ✓ |
| regaining connectivity reconnects unasked | ✗ | ✓ |
| returning to the tab reconnects unasked | ✗ | ✓ |
| a healthy session is left alone | ✗ vacuous → now real | ✓ |

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 85 passed**. Screenshot checked: after recovery the transcript is intact, `are you back?` is answered, status reads `live`.

The `drop` scenario is now one-shot — a mock that drops every socket can show the disconnected state but never whether the way out of it works, since reconnect would reopen straight into another drop.

## Left alone

`visibilitychange` is dispatched by the test rather than by genuinely backgrounding the tab, which Playwright cannot do to a real phone's lock screen. The listener wiring and the guard are what the test covers; the browser firing that event when a phone unlocks is behaviour I am taking on trust.