### PR TITLE
Gate a forwarded session link before the reader writes anything

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -47,6 +47,7 @@ import { dedupeUI } from '@/components/chat/dedupe-ui'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { OnboardGate } from '@/components/chat/onboard-gate'
 import { LowBalanceNotice, isLowBalance } from '@/components/agent-address'
 
 export default function ChatSessionPage() {
@@ -114,6 +115,7 @@ export default function ChatSessionPage() {
     respondToPlanReview,
     setMode,
     reconnect,
+    connect,
     interrupt,
     dashboardHtml,
     profile,
@@ -207,6 +209,20 @@ export default function ChatSessionPage() {
     }
     return ''
   }, [displayUI])
+
+  // Eager, exactly as the landing page does it. The gate is driven by
+  // ONBOARD_REQUIRED, which the host sends in answer to CONNECT — so a route that
+  // does not connect until the first send shows a gated agent as open: composer,
+  // offer chips, and a filled opener inviting the reader in. They write a real
+  // message, send it, and only then meet the gate, with their text already
+  // consumed into a run that cannot proceed. That is the ordering #27 fixed for
+  // the landing page; a forwarded session link went round it.
+  const connected = useRef(false)
+  useEffect(() => {
+    if (connected.current) return
+    connected.current = true
+    connect()
+  }, [connect])
 
   const handleReconnect = useCallback(() => {
     setConnectionError(null)
@@ -309,7 +325,8 @@ export default function ChatSessionPage() {
   )
 
   return (
-    <WorkspaceShell
+    <>
+      <WorkspaceShell
       chat={chatPane}
       hasDashboard={dashboardHtml !== null}
       chatAwaitsReader={awaitsReader}
@@ -321,6 +338,24 @@ export default function ChatSessionPage() {
           className="w-full h-full border-0"
         />
       }
-    />
+      />
+
+      {/* The wall, only when there is no conversation behind it. An agent that
+          starts open and gates mid-session keeps the in-transcript card instead —
+          there is a thread back there that has to stay readable, which is the
+          distinction onboard-gate.tsx already draws.
+
+          Keyed on there being no *user* message rather than an empty displayUI:
+          the onboard prompt is itself an item, so the length was never zero and
+          the wall never rendered. What decides this is whether the reader has a
+          conversation to lose, and that is what a user message means. */}
+      {pendingOnboard && !displayUI.some(item => item.type === 'user') && (
+        <OnboardGate
+          onboard={pendingOnboard}
+          agentName={agentInfoMap[address]?.name || shortAddress(address)}
+          onSubmit={(options: { inviteCode?: string; payment?: number }) => submitOnboard(options)}
+        />
+      )}
+    </>
   )
 }

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -108,6 +108,14 @@ export async function mockAgent(
       }
 
       if (msg.type !== 'INPUT') return
+
+      // An agent that starts open and gates partway through. There is a
+      // conversation behind this one, so it must keep the in-transcript card
+      // rather than getting the wall — the thread has to stay readable.
+      if (scenario === 'gate-midway') {
+        send(ws, { type: 'ONBOARD_REQUIRED', methods: ['invite_code'] })
+        return
+      }
 
       // The connection goes away mid-run: a tunnel, a wifi/cellular handover, the
       // screen locking. Dropped on INPUT rather than on CONNECT because both the

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -121,3 +121,73 @@ test.describe('phone, keyboard open', () => {
     await shot('keyboard')
   })
 })
+
+test.describe('a shared session link', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  /** Someone forwards a chat URL to a colleague who was never invited. */
+  const SHARED = `/${AGENT_ADDRESS}/forwarded-session-link`
+
+  test('gates before the reader writes anything', async ({ page, shot }) => {
+    await mockAgent(page, 'onboard-payment')
+    await page.goto(SHARED)
+
+    // The landing page opens its socket eagerly, so ONBOARD_REQUIRED arrives and
+    // the wall is up before anything is typed. This route did not connect at all
+    // until the first send, so a gated agent looked open: a composer, the offer
+    // chips, and a filled "What can you do?" inviting the reader in. They wrote a
+    // real message, sent it, and only then met the gate — with their text already
+    // consumed into a run that could not proceed. That is the ordering #27 fixed
+    // for the landing page and left standing here.
+    await expect(
+      page.getByRole('dialog'),
+      'a gated agent looks open when reached by a session link',
+    ).toBeVisible({ timeout: 20_000 })
+
+    await expect(page.getByText(new RegExp(`${PROFILE.name} is invite-only`))).toBeVisible()
+
+    await shot('gate')
+  })
+
+  test('nothing behind the gate invites a message', async ({ page }) => {
+    await mockAgent(page, 'onboard-payment')
+    await page.goto(SHARED)
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 20_000 })
+
+    // The wall is opaque and covers the pane, so the composer and the openers
+    // behind it must not be reachable — offering a way to type into an agent that
+    // will refuse is the whole failure.
+    await expect(page.getByRole('button', { name: 'What can you do?' })).toHaveCount(0)
+  })
+
+  test('an open agent reached the same way is not gated', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(SHARED)
+
+    // Connecting eagerly must not put a wall in front of agents that take anyone.
+    await expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+})
+
+test.describe('an agent that gates partway through', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('keeps the conversation readable behind an in-transcript prompt', async ({ page, shot }) => {
+    await mockAgent(page, 'gate-midway')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+
+    // The wall is for arriving at a closed door. Here the reader is already
+    // inside, so covering their thread with an opaque panel would take away the
+    // conversation they are being asked about — which is the distinction the new
+    // condition draws, and the branch it would be easy to get wrong.
+    await expect(page.getByText(/verification required/i)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('dialog'), 'the wall covered an existing conversation').toHaveCount(0)
+    // Scoped to the pane: unscoped, the first match is the drawer's session title,
+    // which is hidden. That has now cost four tests across these passes.
+    await expect(page.locator('main').getByText('What can you do?').first()).toBeVisible()
+
+    await shot('midway')
+  })
+})

