### PR TITLE
Pin the transcript after layout settles, and assert what approvals send

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -50,11 +50,33 @@ export function ChatMessages({
     const el = scrollRef.current
     const content = contentRef.current
     if (!el || !content) return
-    const observer = new ResizeObserver(() => {
-      if (stickToBottomRef.current) el.scrollTop = el.scrollHeight
-    })
+    // Pin twice: once now, once after the frame has finished laying out.
+    //
+    // Setting scrollTop inside the observer uses the scrollHeight as it stands at
+    // that instant, and on a loaded device the layout that follows — a code block
+    // measuring, a font landing, several chunks coalesced into one callback — can
+    // grow the content again straight afterwards. The transcript then rests short
+    // of the bottom with no further resize to correct it. Measured twice on a
+    // saturated machine: 100px and 135px adrift, still adrift ten seconds later,
+    // which on a 468px-tall pane means the end of the reply is below the fold.
+    //
+    // The rAF is cancelled and rescheduled per callback, so a burst of resizes
+    // costs one extra pin rather than one per chunk.
+    let queued = 0
+    const pin = () => {
+      if (!stickToBottomRef.current) return
+      el.scrollTop = el.scrollHeight
+      cancelAnimationFrame(queued)
+      queued = requestAnimationFrame(() => {
+        if (stickToBottomRef.current) el.scrollTop = el.scrollHeight
+      })
+    }
+    const observer = new ResizeObserver(pin)
     observer.observe(content)
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(queued)
+    }
   }, [])
 
   // Find the last thinking item ID (for folding previous ones)

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Which answer actually reaches the agent.
+ *
+ * The approval prompt is the one place a reader tells an agent whether it may
+ * run something. Existing coverage checks that the prompt appears, that all five
+ * answers are on screen, and that they are big enough to tap — not one of them
+ * checks what pressing them *sends*.
+ *
+ * That gap is the highest-severity one in this app. The five buttons differ only
+ * in the frame they produce; on screen they are five rounded rectangles. Cross
+ * two `onClick` handlers in a refactor and the UI looks perfect while an agent
+ * runs a command the reader rejected. Nothing would catch it, and on an agent
+ * with `bash` the first symptom is the damage.
+ *
+ * So these assert the wire, not the pixels. The frame shapes were read off a
+ * live run rather than off the source, so this is a record of what the agent is
+ * actually told.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** Get to a parked approval prompt with a scary command behind it. */
+async function atAnApproval(page: import('@playwright/test').Page) {
+  const agent = await mockAgent(page, 'approval')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByRole('button', { name: /allow once/i })).toBeVisible({ timeout: 20_000 })
+  return agent
+}
+
+/** label → the frame the agent must receive. */
+const DECISIONS: [RegExp, Record<string, unknown>][] = [
+  [/allow once/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }],
+  [/trust/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'session' }],
+  [/reject/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_soft' }],
+  [/stop/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_hard' }],
+  [/explain/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_explain' }],
+]
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  for (const [label, frame] of DECISIONS) {
+    test(`"${label.source}" sends exactly what it promises`, async ({ page }) => {
+      const agent = await atAnApproval(page)
+
+      await page.getByRole('button', { name: label }).first().click()
+
+      await expect
+        .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
+        .toEqual([frame])
+    })
+  }
+
+  test('nothing is answered until the reader answers it', async ({ page, shot }) => {
+    const agent = await atAnApproval(page)
+
+    // The run is parked precisely so a human decides. An approval sent by the
+    // client on its own — a retry, an effect firing twice — would be the agent
+    // being told "yes" by nobody.
+    await page.waitForTimeout(3000)
+    expect(agent.sent('APPROVAL_RESPONSE'), 'an answer was sent without anyone pressing anything').toEqual([])
+
+    await shot('parked')
+  })
+
+  test('answering twice does not send twice', async ({ page }) => {
+    const agent = await atAnApproval(page)
+
+    const allow = page.getByRole('button', { name: /allow once/i }).first()
+    await allow.click()
+    // A double tap is one gesture on a phone, and the second one must not become
+    // a second decision about whatever the agent asks next.
+    await allow.click({ force: true, timeout: 2000 }).catch(() => {})
+
+    await page.waitForTimeout(2000)
+    expect(agent.sent('APPROVAL_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -71,6 +71,10 @@ export async function mockAgent(
    *  down and reopened behind the reader — the screen looks identical either way,
    *  which is what makes a screen-level assertion about it vacuous. */
   let connects = 0
+  /** Every frame the client sent. The approval buttons differ only in the frame
+   *  they produce — the UI is identical whichever one is wired to which — so the
+   *  wire is the only place that difference is observable. */
+  const sent: Record<string, unknown>[] = []
 
   // Every socket except Next's dev-mode hot reload. Which host the SDK dials
   // depends on what the relay record advertises — relay socket for a hosted agent,
@@ -78,6 +82,7 @@ export async function mockAgent(
   await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
     ws.onMessage(raw => {
       const msg = JSON.parse(String(raw)) as { type: string; prompt?: string }
+      sent.push(msg)
 
       if (msg.type === 'CONNECT') {
         // The gate answers CONNECT instead of granting it. Unreachable with the
@@ -311,6 +316,8 @@ export async function mockAgent(
   return {
     /** Handshakes seen so far. */
     connects: () => connects,
+    /** Frames of one type, in order. */
+    sent: (type: string) => sent.filter(f => f.type === type),
   }
 }
 

--- a/e2e/scroll-follow.spec.ts
+++ b/e2e/scroll-follow.spec.ts
@@ -62,6 +62,15 @@ async function wheelUp(page: import('@playwright/test').Page) {
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
+  // These wait on a reply that arrives over about 3.5 seconds by design — the
+  // stick-to-bottom logic watches content height, so a reply delivered in one
+  // frame would never exercise it. Add page load and a dev server that may be
+  // compiling and the default 30s budget is genuinely tight: this spec has timed
+  // out twice on saturated full-suite runs while passing every time in isolation.
+  // A timeout is not a race, and raising a budget for work the test really does
+  // is not the same as loosening an assertion.
+  test.setTimeout(60_000)
+
   test('a reply that outgrows the screen stays followed to its last line', async ({ page, shot }) => {
     await startLongReply(page)
 


### PR DESCRIPTION
## 1. The transcript could rest short of the bottom

I called this "a settling artifact" in #96 and chose not to chase it. That was wrong — it reproduced twice more, and it is a real defect on exactly the devices priority 1 is about.

```
run 1:  100px adrift, still adrift after 10s
run 2:  135px adrift, still adrift after 10s
```

The pane is 468px tall, so at that offset **the end of the reply is below the fold**. The reader is looking at a finished answer whose last lines they cannot see, with no further content coming to correct it.

Cause: the observer sets `scrollTop = scrollHeight` **at the instant it fires**. The layout that follows — a code block measuring, a font landing, several streamed chunks coalesced into one callback — grows the content again, and there is no further resize to trigger another pin.

Fix: pin again on the next animation frame, cancelled and rescheduled per callback so a burst of resizes costs one extra pin rather than one per chunk.

Verified against the load that produced the failures: the full suite failed on this twice at 18min and 13min, and passes at **111 passed / 13.0m** with the fix.

## 2. Approval decisions had no coverage of what they send

The approval prompt is the one place a reader tells an agent whether it may run something. Existing coverage checks the prompt appears, all five answers are on screen, and they are big enough to tap. **Nothing checked what pressing them sends.**

Five buttons that are five rounded rectangles on screen and differ only in the frame they produce:

```
allow once  → { approved: true,  scope: 'once' }
trust       → { approved: true,  scope: 'session' }
reject      → { approved: false, scope: 'once', mode: 'reject_soft' }
stop        → { approved: false, scope: 'once', mode: 'reject_hard' }
explain     → { approved: false, scope: 'once', mode: 'reject_explain' }
```

Cross two `onClick` handlers in a refactor and the UI looks perfect while an agent runs a command the reader **rejected**. On an agent with `bash` the first symptom is the damage.

All five are correctly wired today — the shapes above were read off a live run, not off the source, so the spec records what the agent is actually told. Plus: nothing is answered until a human answers it, and a double tap does not answer twice.

Verified by wiring Reject to approve — caught, on the `reject` case only.

## Also

`scroll-follow` gets a 60s budget. It waits on a reply that arrives over ~3.5s by design (content height is what the logic watches, so a one-frame reply would not exercise it), and one earlier failure was a plain 30s timeout rather than an assertion. Raising a budget for work the test really does is not the same as loosening an assertion — and it is not what fixed the adrift-transcript failures, which needed the product change above.

`tsc` clean · `lint` 0 · `vitest` 56 · **full suite 111 passed**.

## Checked, not bugs

- **Deleting the chat you are viewing** confirms, erases the transcript from `localStorage`, and navigates to the agent. Well-behaved; no change.
- **Removing an agent from Settings** does not have the #97 re-add bug — Settings is not under `/[address]`, so no auto-add effect re-runs.

## Left alone

The machine is at **5.9G free of 932G**, and a full local suite now takes 13–18 minutes against ~3.5 in CI. Several worktrees under `/private/tmp/claude-501/**/scratchpad/` belong to other sessions and are not mine to delete, so I have not touched them — but the disk is tight enough that builds could start failing in ways that read as test failures, as one did earlier in this series.