### PR TITLE
Do not offer attachments to an agent that refuses them

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -48,6 +48,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
 import { OnboardGate } from '@/components/chat/onboard-gate'
+import { acceptsAttachments } from '@/components/chat/skill-offers'
 import { LowBalanceNotice, isLowBalance } from '@/components/agent-address'
 
 export default function ChatSessionPage() {
@@ -325,6 +326,9 @@ export default function ChatSessionPage() {
           onRetry={lastUserMessage ? () => handleSend(lastUserMessage) : undefined}
           onDismissError={() => setConnectionError(null)}
           skills={skills}
+          acceptsAttachments={acceptsAttachments(
+            profile?.accepted_inputs ?? agentInfoMap[address]?.accepted_inputs
+          )}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
           notice={
             typeof balanceUsd === 'number' && isLowBalance(balanceUsd)

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -12,7 +12,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
-import { bestOffers, UNIVERSAL_OPENER } from '@/components/chat/skill-offers'
+import { bestOffers, UNIVERSAL_OPENER, acceptsAttachments } from '@/components/chat/skill-offers'
 import { AgentAddress, TopUp } from '@/components/agent-address'
 
 
@@ -392,6 +392,7 @@ export default function AgentLandingPage() {
                 onSend={handleSend}
                 placeholder="Message this agent..."
                 skills={skills}
+                acceptsAttachments={acceptsAttachments(agentInfo?.accepted_inputs)}
                 statusBar={
                   <ModeStatusBar
                     mode={mode}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -23,6 +23,7 @@ export function ChatInput({
   statusBar,
   className,
   skills,
+  acceptsAttachments = true,
   awaitingYou = false,
   onJumpToPending,
 }: ChatInputProps) {
@@ -324,7 +325,13 @@ export function ChatInput({
               className="hidden"
             />
 
-            {/* File picker button - always available */}
+            {/* Only when the agent will take one. Agents publish
+                `accepted_inputs`, the landing page already prints it, and this
+                button ignored it — so a text-only agent still invited a photo
+                that it would refuse. Undeclared means allowed: almost nothing
+                publishes this yet, and hiding attachments from everyone would be
+                the worse error. */}
+            {acceptsAttachments && (
             <button
               onClick={() => fileInputRef.current?.click()}
               disabled={isVoiceActive}
@@ -333,6 +340,7 @@ export function ChatInput({
             >
               <HiOutlinePlus className="h-4 w-4 stroke-[2.5]" />
             </button>
+            )}
 
             {/* Textarea - always available so user can type during execution */}
             <textarea

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -46,6 +46,7 @@ export function Chat({
   onRetry,
   onDismissError,
   skills,
+  acceptsAttachments,
   agentName,
 }: ChatProps & { agentName?: string }) {
   const offers = useMemo(() => bestOffers(skills ?? []), [skills])
@@ -124,6 +125,7 @@ export function Chat({
         placeholder={inputPlaceholder}
         statusBar={statusBar}
         skills={skills}
+        acceptsAttachments={acceptsAttachments}
         // The composer is the one part of the page a reader always looks at, so it
         // is where "it is your move" has to be said. Everything else — the spinner,
         // the token counter, the status chip on the card — was either lying or

--- a/components/chat/skill-offers.ts
+++ b/components/chat/skill-offers.ts
@@ -56,3 +56,13 @@ export function bestOffers(skills: { name: string; description?: string }[]) {
       a.offer.length - b.offer.length)
     .slice(0, 3)
 }
+
+/** Whether to offer attachments at all.
+ *
+ *  Undeclared means allowed — almost no agent publishes `accepted_inputs` yet,
+ *  and reading silence as refusal would take the paperclip away from nearly
+ *  everyone. Only an explicit "neither images nor files" hides it. */
+export function acceptsAttachments(inputs?: { images?: boolean; files?: unknown } | null) {
+  if (!inputs) return true
+  return Boolean(inputs.images || inputs.files)
+}

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -329,6 +329,8 @@ export interface ChatProps {
    *  on screen when the reader scrolls back down to type — today, a balance that
    *  is about to run out. */
   notice?: React.ReactNode
+  /** False only when the agent has declared it takes neither images nor files. */
+  acceptsAttachments?: boolean
   /** ULW state for 3-state bottom panel */
   mode?: ApprovalMode
   ulwTurnsRemaining?: number | null
@@ -370,6 +372,8 @@ export interface ChatInputProps {
   /** Status bar below input (mode indicator + hints) */
   statusBar?: React.ReactNode
   skills?: SkillInfo[]
+  /** False only when the agent has declared it takes neither images nor files. */
+  acceptsAttachments?: boolean
 }
 
 export interface ChatMessagesProps {

--- a/e2e/attachments.spec.ts
+++ b/e2e/attachments.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Offering to attach a file to an agent that will not take one.
+ *
+ * Agents declare what they accept — `accepted_inputs: { text, images, files }` —
+ * and the landing page already reads it, printing "text" for a text-only agent
+ * in its inventory panel. The composer never consulted it: the paperclip was
+ * comment-labelled "always available" and shown to every agent.
+ *
+ * So a reader picks a photo, sends it, and the agent refuses. That is the same
+ * shape as the invite gate before #96 — a control that invites an action which
+ * cannot succeed — and on a phone the paperclip sits under the thumb.
+ *
+ * Undeclared means allowed. Most agents publish nothing here, and hiding
+ * attachments from all of them would be a far worse error than showing one too
+ * many.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+async function landOn(page: import('@playwright/test').Page, accepted?: unknown) {
+  await mockAgent(page, 'reply', accepted ? ({ accepted_inputs: accepted } as never) : {})
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('an agent that takes only text is not offered attachments', async ({ page, shot }) => {
+    await landOn(page, { text: true, images: false })
+
+    await expect(
+      page.getByRole('button', { name: /attach file/i }),
+      'the paperclip is offered to an agent that will refuse the file',
+    ).toHaveCount(0)
+
+    await shot('text-only')
+  })
+
+  test('an agent that takes images keeps its paperclip', async ({ page }) => {
+    await landOn(page, { text: true, images: true })
+    await expect(page.getByRole('button', { name: /attach file/i })).toBeVisible()
+  })
+
+  test('an agent that takes files keeps its paperclip', async ({ page }) => {
+    await landOn(page, { text: true, images: false, files: { max_file_size_mb: 10 } })
+    await expect(page.getByRole('button', { name: /attach file/i })).toBeVisible()
+  })
+
+  test('an agent that declares nothing keeps its paperclip', async ({ page }) => {
+    await landOn(page)
+
+    // The permissive default, and the case that matters most: almost no agent
+    // publishes accepted_inputs today, so reading "undeclared" as "refuses"
+    // would take attachments away from nearly everyone.
+    await expect(page.getByRole('button', { name: /attach file/i })).toBeVisible()
+  })
+
+  test('the same rule applies inside a conversation', async ({ page }) => {
+    await landOn(page, { text: true, images: false })
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // The composer on the session route is a second instance of the same
+    // component, and the landing page is not where most messages get sent.
+    await expect(page.getByRole('button', { name: /attach file/i })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Priority 1 — the composer on a phone.

## The finding

Agents publish `accepted_inputs: { text, images, files }`, and the landing page **already reads it** — a text-only agent's inventory panel prints `text`. The composer never consulted it. The attach button carried the comment *"File picker button - always available"* and was shown to every agent.

So a reader taps the paperclip, picks a photo, sends it, and the agent refuses. That is the same shape as the invite gate before #96: a control inviting an action that cannot succeed. On a phone the paperclip sits directly under the thumb, left of the text field.

## The fix

Hide it only when the agent has **explicitly** declared it takes neither images nor files.

**Undeclared means allowed.** Almost nothing publishes `accepted_inputs` today, so reading silence as refusal would take attachments away from nearly everyone — a far worse error than showing one too many. That case has its own test.

Both routes are wired. The session composer is a second instance of the same component and is where most messages actually get sent — the lesson from #96 and #97 is that one route quietly missing a behaviour is this codebase's recurring failure, so I did not fix only the one I was looking at.

## Verification

| | before | after |
|---|---|---|
| text-only agent is not offered attachments | ✗ *the paperclip is offered to an agent that will refuse the file* | ✓ |
| images-accepting agent keeps it | ✓ | ✓ |
| files-accepting agent keeps it | ✓ | ✓ |
| undeclared keeps it | ✓ | ✓ |
| the same rule applies inside a conversation | ✗ | ✓ |

`tsc` clean · `lint` 0 · `vitest` 56. Screenshot checked at 375px: the paperclip is gone and the composer closes up cleanly around the remaining mic and send controls.

I also confirmed the declaration genuinely reaches the page before building on it — the inventory panel renders `text` for `{ text: true, images: false }` — rather than assuming the plumbing existed.

## About the local suite result

The full local run came back **122 passed, 1 failed**, the failure being `scroll-follow` — a spec this change does not touch — with `getByText('step-1.ts')` never appearing, i.e. the reply never started. That run took **26 minutes** for a 12-minute suite.

The cause is environmental. The disk had fallen to **3.8G free of 932G**; earlier in this series a full disk surfaced as three unrelated test failures and cost me a misdiagnosis. I reclaimed ~1.5G (my `.next` and test artifacts, plus two stale Playwright Chromium builds — 1187 and 1208, where only 1234 is required; the cache re-downloads on demand) and the spec then passed 3/3 on a warm build, failing only on the first run after a cold `.next` when compilation exceeds the 20s wait.

CI builds once with `npm run build && npm start` rather than running a dev server, does not have this problem, and is the signal I am trusting here. The specs this change actually touches — `attachments`, `composer`, `chat` — pass **17/17** locally.

I am flagging rather than hiding this: my local signal is currently degraded, and I would rather say so than present a green number I do not fully believe.