### PR TITLE
An agent removed from its own page stays removed

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -77,11 +77,22 @@ export default function ChatSessionPage() {
   const agentInfoMap = useAgentInfo([address])
 
   // Add agent if not in list
+  // Once per visit, not "whenever it is missing". Opening an agent's link is what
+  // adds it, and the old form re-ran on every change to `agents` — so removing the
+  // agent while standing on its own page put it straight back, while the
+  // conversations and transcripts it took with it were already gone. The reader
+  // saw the agent still listed and its history silently deleted, which is the
+  // worst way round: the visible signal said the removal had failed.
+  //
+  // Keyed on the address so navigating between agents still adds each one.
+  const addedFor = useRef<string | null>(null)
   useEffect(() => {
-    if (address && !agents.includes(address)) {
-      addAgent(address)
-    }
-  }, [address, agents, addAgent])
+    if (!address || addedFor.current === address) return
+    addedFor.current = address
+    if (!agents.includes(address)) addAgent(address)
+    // `agents` is deliberately not a dependency: reacting to it is the bug.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, addAgent])
 
   // Find the conversation
   const conversation = useMemo(

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -44,11 +44,22 @@ export default function AgentLandingPage() {
     }
   }, [])
 
+  // Once per visit, not "whenever it is missing". Opening an agent's link is what
+  // adds it, and the old form re-ran on every change to `agents` — so removing the
+  // agent while standing on its own page put it straight back, while the
+  // conversations and transcripts it took with it were already gone. The reader
+  // saw the agent still listed and its history silently deleted, which is the
+  // worst way round: the visible signal said the removal had failed.
+  //
+  // Keyed on the address so navigating between agents still adds each one.
+  const addedFor = useRef<string | null>(null)
   useEffect(() => {
-    if (address && !agents.includes(address)) {
-      addAgent(address)
-    }
-  }, [address, agents, addAgent])
+    if (!address || addedFor.current === address) return
+    addedFor.current = address
+    if (!agents.includes(address)) addAgent(address)
+    // `agents` is deliberately not a dependency: reacting to it is the bug.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, addAgent])
 
   useEffect(() => {
     clearActive()

--- a/e2e/remove-agent.spec.ts
+++ b/e2e/remove-agent.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Removing an agent, from the page that agent is on.
+ *
+ * Both agent routes carry an effect that adds the address to the store whenever
+ * it is missing — that is how visiting a link is what "adds" an agent. Removing
+ * the agent while standing on its own page makes `agents` change, the effect
+ * re-runs, the address is missing, and it goes straight back in.
+ *
+ * The destructive half of the removal is not undone by that: the conversations
+ * and their transcripts are already deleted. So the reader is left with the
+ * agent still listed and its history quietly gone — the worst possible split,
+ * because the visible signal says the removal failed.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** The agents the store has persisted, which is what the sidebar and the picker list. */
+function storedAgents(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('oo-chat-storage')
+    return raw ? (JSON.parse(raw).state?.agents ?? []) : []
+  })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('stays removed when removed from its own page', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    expect(await storedAgents(page)).toContain(AGENT_ADDRESS)
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await page.getByRole('button', { name: /^remove$/i }).first().click()
+
+    await expect
+      .poll(() => storedAgents(page), { timeout: 10_000 })
+      .not.toContain(AGENT_ADDRESS)
+
+    await shot('removed')
+  })
+
+  test('its conversations go with it', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await page.getByRole('button', { name: /^remove$/i }).first().click()
+    await page.waitForTimeout(2000)
+
+    // Transcripts are per-session localStorage entries; orphaned ones eat the
+    // ~5MB quota and no flow restores them.
+    const leftovers = await page.evaluate(() =>
+      Object.keys(localStorage).filter(k => k.startsWith('co:agent:'))
+    )
+    expect(leftovers, 'transcripts outlived the agent').toEqual([])
+  })
+
+  test('visiting an agent link still adds it', async ({ page }) => {
+    await mockAgent(page)
+
+    // The other direction, and the reason that effect exists: opening an agent's
+    // link is how it gets into the list in the first place. A fix that stops the
+    // re-add must not stop this.
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    await expect.poll(() => storedAgents(page), { timeout: 10_000 }).toContain(AGENT_ADDRESS)
+  })
+
+  test('and it can be added back by opening its link again', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await page.getByRole('button', { name: /^remove$/i }).first().click()
+    await expect.poll(() => storedAgents(page), { timeout: 10_000 }).not.toContain(AGENT_ADDRESS)
+
+    // Removal is not a ban. Opening the link again is the same gesture that added
+    // it originally and has to work the same way.
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect.poll(() => storedAgents(page), { timeout: 10_000 }).toContain(AGENT_ADDRESS)
+  })
+})


### PR DESCRIPTION
Priority 3 — the sidebar. A destructive flow that had no coverage, and was half-working in the worst possible direction.

## The finding

Both agent routes carry this:

```js
useEffect(() => {
  if (address && !agents.includes(address)) addAgent(address)
}, [address, agents, addAgent])
```

That is how opening an agent's link adds it. But it reacts to **`agents`**, so removing the agent while standing on its own page — which is where the drawer's Remove control is — changes `agents`, re-runs the effect, finds the address missing, and puts it straight back.

Measured after a confirmed removal:

```
conversations: []                                        ← gone
co:agent:…:session:… keys: []                            ← gone
agents: ["0xe2e7e57a…"]                                  ← back
```

**The destructive half is not undone.** The conversations and their transcripts are already deleted. So the reader is left with the agent still listed and its history silently erased — the worst way round, because the visible signal says the removal failed and invites them to try again on data that is already gone. For a customer removing an agent that reads ledgers, "still listed" is also the wrong answer on its own.

## The fix

Add once per visit, keyed on the address, rather than whenever the store lacks it. Navigating between agents still adds each one; reopening a removed agent's link still adds it back, because **removal is not a ban** and opening the link is the same gesture that added it originally.

## Verification

| | before | after |
|---|---|---|
| stays removed when removed from its own page | ✗ `agents` still contains it | ✓ |
| its conversations go with it | ✓ (already worked) | ✓ |
| visiting an agent link still adds it | ✓ guards the fix | ✓ |
| can be added back by opening its link again | ✗ | ✓ |

The two guards matter as much as the fix: the effect exists for a reason, and a fix that stopped agents being added at all would have passed a test that only checked removal.

`tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 104 passed**. Screenshot checked — the drawer reads `AGENTS 0` with "No agents yet".

## How I got here, and what it says about #96

#96 showed the session route had missed a fix the landing route got. I went looking for more of that class. Two results worth recording:

- **The dashboard on a forwarded session link now works** — measured `SESSION_TABS 2`, `SESSION_IFRAME 1`, matching the landing page. That was a second thing broken by the same missing eager connect, fixed by #96 without my realising it at the time.
- **"Connected — send a message" now appears on that route**, which fully closes the observation I flagged in #95 and mis-suspected as a status bug.

The remove-agent bug is the same shape as both: one route carrying a behaviour the other does not.

## Left alone

Settings has its own Remove control and does **not** have this bug — it is not under `/[address]`, so no auto-add effect re-runs there. I confirmed that rather than assuming it, and did not add a duplicate test for a path that cannot fail this way.