### PR TITLE
Cover getting back to a conversation, and close the type scale

### DIFF
--- a/e2e/continuity.spec.ts
+++ b/e2e/continuity.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Getting back to a conversation you already had.
+ *
+ * Phones reload tabs without being asked — memory pressure, a restored session,
+ * a fat-fingered pull-to-refresh. The transcript lives in localStorage under
+ * `co:agent:{address}:session:{id}` rather than on a server, so "still there
+ * after a reload" is a property of this app's own storage handling and not
+ * something the backend would ever restore for us.
+ *
+ * All three paths here already work. They are covered because they are the ones
+ * that break silently in a store refactor and that nobody would think to check
+ * by hand: the failure is a reader coming back to an empty screen where their
+ * conversation used to be, and there is no error to notice.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+async function haveAConversation(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a reload puts the reader back in the same conversation', async ({ page, shot }) => {
+    await haveAConversation(page)
+    const url = page.url()
+
+    await page.reload()
+
+    // Same session, both sides of the exchange still on screen. A store that
+    // hydrated late or keyed wrongly would leave the reader on an empty session
+    // at the same URL — no error, just their conversation gone.
+    expect(page.url(), 'the reload landed somewhere else').toBe(url)
+
+    // Scoped to the conversation pane: the closed drawer also holds this text as
+    // the session's title, hidden, and an unscoped match resolves to that one and
+    // reports it as not visible.
+    const pane = page.locator('main')
+    await expect(pane.getByText('What can you do?').first()).toBeVisible({ timeout: 20_000 })
+    await expect(pane.getByText('You said: What can you do?')).toBeVisible()
+
+    await shot('reloaded')
+  })
+
+  test('and the conversation can be continued after it', async ({ page }) => {
+    await haveAConversation(page)
+    await page.reload()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // Restoring the transcript is only half of it — the socket has to come back
+    // too, or the reader is looking at a conversation they cannot add to.
+    await page.getByPlaceholder(/message/i).fill('still there?')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('You said: still there?')).toBeVisible({ timeout: 20_000 })
+  })
+
+  test('back from a conversation returns to the agent, intact', async ({ page }) => {
+    await haveAConversation(page)
+
+    // Sending navigates, so back is the gesture a phone reader reaches for first.
+    await page.goBack()
+
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('link', { name: /top up/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'What can you do?' })).toBeVisible()
+  })
+
+  test('a session link this browser has never seen opens, rather than breaking', async ({ page, shot }) => {
+    await mockAgent(page)
+
+    // A shared link, or the same link after storage was cleared. There is no
+    // transcript to show and that is fine — what matters is that it is a usable
+    // page and not a blank one or a redirect loop.
+    await page.goto(`/${AGENT_ADDRESS}/11111111-2222-3333-4444-555555555555`)
+
+    // The empty session names the agent in a paragraph rather than a heading —
+    // the heading role belongs to the landing page's hero, which this is not.
+    await expect(page.locator('main').getByText(PROFILE.name).first()).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByPlaceholder(/message/i)).toBeVisible()
+
+    await shot('unknown-session')
+  })
+})

--- a/e2e/design-system.spec.ts
+++ b/e2e/design-system.spec.ts
@@ -90,3 +90,36 @@ test('no component ships its own violet', async () => {
     .filter(l => l.trim() && !l.includes('// '))
   expect(hits, 'an off-palette hue came back').toEqual([])
 })
