### PR TITLE
Assert the other two decisions that reach the agent

### DIFF
--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -78,3 +78,62 @@ test.describe('phone', () => {
     expect(agent.sent('APPROVAL_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
   })
 })
+
+test.describe('the other decisions that reach the agent', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('an answered question sends the option that was chosen', async ({ page, shot }) => {
+    const agent = await mockAgent(page, 'ask-user')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('Which environment should I deploy to?')).toBeVisible({ timeout: 20_000 })
+
+    // The two options are adjacent rounded rectangles and the agent acts on the
+    // answer. Sending the wrong one deploys to production because someone tapped
+    // staging — the same class of failure as a crossed approval handler, on a
+    // control that carries arbitrary agent-defined choices.
+    await page.getByRole('button', { name: 'production', exact: true }).click()
+
+    await expect
+      .poll(() => agent.sent('ASK_USER_RESPONSE'), { timeout: 10_000 })
+      .toEqual([{ type: 'ASK_USER_RESPONSE', answer: 'production' }])
+
+    await shot('answered')
+  })
+
+  test('the other option sends the other answer', async ({ page }) => {
+    const agent = await mockAgent(page, 'ask-user')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('Which environment should I deploy to?')).toBeVisible({ timeout: 20_000 })
+
+    // Asserting one option proves the wiring exists; asserting both proves it
+    // distinguishes. A handler that always sent the first option would pass the
+    // test above.
+    await page.getByRole('button', { name: 'staging', exact: true }).click()
+
+    await expect
+      .poll(() => agent.sent('ASK_USER_RESPONSE'), { timeout: 10_000 })
+      .toEqual([{ type: 'ASK_USER_RESPONSE', answer: 'staging' }])
+  })
+
+  test('a trust chip tells the agent which mode it is in', async ({ page }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // The chip reads "accept" and the mode is "accept_edits" — a label that is
+    // not its value is exactly what a rename breaks silently, and the mode is
+    // what decides whether the agent asks before it edits.
+    await page.getByRole('button', { name: 'accept', exact: true }).click()
+    await page.getByRole('button', { name: 'plan', exact: true }).click()
+
+    await expect
+      .poll(() => agent.sent('mode_change'), { timeout: 10_000 })
+      .toEqual([
+        { type: 'mode_change', mode: 'accept_edits' },
+        { type: 'mode_change', mode: 'plan' },
+      ])
+  })
+})


### PR DESCRIPTION
#98 pinned what the five approval buttons send. The same gap existed on the other controls whose entire purpose is to transmit a choice, so this finishes that sweep.

## What is now pinned

**An answered question** → `ASK_USER_RESPONSE { answer }`, the chosen option verbatim.

Both options are asserted, not one. A handler that always sent the first option would sail through a test that only checked `production`. The agent acts on this answer, so the failure here is deploying to production because someone tapped staging — the same shape as a crossed approval handler, on a control carrying arbitrary agent-defined choices.

**A trust chip** → `mode_change { mode }`.

The chip reads `accept` and the mode is `accept_edits`. A label that is not its value is exactly what a rename breaks silently, and the mode is what decides whether the agent asks before it edits.

Both are correct today. Verified by crossing the mode wiring so every chip sent `safe` — caught, on that test only.

## A wrong conclusion I nearly filed

My first probe looked for `MODE` / `SET_MODE` / `APPROVAL_MODE` and found nothing, then confirmed that `INPUT` carries only `input_id` and `prompt`. Read literally: **the trust mode never reaches the agent** — safe/plan/accept would be decorative, which would be one of the most serious things I could report on this app.

It was my probe. The SDK sends `mode_change`, lowercase, and my list of candidate type names was all uppercase. Reading `remote-agent.js` rather than trusting the absence is what caught it:

```js
const msg = { type: 'mode_change', mode… }
```

An absence measured with the wrong query looks identical to a real absence. That is the third time in this series a measurement has pointed at a severe non-bug, and the pattern each time is that I asked a question narrower than the thing I was claiming.

## Verification

`tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 114 passed**. `git status` confirms test files only.

## Left alone

`ulw_turns_reached`'s "continue" and the onboard submit are the two remaining decision-carrying frames without wire coverage. The ULW one is reachable and worth the same treatment; I stopped here rather than stretch the pass, and it is a small follow-on now that `mockAgent().sent()` exists.

The disk is at **5.9G free of 932G** and a full local suite now takes 11–18 minutes against ~3.3 in CI. Worktrees under `/private/tmp/claude-501/**/scratchpad/` belong to other sessions and are not mine to remove.