### PR TITLE
Give the empty session the opener it claimed to have

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -12,7 +12,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
-import { bestOffers } from '@/components/chat/skill-offers'
+import { bestOffers, UNIVERSAL_OPENER } from '@/components/chat/skill-offers'
 import { AgentAddress, TopUp } from '@/components/agent-address'
 
 
@@ -310,10 +310,10 @@ export default function AgentLandingPage() {
               <div className="reveal flex flex-wrap justify-center gap-2" style={{ '--reveal-delay': '180ms' } as React.CSSProperties}>
                 {/* The universal opener leads, filled — agent-specific offers follow */}
                 <button
-                  onClick={() => begin('What can you do?')}
+                  onClick={() => begin(UNIVERSAL_OPENER)}
                   className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-neutral-800 active:translate-y-0"
                 >
-                  What can you do?
+                  {UNIVERSAL_OPENER}
                 </button>
                 {bestOffers(skills).map(({ skill, offer }) => (
                     <button

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -9,7 +9,7 @@ import { StatusBar } from './messages'
 import { UlwSetupPanel } from './ulw-setup-panel'
 import { UlwMonitorPanel } from './ulw-monitor-panel'
 import { UlwFullscreen } from './ulw-fullscreen'
-import { bestOffers } from './skill-offers'
+import { bestOffers, UNIVERSAL_OPENER } from './skill-offers'
 import type { ChatProps, ThinkingUI, UserUI } from './types'
 
 export function Chat({
@@ -172,12 +172,22 @@ export function Chat({
                 every visitor sees after passing a gate, and it used to ask them to
                 think of something themselves in the first five seconds. Same chip
                 markup as the landing page so there is one definition of a chip. */}
-            {offers.length > 0 && (
-              <div
-                className="reveal mt-6 flex flex-wrap justify-center gap-2 px-6"
-                style={{ '--reveal-delay': '200ms' } as React.CSSProperties}
+            <div
+              className="reveal mt-6 flex flex-wrap justify-center gap-2 px-6"
+              style={{ '--reveal-delay': '200ms' } as React.CSSProperties}
+            >
+              {/* The universal opener leads, filled — same as the landing page.
+                  Outside the offers.length guard on purpose: an agent that
+                  publishes no usable skill chips is exactly the one whose reader
+                  has nothing to go on, and this row used to disappear entirely
+                  for them. */}
+              <button
+                onClick={() => onSend(UNIVERSAL_OPENER)}
+                className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all hover:bg-neutral-800"
               >
-                {offers.map(({ skill, offer }) => (
+                {UNIVERSAL_OPENER}
+              </button>
+              {offers.map(({ skill, offer }) => (
                   <button
                     key={skill.name}
                     onClick={() => onSend('/' + skill.name)}
@@ -185,9 +195,8 @@ export function Chat({
                   >
                     {offer}
                   </button>
-                ))}
-              </div>
-            )}
+              ))}
+            </div>
           </div>
         </div>
       ) : (

--- a/components/chat/skill-offers.ts
+++ b/components/chat/skill-offers.ts
@@ -7,6 +7,15 @@
  * the component that renders them, rather than being duplicated.
  */
 
+/** The offer that always applies, whatever the agent turns out to do.
+ *
+ *  It leads the chip row on both surfaces: skill-derived offers only help a
+ *  reader who already knows roughly what they want, and the person staring at a
+ *  fresh session — usually one second after being let through an invite gate —
+ *  is precisely the one who does not. One definition, because it was a bare
+ *  string on the landing page and simply absent from the empty session. */
+export const UNIVERSAL_OPENER = 'What can you do?'
+
 /** A chip is a speech act — it must complete "Help me ___". Extract a short
  *  imperative from the skill description's opening (cutting at the first
  *  clause boundary), or return null so command-named skills stay off the

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -26,7 +26,31 @@ test('a fresh session offers the same openers the landing page does', async ({ p
   const opener = page.locator('main').getByRole('button', { name: 'Ship the current branch to production' })
   await expect(opener, 'the empty session offers nothing to say').toBeVisible()
 
+  // The universal opener, which is the whole point of the row for a visitor who
+  // has just been let in and does not yet know what this agent is for. The
+  // landing page leads with it, filled; this screen offered only the
+  // skill-derived chips, so the one person who most needs a starting point was
+  // the one it did not serve. This test's own name claimed parity while
+  // asserting a single skill chip.
+  const universal = page.locator('main').getByRole('button', { name: 'What can you do?' })
+  await expect(universal, 'the empty session has no opener for someone with no idea what to ask').toBeVisible()
+
+  // And it leads, as it does on the landing page — the offer that always applies
+  // sits before the ones that only sometimes do.
+  const first = await universal.boundingBox()
+  const second = await opener.boundingBox()
+  expect(first!.y, 'the universal opener is not the first chip').toBeLessThanOrEqual(second!.y)
+
   await shot('fresh-session')
+})
+
+test('the universal opener sends what it says', async ({ page }) => {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}/fresh-session-3`)
+  await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
+
+  await page.locator('main').getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
 })
 
 test('tapping an opener sends it', async ({ page }) => {
@@ -50,4 +74,24 @@ test('settings with no agents says what to do next', async ({ page, shot }) => {
   await expect(panel.getByText(/paste an agent's address|open a link someone shared/i)).toBeVisible()
 
   await shot('settings-empty')
+})
+
+test('an agent with no usable chips still offers the universal opener', async ({ page, shot }) => {
+  // Skills whose descriptions produce no chip — bestOffers rejects internal
+  // utilities outright. The row used to be behind `offers.length > 0`, so for
+  // these agents it vanished completely, and the reader with the least to go on
+  // got the least help. This is the case the guard was hiding.
+  await mockAgent(page, 'reply', {
+    skills: [{ name: 'debug_dump', description: 'internal' }],
+  })
+
+  await page.goto(`/${AGENT_ADDRESS}/fresh-session-4`)
+  await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
+
+  const pane = page.locator('main')
+  await expect(pane.getByRole('button', { name: 'What can you do?' })).toBeVisible()
+  // And nothing derived from a skill that should not be offered.
+  await expect(pane.getByRole('button', { name: /debug/i })).toHaveCount(0)
+
+  await shot('no-skills')
 })


### PR DESCRIPTION
Priority 5, empty states. This started as the loose end I left in #94 — "the unknown-session empty state shows no skill chips, but I did not confirm why."

## First, the correction

**That observation was wrong.** The chips do render; my screenshot caught the page ~1s before `skills` resolved. Measured over 10s, the skill chip is there and visible at `y=334`. No bug, and I should not have reported it as a possible one without checking.

But measuring it turned up a real gap next door.

## The actual gap

The landing page leads its chip row with a **filled `What can you do?`** — deliberately, per its own comment: *"The universal opener leads, filled — agent-specific offers follow."*

The empty session had only the skill-derived chips. That screen is what every visitor sees **one second after being let through an invite gate**, so the one person who most needs a starting point — someone who does not yet know what this agent is for — was the one it did not serve.

Two things asserted parity that did not exist:

- `chat.tsx`: *"The same three openers the landing page offers"*
- the e2e test, titled *"a fresh session offers the same openers the landing page does"*, asserting **one skill chip**

A test whose name overclaims is worse than no test: it makes the gap look covered.

## And it was worse than missing

The row sat behind `offers.length > 0`. For an agent whose skills produce no usable chips — `bestOffers` rejects internal utilities outright — the row **vanished completely**. The reader with the least to go on got the least help. The opener now sits outside that guard.

## Verification

Written first, failed with *"the empty session has no opener for someone with no idea what to ask"*.

| | before | after |
|---|---|---|
| the universal opener is offered | ✗ element not found | ✓ |
| it leads the row, as on landing | — | ✓ |
| tapping it sends what it says | ✗ | ✓ |
| an agent with no usable chips still gets it | ✗ (row absent entirely) | ✓ |

The no-chips case re-checked by restoring the `offers.length > 0` guard: **fails**. `tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 96 passed**.

Screenshot checked: filled `What can you do?` leading, `Ship the current branch to production` beside it — the same row the landing page draws.

## One definition

The opener was a bare string on the landing page and absent from the session. It is now `UNIVERSAL_OPENER` in `skill-offers.ts`, used by both, beside `bestOffers` which already lives there for the same reason.