+
+test('the arbitrary type sizes are the three deliberate ones', async () => {
+  // Measured across landing, transcript and settings, the app renders eight
+  // distinct sizes: 24, 20, 16, 15, 14, 13, 12, 11. Five come from Tailwind's
+  // named steps; the other three are arbitrary values, and they are deliberate
+  // half-steps rather than drift —
+  //
+  //   11px  the micro-label (86 uses)   — under text-xs
+  //   13px  tool rows and chips (19)    — between text-xs and text-sm
+  //   15px  message body (11)           — between text-sm and text-base
+  //
+  // That is a closed set and it was never written down anywhere, which is the
+  // actual problem: a scale nobody can see is a scale nobody can keep. A fourth
+  // size would be indistinguishable from the three on screen and impossible to
+  // argue against in review.
+  //
+  // The existing check above bans 9, 10, 12 and 14 because each duplicates a
+  // named step. This one is the complement: everything else must be named.
+  const { execSync } = await import('node:child_process')
+  const sizes = new Set(
+    // [0-9.]+ rather than [0-9]+: a first version of this matched integers only,
+    // and text-[10.5px] walked straight through it. Fractional sizes are exactly
+    // the kind that get added to nudge one label into line.
+    execSync('grep -rhoE "text-\\[[0-9.]+px\\]" app components || true', { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean)
+  )
+
+  expect(
+    [...sizes].sort(),
+    'a new arbitrary size appeared — use a named step, or add it here with a reason',
+  ).toEqual(['text-[11px]', 'text-[13px]', 'text-[15px]'])
+})


### PR DESCRIPTION
Two things, both test-only.

## Getting back to a conversation (priority 1)

Phones reload tabs without being asked — memory pressure, a restored session, a fat-fingered pull-to-refresh. The transcript lives in `localStorage` under `co:agent:{address}:session:{id}` rather than on a server, so "still there afterwards" is a property of **this app's own storage handling**; nothing on the backend would ever restore it.

Four paths, **all of which already work**: a reload lands in the same conversation · it can be continued afterwards (the socket comes back, not just the text) · back returns to the agent intact · a session link this browser has never seen opens as a usable empty session rather than a blank page or a redirect loop.

Covered because they break *silently* in a store refactor. The failure mode is a reader coming back to an empty screen where their conversation used to be, with no error to notice.

Teeth checked: clearing `localStorage` before the reload fails the first test.

## Closing the type scale (priority 5)

Measured across landing, transcript and settings, the app renders **eight distinct sizes**: 24, 20, 16, 15, 14, 13, 12, 11. Five are Tailwind's named steps. The other three are arbitrary values — and they turn out to be deliberate half-steps, not drift:

| | | |
|---|---|---|
| `text-[11px]` | 86 uses | the micro-label, under `text-xs` |
| `text-[13px]` | 19 uses | tool rows and chips, between `text-xs` and `text-sm` |
| `text-[15px]` | 11 uses | message body, between `text-sm` and `text-base` |

So the scale **is** disciplined. The problem is that it was never written down anywhere: a scale nobody can see is a scale nobody can keep, and a fourth size would be indistinguishable from these three on screen and impossible to argue against in review.

The existing check bans 9, 10, 12 and 14 because each duplicates a named step. This one is the complement — everything else must be named — and it records *why* each of the three exists.

**My first version of it was broken.** It matched `[0-9]+px`, so `text-[10.5px]` walked straight through. Found by trying to break it, which is the only reason it is worth having; fractional sizes are exactly the kind someone adds to nudge one label into line. Now `[0-9.]+`, re-checked, and it fails with *"a new arbitrary size appeared — use a named step, or add it here with a reason"*.

## Verification

`tsc --noEmit` clean · `npm run lint` 0 · `vitest` 56 · **full Playwright suite 94 passed**. `git status` confirms test files only. Screenshots checked — the unknown-session link renders a clean empty state with avatar, name, and a usable composer.

## Two of my own locator mistakes, same shape as last time

`getByText('What can you do?')` resolved to the **closed drawer's session title** (hidden) rather than the transcript, and the empty session names the agent in a `<p>` rather than a heading, so a `getByRole('heading')` found nothing. Both scoped to `main` now. That is three passes running where an unscoped text query has matched the hidden drawer; I should reach for the pane locator first.

## Left alone

The unknown-session empty state shows no skill chips, where the landing page's empty session does. `empty-states.spec` covers the offers case and passes, so this is probably a timing difference in when `skills` arrives over the socket — but I did not confirm that, and I would rather say so than assert it.