### PR TITLE
Say the agent is offline on the session route too

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -49,7 +49,7 @@ import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
 import { OnboardGate } from '@/components/chat/onboard-gate'
 import { acceptsAttachments } from '@/components/chat/skill-offers'
-import { LowBalanceNotice, isLowBalance } from '@/components/agent-address'
+import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
 
 export default function ChatSessionPage() {
   const params = useParams()
@@ -331,9 +331,11 @@ export default function ChatSessionPage() {
           )}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
           notice={
-            typeof balanceUsd === 'number' && isLowBalance(balanceUsd)
-              ? <LowBalanceNotice address={address} balanceUsd={balanceUsd} />
-              : null
+            agentInfoMap[address]?.online === false
+              ? <OfflineNotice />
+              : typeof balanceUsd === 'number' && isLowBalance(balanceUsd)
+                ? <LowBalanceNotice address={address} balanceUsd={balanceUsd} />
+                : null
           }
         />
       </div>

--- a/components/agent-address.tsx
+++ b/components/agent-address.tsx
@@ -124,3 +124,12 @@ export function LowBalanceNotice({ address, balanceUsd }: { address: string; bal
     </div>
   )
 }
+
+/** Shown with the composer when the agent has no reachable route. */
+export function OfflineNotice() {
+  return (
+    <div className="border-t border-neutral-200 bg-neutral-50 px-4 py-2 text-center text-[11px] text-neutral-600">
+      This agent is offline — messages may not be delivered.
+    </div>
+  )
+}

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -51,3 +51,18 @@ export const test = base.extend<{ shot: (name: string) => Promise<void> }>({
 })
 
 export { expect }
+
+/** The conversation pane — what is actually in front of the reader.
+ *
+ *  Reach for this instead of `page.getByText(...)`. The sidebar renders the same
+ *  words as the pane (an agent's name, a session title, "offline"), and when the
+ *  drawer is closed those copies are still in the DOM at `visibility: hidden`,
+ *  off-screen. An unscoped locator finds them first, and the failure it produces
+ *  is "expected visible, received hidden" — which reads exactly like the feature
+ *  being broken.
+ *
+ *  That has now cost five tests across this suite, and once cost a working fix
+ *  being reported as not working. */
+export function pane(page: import('@playwright/test').Page) {
+  return page.locator('main')
+}

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -16,7 +16,7 @@
  * treat them as such. Offline means no route and no reply.
  */
 
-import { test, expect } from './fixtures'
+import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 
 test.describe('phone', () => {
@@ -31,10 +31,35 @@ test.describe('phone', () => {
     await expect(page.getByText(/messages may not be delivered/i)).toBeVisible({ timeout: 20_000 })
   })
 
-  // The session route shows no warning at all — filed as an issue rather than
-  // fixed here: keying the notice on `agentInfoMap[address].online === false`
-  // did not take effect on that route, and I would rather leave it visibly open
-  // than ship a fix I could not make work.
+  test('a session link says it too', async ({ page, shot }) => {
+    await mockAgent(page, 'offline')
+    await page.goto(`/${AGENT_ADDRESS}/forwarded-while-offline`)
+
+    await expect(pane(page).getByText(PROFILE.name).first()).toBeVisible({ timeout: 20_000 })
+
+    // Scoped to the pane. Unscoped, `/offline/i` matches two elements and the
+    // first is the drawer's "ALL AGENTS OFFLINE" label — hidden, off-screen, and
+    // it reports "expected visible, received hidden", which reads exactly like
+    // the notice not rendering. That is how a working version of this fix got
+    // reported as not working.
+    await expect(
+      pane(page).getByText(/may not be delivered/i),
+      'a session link into an unreachable agent looks perfectly normal',
+    ).toBeVisible({ timeout: 15_000 })
+
+    await shot('offline-session')
+  })
+
+  test('offline outranks a low balance', async ({ page }) => {
+    await mockAgent(page, 'offline', { balance_usd: 0.2 })
+    await page.goto(`/${AGENT_ADDRESS}/broke-and-offline`)
+    await expect(pane(page).getByText(PROFILE.name).first()).toBeVisible({ timeout: 20_000 })
+
+    // Credit is irrelevant to an agent that cannot be reached, and two stacked
+    // warnings above a composer read as noise rather than one thing to act on.
+    await expect(pane(page).getByText(/may not be delivered/i)).toBeVisible({ timeout: 15_000 })
+    await expect(pane(page).getByText(/running low/i)).toHaveCount(0)
+  })
 
   test('a reachable agent is not accused of being offline', async ({ page }) => {
     await mockAgent(page)


### PR DESCRIPTION
Closes #103.

## The fix

The landing page has always said *"This agent is offline — messages may not be delivered."* The session route — where a forwarded link lands, and where most messages are actually sent — said nothing: full composer, opener chips, no warning. A reader types into an agent that is not there and waits.

It now uses the `notice` slot above the composer, the one the low-balance warning already occupies (#85). **Offline outranks a low balance**: credit is irrelevant to an agent that cannot be reached, and two stacked warnings above a composer read as noise rather than as one thing to act on. That precedence has its own test.

Neutral grey rather than red — offline is a state, not an error.

## I was wrong in #103, and here is how

I filed that issue saying this exact fix "did not take effect" and that I could not establish why. **It did take effect.** The fix was correct when I wrote it, and I reported it as broken.

The assertion was `page.getByText(/offline/i).first()`. Instrumented, that matches two elements:

```
SPAN  vis=hidden   143x17  inAside=true    <- the drawer's "ALL AGENTS OFFLINE"
DIV   vis=visible  375x34  inAside=false   <- the notice, rendering correctly
```

`.first()` is the hidden one. Playwright reports *expected visible, received hidden*, which reads exactly like the feature not working — so I trusted it, reverted a working change, and wrote an issue explaining a problem that did not exist.

Getting to the truth took one measurement I should have taken then: rendering `agentInfoMap[address]?.online` into a temporary data attribute. It read `false` immediately and stayed false, which meant the input was fine and the fault had to be in the test.

## The recurring part

This is the **fifth** time an unscoped `getByText` has matched the hidden drawer in this suite. I noted the lesson in #94, again in #96, and did it again anyway — this time at the cost of a false bug report.

So it is now a fixture rather than a note: a `pane(page)` helper returning `page.locator('main')`, with the failure mode documented on it. A note I have to remember is not a fix; a helper that is easier to reach for than the wrong thing has a chance.

## Verification

| | before | after |
|---|---|---|
| landing says offline | ok (guard from #104) | ok |
| a session link says it too | FAILED | ok |
| offline outranks a low balance | new | ok |
| a reachable agent is not accused | ok, guards the other way | ok |

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 129 passed**. Screenshot checked at 375px — the notice sits above the composer and the header dot is grey.