--- a/e2e/scroll-follow.spec.ts
+++ b/e2e/scroll-follow.spec.ts
@@ -68,7 +68,14 @@ test.describe('phone', () => {
     // The sentence the agent ends on. If following breaks this is below the fold
     // and the reader is looking at the middle of a finished answer.
     await expect(page.getByText('The last line is the one that matters.')).toBeVisible({ timeout: 20_000 })
-    expect(await distanceFromBottom(page), 'the transcript stopped following the reply').toBeLessThanOrEqual(4)
+
+    // Polled, not read once. "Settles at the bottom" is an eventual state: under
+    // load the observer coalesces and the last pin can land a frame after the
+    // text is on screen, which showed up as 100px adrift in a full-suite run and
+    // never in isolation. A poll still fails if it never settles.
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 10_000 })
+      .toBeLessThanOrEqual(4)
 
     await shot('followed')
   })
@@ -99,6 +106,13 @@ test.describe('phone', () => {
     // first run after each edit, when the dev server was still compiling and
     // everything arrived in one lump.
     await expect(page.getByText('The last line is the one that matters.')).toBeVisible({ timeout: 20_000 })
+
+    // Wait for the transcript to actually be at the bottom before asking whether
+    // a way back down is offered — while it is still settling the button is
+    // correct to be there, and the question being asked is the other one.
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 10_000 })
+      .toBeLessThanOrEqual(4)
 
     const button = page.getByRole('button', { name: /scroll to bottom/i })
     // Nothing to go back to while already there — a permanent button is clutter.


### PR DESCRIPTION
## The finding

The invite gate is driven by `ONBOARD_REQUIRED`, which the host sends **in answer to CONNECT**. The landing page opens its socket eagerly, so the wall is up before anything is typed.

The session route did not connect **at all** until the first send. So a gated agent reached by a forwarded chat URL looked open:

```
LANDING_GATE  1      ← dialog, immediately
SESSION_GATE  0      ← composer, offer chips, filled "What can you do?"
AFTER_SEND    …      ← "Verification Required", textarea empty
```

The reader writes a real message — `please reconcile the july ledger` — sends it, and only then meets the gate, **with their text already consumed** into a run that cannot proceed.

That is precisely the ordering `onboard-gate.tsx` documents as fixed in #27: *"composer → reader types → connect → agent refuses → the message they wrote is gone."* The fix covered the landing page; a shared session link went round it. A colleague forwarding a chat URL to someone who was never invited is an ordinary thing for these customers to do.

**And I made it worse last pass.** #95 added the filled universal opener to that same empty session — a black button encouraging exactly this.

## The fix

Connect eagerly on the session route, as the landing page does, and render the wall when the gate arrives.

**Only when there is no user message behind it.** An agent that starts open and gates partway through keeps the in-transcript card — there is a conversation back there that has to stay readable, which is the distinction `onboard-gate.tsx` already draws. Both branches are covered by tests; a new `gate-midway` scenario drives the second.

My first attempt keyed the wall on `displayUI.length === 0` and it never rendered: the onboard prompt is itself a UI item, so the length is never zero. What actually decides it is whether the reader has a conversation to lose, which is what a user message means.

## Verification

| | before | after |
|---|---|---|
| a forwarded link gates before anything is typed | ✗ *a gated agent looks open* | ✓ |
| nothing behind the wall invites a message | ✗ | ✓ |
| an open agent reached the same way is not gated | ✓ guards the other way | ✓ |
| gating partway through keeps the thread readable | — new | ✓ |

`tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 100 passed**. Screenshot checked — the wall is identical to the landing page's, and its closing line, *"No code? Ask whoever shared this agent with you"*, is exactly right for this route.

## Also in here: a real flake fix

The full suite failed twice on `scroll-follow` with the transcript 100px off the bottom, while the same spec passed 3/3 in isolation. Both failures had one root: the settle position was **read once** rather than polled. Under full-suite load the ResizeObserver coalesces and the last pin lands a frame after the text appears. Now polled — which still fails if it never settles. Full suite green afterwards, 100 passed.

## Two things I resolved as *not* bugs

- The empty session never says "Connected — send a message". Measured: **zero handshakes** on that route before a send, so the line was honest. (It is now moot — the route connects eagerly.)
- #94's "no skill chips on an unknown session" was my screenshot catching the page ~1s early, as reported in #95.

## Left alone

Under sustained load the transcript can sit ~100px off the bottom for a beat after the final chunk, rather than pinning immediately. It self-corrects on any further content and the scroll-down button is offered meanwhile, so I treated it as a settling artifact rather than chasing a ResizeObserver coalescing fix I could not reproduce outside a loaded full-suite run.