### PR TITLE
Carry an attachment across the send that navigates

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -176,9 +176,9 @@ export default function ChatSessionPage() {
     }
 
     // Then send the pending message
-    const pendingMessage = consumePendingMessage()
+    const { message: pendingMessage, images: pendingImages } = consumePendingMessage()
     if (pendingMessage) {
-      send(pendingMessage)
+      send(pendingMessage, pendingImages ?? undefined)
     }
   }, [sessionId, initialMode, initialTurns, consumePendingMessage, send, setMode])
 

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -158,11 +158,16 @@ export default function AgentLandingPage() {
     if (!promoted.current) clearRef.current()
   }, [])
 
-  const handleSend = useCallback((content: string, _images?: string[]) => {
+  // `images` used to be `_images` — accepted and dropped. Sending here does not
+  // send: it stores the message and navigates to a session that sends it on
+  // arrival, and the store carried only a string. So an attachment picked before
+  // the conversation existed vanished on the way, after the reader had already
+  // watched its thumbnail appear in the composer.
+  const handleSend = useCallback((content: string, images?: string[]) => {
     const sessionId = draftSessionId
     promoted.current = true
     createConversation(sessionId, address)
-    setPendingMessage(content)
+    setPendingMessage(content, images)
 
     const params = new URLSearchParams()
     if (mode !== 'safe') {

--- a/e2e/attach-send.spec.ts
+++ b/e2e/attach-send.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * An attachment picked before the conversation exists.
+ *
+ * Sending from the landing page does not send: it stores the text and navigates
+ * to a session, which sends it on arrival. The store carried a bare string, so
+ * anything attached alongside was dropped on the way — silently, after the
+ * reader had already seen the thumbnail sitting in the composer.
+ *
+ * Inside a session the same attachment transmits correctly, which is what makes
+ * this hard to notice: the feature works everywhere except the first message,
+ * and the first message is the one a shared link is for.
+ */
+
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** A 1x1 PNG — the smallest thing that is genuinely an image. */
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+async function attach(page: import('@playwright/test').Page) {
+  await page.locator('input[type="file"]').first().setInputFiles({
+    name: 'shot.png',
+    mimeType: 'image/png',
+    buffer: PNG,
+  })
+  // The thumbnail is the promise being made to the reader.
+  await expect(page.locator('img[src^="data:"]').first()).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('an image attached on the landing page reaches the agent', async ({ page, shot }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    await attach(page)
+    await shot('attached')
+
+    await page.getByPlaceholder(/message/i).fill('what is in this screenshot')
+    await page.keyboard.press('Enter')
+
+    // The whole point of the message. Without the image the agent is answering a
+    // question about something it was never shown.
+    await expect
+      .poll(() => agent.sent('INPUT').some(f => Array.isArray((f as { images?: unknown[] }).images) && (f as { images: unknown[] }).images.length === 1), { timeout: 15_000 })
+      .toBe(true)
+  })
+
+  test('and the conversation shows it was sent', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    await attach(page)
+    await page.getByPlaceholder(/message/i).fill('look at this')
+    await page.keyboard.press('Enter')
+
+    // Arriving in a session where the image has vanished from the reader's own
+    // message is the visible half of the same bug.
+    await expect(pane(page).getByText('look at this').first()).toBeVisible({ timeout: 20_000 })
+    await expect(pane(page).locator('img[src^="data:"]').first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('a message with no attachment still sends cleanly', async ({ page }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    // Carrying attachments across must not attach an empty array to every message.
+    const first = agent.sent('INPUT')[0] as { images?: unknown }
+    expect(first.images, 'a plain message now carries an empty images field').toBeUndefined()
+  })
+})

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -27,6 +27,11 @@ interface ChatState {
   userProfile: UserProfile | null
   // Transient state (not persisted)
   pendingMessage: string | null  // Message to send after navigation
+  // Anything attached with it. Sending from the landing page navigates first and
+  // sends on arrival, so whatever the composer held has to travel too — it used
+  // to be dropped here, silently, after the reader had already seen the
+  // thumbnail sitting in the composer.
+  pendingImages: string[] | null
   _hasHydrated: boolean
 }
 
@@ -40,8 +45,8 @@ interface ChatActions {
   setApiKey: (apiKey: string) => void
   setUserProfile: (profile: UserProfile | null) => void
   clearActive: () => void
-  setPendingMessage: (message: string | null) => void
-  consumePendingMessage: () => string | null
+  setPendingMessage: (message: string | null, images?: string[]) => void
+  consumePendingMessage: () => { message: string | null; images: string[] | null }
 }
 
 type ChatStore = ChatState & ChatActions
@@ -56,6 +61,7 @@ export const useChatStore = create<ChatStore>()(
       openonionApiKey: '',
       userProfile: null,
       pendingMessage: null,
+      pendingImages: null,
       _hasHydrated: false,
 
       createConversation: (sessionId, agentAddress) => {
@@ -140,14 +146,15 @@ export const useChatStore = create<ChatStore>()(
         set({ activeSessionId: null })
       },
 
-      setPendingMessage: (message) => {
-        set({ pendingMessage: message })
+      setPendingMessage: (message, images) => {
+        set({ pendingMessage: message, pendingImages: images?.length ? images : null })
       },
 
       consumePendingMessage: () => {
         const message = get().pendingMessage
-        set({ pendingMessage: null })
-        return message
+        const images = get().pendingImages
+        set({ pendingMessage: null, pendingImages: null })
+        return { message, images }
       },
     }),
     {


### PR DESCRIPTION
Priority 1. Silent data loss on the first message of a shared link.

## The finding

Attach a screenshot on an agent's landing page, type "what is in this screenshot", send. The agent receives:

```json
{"type":"INPUT","input_id":"…","prompt":"what is in this screenshot"}
```

No image. The reader watched the thumbnail appear in the composer, sent, and the agent is now answering a question about something it was never shown.

Inside a session the identical attachment transmits correctly:

```json
{"type":"INPUT","input_id":"…","prompt":"…","images":["data:image/png;base64,…"]}
```

That contrast is what makes it hard to notice: attachments work everywhere except the **first** message — and the first message is what a shared link exists for.

## Cause

Sending from the landing page does not send. It stores the message and navigates to a session, which sends it on arrival. The store carried a bare `string`, and the handler said so plainly:

```js
const handleSend = useCallback((content: string, _images?: string[]) => {
```

Accepted and dropped. The underscore was accurate.

## Fix

`pendingMessage` now travels with `pendingImages`, and the landing page stops discarding what it was handed. `consumePendingMessage()` returns both.

A plain message still sends no `images` field at all — asserted, because attaching an empty array to every message would be a quiet protocol change affecting every send in the app.

## Verification

| | before | after |
|---|---|---|
| an image attached on the landing page reaches the agent | FAILED, no images field | ok |
| the conversation shows it was sent | FAILED | ok |
| a plain message carries no images field | ok, guards the fix | ok |

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 132 passed**. Screenshot checked at 375px: the thumbnail and its remove button sit in the composer before sending.

## The survey this came out of

I opened this pass intending to do the batch survey I recommended in #103 — checking everything the landing page derives from `agentInfo` against the session route, since three bugs had come from that shape (#96 gate, #102 attachments, #105 offline).

**That survey came back clean.** Every field that changes what a reader can do is honoured on both routes; Settings and the sidebar both know `online` and `balance_usd` too. The only fields the session route does not read are `model`, `trust` and `version` — identity text legitimately shown once on the landing page. Recording that as a measured result so it is not repeated.

The survey being clean is what sent me looking at payloads instead, which is where this was. Worth noting the direction reversed: the three earlier bugs were the session route missing what the landing page had. This one is the landing page dropping what the session route handles correctly.
