### PR TITLE
Make the offline scenario actually produce an offline agent

### DIFF
--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -84,6 +84,12 @@ export async function mockAgent(
       const msg = JSON.parse(String(raw)) as { type: string; prompt?: string }
       sent.push(msg)
 
+      // An offline agent answers nothing. Replying to CONNECT with a profile is
+      // proof of life, and the app is right to treat it as such — which is why
+      // this scenario still reported "online" after its endpoints and relay were
+      // taken away. Offline has to mean silence.
+      if (scenario === 'offline') return
+
       if (msg.type === 'CONNECT') {
         // The gate answers CONNECT instead of granting it. Unreachable with the
         // agents in use today — both take invite codes only — which is why this
@@ -287,8 +293,13 @@ export async function mockAgent(
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
+        // Offline means no route at all. Emptying `endpoints` while still
+        // advertising a relay leaves the agent perfectly reachable — the SDK
+        // derives `online` from having somewhere to dial, not from a field — so
+        // this scenario reported "online" and never once produced the state it
+        // is named for. Nothing used it, which is why nobody noticed.
         endpoints: scenario === 'offline' ? [] : ['https://scriptbot.example'],
-        relay: 'wss://oo.openonion.ai/ws',
+        relay: scenario === 'offline' ? null : 'wss://oo.openonion.ai/ws',
         last_seen: new Date(0).toISOString(),
         profile,
       }),

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * An agent that cannot be reached, from a session link.
+ *
+ * The landing page says so plainly: "This agent is offline — messages may not be
+ * delivered." The session route said nothing at all — full composer, opener
+ * chips, no warning — so a reader arriving by a forwarded chat URL types into an
+ * agent that is not there and waits.
+ *
+ * Same shape as the invite gate (#96) and the attach button (#102): one route
+ * carrying a fact the other has, on the route where most messages are sent. The
+ * session half is open — see the issue linked from this file's PR.
+ *
+ * The `offline` scenario itself had never produced an offline agent. It emptied
+ * `endpoints` while still advertising a relay, and still answered CONNECT with a
+ * profile — both of which are proof of reachability, and the app was right to
+ * treat them as such. Offline means no route and no reply.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('the landing page says the agent is offline', async ({ page }) => {
+    await mockAgent(page, 'offline')
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    // Guards the scenario as much as the page: if this stops failing to reach the
+    // offline state, every test below it silently becomes a test of an online agent.
+    await expect(page.getByText(/messages may not be delivered/i)).toBeVisible({ timeout: 20_000 })
+  })
+
+  // The session route shows no warning at all — filed as an issue rather than
+  // fixed here: keying the notice on `agentInfoMap[address].online === false`
+  // did not take effect on that route, and I would rather leave it visibly open
+  // than ship a fix I could not make work.
+
+  test('a reachable agent is not accused of being offline', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}/reachable-session`)
+    await expect(page.locator('main').getByText(PROFILE.name).first()).toBeVisible({ timeout: 20_000 })
+    await page.waitForTimeout(2000)
+
+    // The other direction: a warning that shows for working agents is worse than
+    // none, because it teaches the reader to ignore it.
+    await expect(page.getByText(/may not be delivered/i)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## A scenario that never produced its own state

`mockAgent(page, 'offline')` did not make an agent offline. It emptied `endpoints` — while still advertising a relay, and still answering `CONNECT` with a profile. Both are proof of reachability, and **the app was right to report "online"**.

Nothing in the suite used the scenario, which is why nobody noticed. Had anyone written an offline test against it, it would have passed while testing an online agent.

Offline now means what it says: no endpoints, no relay, and no reply.

Getting there took three wrong attempts, each of which taught something about the app:

1. Emptying `endpoints` — still online, because the relay is a route.
2. Setting `online: false` on the profile — still online; the SDK **derives** that field from having somewhere to dial rather than reading it.
3. Removing the relay too — still online, because the mock kept answering `CONNECT`, and an agent that answers is online.

Each of those is correct behaviour by the app. The scenario was the thing that was wrong.

## What it revealed

The landing page's offline warning — *"This agent is offline — messages may not be delivered."* — had never been tested. It works, and now has a guard, which also protects the scenario: if `offline` ever stops reaching the state, that test fails rather than every offline test silently becoming an online test.

The **session route has no equivalent**. Measured on a phone with a genuinely unreachable agent:

```
LANDING  offlineWord=true   warning=true
SESSION  offlineWord=false  warning=false
```

Full composer, opener chips, no warning. That is the third instance of one shape — the session route missing a fact the landing route has, after the invite gate (#96) and the attach button (#102).

## Why the session half is not fixed here

I tried, using the `notice` slot the low-balance warning already occupies (#85), keyed on `agentInfoMap[address]?.online === false`. **It did not take effect**, and I did not establish why: `online` is false on the landing route, which reads the same hook for the same address, but the session render did not see it within a 15s window.

Rather than ship a fix I could not verify, or quietly drop the finding, it is **#103** with the measurements, the approach I tried, and where I would start.

## Verification

`tsc` clean · `lint` 0 · `vitest` 56 · **full Playwright suite 127 passed** (9.9m, clean run — the disk pressure from #102 has eased after reclaiming ~1.5G).