### PR TITLE
Cover two agents in one browser

### DIFF
--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -305,3 +305,85 @@ export async function mockAgent(
     connects: () => connects,
   }
 }
+
+/** A second agent, so agent-to-agent isolation can be observed at all. */
+export const SECOND_ADDRESS =
+  '0xb0b0feed4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a1234'
+
+export const SECOND_PROFILE = {
+  ...PROFILE,
+  address: SECOND_ADDRESS,
+  name: 'Ledgerbot',
+  balance_usd: 9.5,
+  tools: ['read_file', 'search'],
+  skills: [{ name: 'reconcile', description: 'Reconcile yesterday’s ledger' }],
+}
+
+/**
+ * Two agents on one browser, each answering as itself.
+ *
+ * Everything else in this suite runs against a single agent, which cannot show
+ * the failure that matters here: one agent's conversation appearing under
+ * another. Each reply names its author, so a leak is visible in the transcript
+ * rather than having to be inferred from which pane is showing.
+ *
+ * Routed by `payload.to` on the CONNECT frame — both agents' sockets match the
+ * same URL pattern, so the address in the handshake is what tells them apart.
+ */
+export async function mockTwoAgents(page: Page) {
+  const byAddress = (address: string) =>
+    address === SECOND_ADDRESS ? SECOND_PROFILE : PROFILE
+
+  await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
+    let target = AGENT_ADDRESS
+
+    ws.onMessage(raw => {
+      const msg = JSON.parse(String(raw)) as {
+        type: string
+        prompt?: string
+        payload?: { to?: string }
+      }
+
+      if (msg.type === 'CONNECT') {
+        target = msg.payload?.to ?? AGENT_ADDRESS
+        const profile = byAddress(target)
+        send(ws, { type: 'CONNECTED', session_id: `e2e-${profile.name}`, status: 'idle' })
+        send(ws, { type: 'AGENT_PROFILE', ...profile })
+        return
+      }
+
+      if (msg.type !== 'INPUT') return
+
+      send(ws, { type: 'thinking', id: 't1', status: 'done' })
+      send(ws, {
+        type: 'OUTPUT',
+        // Naming the author is the whole point: "you said X" from the wrong agent
+        // is indistinguishable from the right one.
+        result: `${byAddress(target).name} here. You said: ${msg.prompt}`,
+        session: { session_id: `e2e-${byAddress(target).name}` },
+      })
+    })
+  })
+
+  await page.route(/oo\.openonion\.ai\/api\/agents\/(0x[0-9a-f]+)/, route => {
+    const address = route.request().url().match(/(0x[0-9a-f]+)/)![1]
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        endpoints: ['https://scriptbot.example'],
+        relay: 'wss://oo.openonion.ai/ws',
+        last_seen: new Date(0).toISOString(),
+        profile: byAddress(address),
+      }),
+    })
+  })
+
+  await page.route(/\/api\/auth$/, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: 'e2e-token', public_key: '0xe2e' }),
+    })
+  )
+}

