### PR TITLE
Say what to do when the microphone will not work

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -199,11 +199,7 @@ export function ChatInput({
         {/* Voice error */}
         {voiceError && (
           <div className="mb-2 flex items-center justify-center gap-2 rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">
-            <span>
-              {voiceError.message.includes('authentication') || voiceError.message.includes('API')
-                ? 'Please set your OpenOnion API key in Settings'
-                : `Error: ${voiceError.message}`}
-            </span>
+            <span>{voiceErrorMessage(voiceError)}</span>
           </div>
         )}
 
@@ -474,4 +470,37 @@ function LoadingSpinner() {
       />
     </svg>
   )
+}
+
+/** What to tell the reader when dictation fails.
+ *
+ *  The default was `Error: ${message}`, which on a blocked microphone renders
+ *  the browser's own "Permission denied" — words that say neither who denied it
+ *  nor what to do. On a phone, where mic access is a per-site permission people
+ *  decline by reflex and forget, that is a dead end at the second most prominent
+ *  control in the composer. The API-key branch already set the standard by
+ *  naming the fix, so the other common failures now do too.
+ *
+ *  Matched on the DOMException name where there is one, because the message text
+ *  differs between browsers while the name does not. */
+function voiceErrorMessage(error: Error): string {
+  const name = (error as DOMException).name
+  const text = error.message || ''
+
+  // Names first, then text. Matching text first put a NotFoundError whose
+  // message happened to contain "denied" into the permission branch, telling a
+  // reader with no microphone to go and change a permission.
+  if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+    return 'No microphone found. Connect one, or type your message instead.'
+  }
+  if (name === 'NotReadableError') {
+    return 'The microphone is in use by another app. Close it and try again.'
+  }
+  if (name === 'NotAllowedError' || /permission|denied/i.test(text)) {
+    return 'Microphone blocked. Allow microphone access for this site in your browser settings, then try again.'
+  }
+  if (/authentication/i.test(text) || /API/.test(text)) {
+    return 'Please set your OpenOnion API key in Settings'
+  }
+  return `Error: ${text}`
 }

--- a/e2e/voice.spec.ts
+++ b/e2e/voice.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * The microphone, when it does not work.
+ *
+ * Dictation is the second most prominent control in the composer and the one
+ * most likely to fail on a phone, where mic access is a per-site permission
+ * people deny by reflex and forget. Nothing covered it.
+ *
+ * It did surface a banner — but a raw one: `Error: Permission denied`. That is
+ * the browser's words, and it tells a reader neither who denied it nor what to
+ * do about it. The API-key branch three lines away already says "Please set your
+ * OpenOnion API key in Settings", which is the standard this should meet.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** Refuse the microphone the way a browser does when the reader blocked it. */
+async function denyTheMicrophone(
+  page: import('@playwright/test').Page,
+  name: 'NotAllowedError' | 'NotFoundError' = 'NotAllowedError',
+) {
+  // Real messages, not one message reused: browsers word these differently while
+  // the DOMException name stays put, which is why the component matches on name.
+  const message = name === 'NotFoundError' ? 'Requested device not found' : 'Permission denied'
+  await page.addInitScript(([errorName, errorMessage]) => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: () => Promise.reject(new DOMException(errorMessage, errorName)),
+      },
+    })
+  }, [name, message])
+}
+
+async function inAConversation(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a blocked microphone says who blocked it and what to do', async ({ page, shot }) => {
+    await denyTheMicrophone(page)
+    await inAConversation(page)
+
+    await page.getByRole('button', { name: /start recording/i }).click()
+
+    // Not "Error: Permission denied". The reader needs to know this is a browser
+    // permission they can change, not the agent refusing them or the app breaking.
+    const banner = page.locator('.bg-red-50').first()
+    await expect(banner).toBeVisible({ timeout: 10_000 })
+    await expect(banner, 'the banner repeats the browser instead of explaining').toContainText(/microphone/i)
+    await expect(banner).toContainText(/browser|settings|allow/i)
+
+    await shot('blocked')
+  })
+
+  test('a missing microphone is not reported as a refusal', async ({ page }) => {
+    await denyTheMicrophone(page, 'NotFoundError')
+    await inAConversation(page)
+
+    await page.getByRole('button', { name: /start recording/i }).click()
+
+    // Nothing to allow if there is no device — telling this reader to change a
+    // permission sends them somewhere that cannot help.
+    const banner = page.locator('.bg-red-50').first()
+    await expect(banner).toBeVisible({ timeout: 10_000 })
+    await expect(banner).toContainText(/no microphone|not find|no.*device/i)
+  })
+
+  test('the composer is usable again after the mic fails', async ({ page }) => {
+    await denyTheMicrophone(page)
+    await inAConversation(page)
+
+    await page.getByRole('button', { name: /start recording/i }).click()
+    await expect(page.locator('.bg-red-50').first()).toBeVisible({ timeout: 10_000 })
+
+    // A failed dictation must not leave the composer stuck in a recording state —
+    // typing is the fallback, and it is the only one left.
+    await expect(page.getByRole('button', { name: /start recording/i })).toBeVisible()
+    await page.getByPlaceholder(/message/i).fill('typing instead')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('You said: typing instead')).toBeVisible({ timeout: 20_000 })
+  })
+})


### PR DESCRIPTION
Priority 1. Dictation is the second most prominent control in the composer and the one most likely to fail on a phone, where mic access is a per-site permission people decline by reflex and forget. **Nothing covered it.**

## What the reader saw

```
Error: Permission denied
```

The browser's own words, in a red banner. It says neither *who* denied it — the browser, not the agent, not the app breaking — nor what to do about it. Three lines away in the same component, the API-key branch already says *"Please set your OpenOnion API key in Settings"*, which is the standard this should have met.

Now:

| failure | message |
|---|---|
| blocked | Microphone blocked. Allow microphone access for this site in your browser settings, then try again. |
| no device | No microphone found. Connect one, or type your message instead. |
| in use elsewhere | The microphone is in use by another app. Close it and try again. |

Matched on the **DOMException name**, not the message text: browsers word these differently while the name stays put.

## The ordering bug in my own fix

My first version checked the text before the name, so a `NotFoundError` whose message happened to contain "denied" landed in the permission branch — telling a reader **with no microphone at all** to go and change a permission. The test caught it because the two cases assert different text; a single "an error is shown" test would have passed.

I also made the mock use each error's real message rather than reusing one string, so the spec cannot pass for the wrong reason.

## Also covered

That a failed dictation leaves the composer usable — the button returns to "Start recording" and typing still works. Typing is the only fallback left at that point, and a composer stuck in a recording state would end the conversation.

## Verification

Written first, failed with `Received string: "Error: Permission denied"`. `tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 120 passed**. Screenshot checked at 375px — the message wraps to three lines and the composer stays put.

## Checked, not changed

- **Spacing rhythm** (priority 5): measured the transcript's vertical gaps — every row carries the same 4px bottom margin, so the rhythm is uniform. The differing internal padding (24/12/0) is per row type and legitimate: a user bubble needs it, a compact tool row does not. No defect, so no change.
- **Indent rails** (priority 5): already guarded by two tests in `transcript.spec.ts`.

## An attempt that did not work

I tried symlinking `node_modules` from the main checkout to stop each pass costing ~600MB. It typechecks clean in the main checkout but produces implicit-`any` errors here — the installed tree is older than current `main` expects and is missing `@connectonion/react` entirely. Correct toolchain beats disk, so I reverted to a real install. The disk is at **5.6G free of 932G**; worktrees under `/private/tmp/claude-501/**/scratchpad/` belong to other sessions and are not mine to remove.