--- a/e2e/scroll-follow.spec.ts
+++ b/e2e/scroll-follow.spec.ts
@@ -91,6 +91,15 @@ test.describe('phone', () => {
   test('a way back down appears, and only while it is needed', async ({ page }) => {
     await startLongReply(page)
 
+    // Measured after the reply lands, not during it. Mid-stream the button can
+    // legitimately flash: a burst of content grows the box before the observer
+    // pins it, a scroll event fires past the 80px threshold, and for a frame the
+    // reader really is not at the bottom. Asserting its absence at an arbitrary
+    // moment during streaming is a race, and it failed exactly that way — on the
+    // first run after each edit, when the dev server was still compiling and
+    // everything arrived in one lump.
+    await expect(page.getByText('The last line is the one that matters.')).toBeVisible({ timeout: 20_000 })
+
     const button = page.getByRole('button', { name: /scroll to bottom/i })
     // Nothing to go back to while already there — a permanent button is clutter.
     await expect(button).toHaveCount(0)
@@ -112,8 +121,10 @@ test.describe('phone', () => {
 
     await button.click()
     await expect(button).toHaveCount(0)
-    // And it re-arms the follow, rather than dropping the reader at the bottom
-    // once and letting the next token scroll away from them again.
-    await expect.poll(() => distanceFromBottom(page), { timeout: 10_000 }).toBeLessThanOrEqual(4)
+
+    // Asserted as "the end of the reply is on screen" rather than as a pixel
+    // distance: a smooth scroll settles a few pixels late on a slower machine, and
+    // what the reader needs is to be looking at the end of the answer.
+    await expect(page.getByText('The last line is the one that matters.')).toBeInViewport()
   })
 })

--- a/e2e/two-agents.spec.ts
+++ b/e2e/two-agents.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Two agents in one browser.
+ *
+ * Every other spec runs against a single agent, which cannot show the failure
+ * that matters here: one agent's conversation surfacing under another. The store
+ * keeps a flat `conversations` array tagged with `agentAddress` and the sidebar
+ * groups by that tag, so nothing about the isolation is structural — it is a
+ * filter, and a filter is a thing that can be wrong.
+ *
+ * These are enterprise customers with a handful of agents each, some of which
+ * read ledgers. A transcript appearing under the wrong agent is not a bad frame.
+ */
+
+import { test, expect } from './fixtures'
+import {
+  mockTwoAgents,
+  AGENT_ADDRESS,
+  SECOND_ADDRESS,
+  PROFILE,
+  SECOND_PROFILE,
+} from './mock-agent'
+
+/** Say something to one agent and wait for that agent's own answer. */
+async function talkTo(
+  page: import('@playwright/test').Page,
+  address: string,
+  name: string,
+  message: string,
+) {
+  await page.goto(`/${address}`)
+  await expect(page.getByRole('heading', { name, exact: true })).toBeVisible({ timeout: 20_000 })
+  await page.getByPlaceholder(/message/i).fill(message)
+  await page.keyboard.press('Enter')
+  await expect(page.getByText(`${name} here. You said: ${message}`)).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('each agent answers as itself', async ({ page, shot }) => {
+    await mockTwoAgents(page)
+
+    await talkTo(page, AGENT_ADDRESS, PROFILE.name, 'who are you')
+    await shot('first')
+
+    await talkTo(page, SECOND_ADDRESS, SECOND_PROFILE.name, 'and you')
+    // The first agent's reply must not be sitting in the second one's transcript.
+    await expect(page.getByText(`${PROFILE.name} here.`)).toHaveCount(0)
+
+    await shot('second')
+  })
+
+  test('a conversation stays under the agent that had it', async ({ page, shot }) => {
+    await mockTwoAgents(page)
+    await talkTo(page, AGENT_ADDRESS, PROFILE.name, 'first thread')
+    await talkTo(page, SECOND_ADDRESS, SECOND_PROFILE.name, 'second thread')
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    const drawer = page.locator('aside')
+    await expect(drawer).toHaveCSS('visibility', 'visible')
+
+    // Both agents listed, each owning its own thread. The store is one flat array
+    // tagged by address, so this grouping is a filter rather than a structure.
+    await expect(drawer.getByText(PROFILE.name)).toBeVisible()
+    await expect(drawer.getByText(SECOND_PROFILE.name)).toBeVisible()
+
+    const first = await drawer.getByText(PROFILE.name).first().boundingBox()
+    const second = await drawer.getByText(SECOND_PROFILE.name).first().boundingBox()
+    const firstThread = await drawer.getByText('first thread').first().boundingBox()
+    const secondThread = await drawer.getByText('second thread').first().boundingBox()
+
+    // Each thread sits below its own agent and above the next one — the ordering
+    // is what a reader uses to tell whose conversation this is.
+    expect(firstThread!.y, 'the first thread is not under its agent').toBeGreaterThan(first!.y)
+    expect(secondThread!.y, 'the second thread is not under its agent').toBeGreaterThan(second!.y)
+    expect(firstThread!.y, 'the threads are interleaved between agents').toBeLessThan(second!.y)
+
+    await shot('drawer')
+  })
+
+  test('switching agents does not carry the transcript across', async ({ page }) => {
+    await mockTwoAgents(page)
+    await talkTo(page, AGENT_ADDRESS, PROFILE.name, 'ledger numbers')
+
+    // Landing on the other agent fresh: nothing of the first conversation may be
+    // on screen, not the reply and not the message that produced it.
+    await page.goto(`/${SECOND_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: SECOND_PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    // Scoped to the conversation pane, not the page. The closed drawer legitimately
+    // still lists the first agent's thread — under the first agent, off-screen at
+    // x=-217 with visibility:hidden — and an unscoped `toHaveCount(0)` counts it and
+    // reads as a leak. The question is what is in front of the reader.
+    const pane = page.locator('main')
+    await expect(pane.getByText('ledger numbers')).toHaveCount(0)
+    await expect(pane.getByText(`${PROFILE.name} here.`)).toHaveCount(0)
+  })
+
+  test('each agent carries its own balance', async ({ page }) => {
+    await mockTwoAgents(page)
+
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('link', { name: /top up/i })).toContainText(`$${PROFILE.balance_usd.toFixed(2)}`)
+
+    // A balance is what a top-up is addressed to, so showing a stale one from the
+    // previously viewed agent would send money to the wrong place.
+    await page.goto(`/${SECOND_ADDRESS}`)
+    await expect(page.getByRole('link', { name: /top up/i })).toContainText(`$${SECOND_PROFILE.balance_usd.toFixed(2)}`)
+    await expect(page.getByRole('link', { name: /top up/i })).toHaveAttribute('href', `https://o.openonion.ai/purchase?key=${SECOND_ADDRESS}`)
+  })
+})


### PR DESCRIPTION
Every spec in the suite runs against **one** agent. That cannot show the failure that actually matters for these customers: one agent's conversation surfacing under another.

The store keeps a flat `conversations` array tagged with `agentAddress`, and the sidebar groups by that tag. Nothing about the isolation is structural — it is a filter, and a filter is a thing that can be wrong. Some of these agents read ledgers.

## Result: no bug

Each agent answers as itself · threads stay under their own agent in the drawer · landing on a second agent carries nothing from the first · each agent shows its own balance and its own `?key=` purchase link.

Reporting that as a measured result rather than an assumption, and leaving the guard behind.

## The guard has teeth

A passing test against working code proves nothing, so I deleted the sidebar's filter:

```js
- map[agent] = conversations.filter(c => c.agentAddress === agent)
+ map[agent] = conversations
```

→ **`the second thread is not under its agent`**. Restored.

## How the two-agent mock works

`mockTwoAgents` routes by **`payload.to` on the CONNECT frame**. Both agents' sockets match the same URL pattern (`wss://scriptbot.example/ws`, from the relay record), so the handshake address is the only thing that distinguishes them. I checked what CONNECT actually carries rather than guessing.

Each reply **names its author** — `Ledgerbot here. You said: …` — because "you said X" from the wrong agent is indistinguishable from the right one. Without that the isolation test could only observe which pane was showing, which is exactly the kind of assertion that passes on broken code.

`mockAgent` is untouched; the 85 existing tests run against it unchanged.

## A false leak I nearly reported

`switching agents does not carry the transcript across` failed at first, and it looked like a real leak. It was my assertion: `page.getByText(...)` counts DOM nodes anywhere, and the **closed drawer** legitimately still lists the first agent's thread — under the first agent, `visibility: hidden`, off-screen at `x=-217`. Scoped to `main`, which is the question worth asking: what is in front of the reader.

## Verification

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 89 passed**. Drawer screenshot checked: `2 AGENTS ONLINE`, Scriptbot with `first thread`, Ledgerbot with `second thread`, each under its own rail.

## Also checked, also not a bug

Sending a message while the socket is down. I expected the composed text to be lost — this codebase has that history (#27) and the composer is not disabled while disconnected. The SDK reconnects on send: the message is delivered, answered, and nothing is dropped. No change made.