### PR TITLE
Carry the file attachment across too

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -176,9 +176,9 @@ export default function ChatSessionPage() {
     }
 
     // Then send the pending message
-    const { message: pendingMessage, images: pendingImages } = consumePendingMessage()
+    const { message: pendingMessage, images: pendingImages, files: pendingFiles } = consumePendingMessage()
     if (pendingMessage) {
-      send(pendingMessage, pendingImages ?? undefined)
+      send(pendingMessage, pendingImages ?? undefined, pendingFiles ?? undefined)
     }
   }, [sessionId, initialMode, initialTurns, consumePendingMessage, send, setMode])
 

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -13,6 +13,7 @@ import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
 import { bestOffers, UNIVERSAL_OPENER, acceptsAttachments } from '@/components/chat/skill-offers'
+import type { FileAttachment } from '@/components/chat/types'
 import { AgentAddress, TopUp } from '@/components/agent-address'
 
 
@@ -163,11 +164,11 @@ export default function AgentLandingPage() {
   // arrival, and the store carried only a string. So an attachment picked before
   // the conversation existed vanished on the way, after the reader had already
   // watched its thumbnail appear in the composer.
-  const handleSend = useCallback((content: string, images?: string[]) => {
+  const handleSend = useCallback((content: string, images?: string[], files?: FileAttachment[]) => {
     const sessionId = draftSessionId
     promoted.current = true
     createConversation(sessionId, address)
-    setPendingMessage(content, images)
+    setPendingMessage(content, images, files)
 
     const params = new URLSearchParams()
     if (mode !== 'safe') {

--- a/e2e/attach-send.spec.ts
+++ b/e2e/attach-send.spec.ts
@@ -30,8 +30,35 @@ async function attach(page: import('@playwright/test').Page) {
   await expect(page.locator('img[src^="data:"]').first()).toBeVisible({ timeout: 10_000 })
 }
 
+/** A plain text file — the other half of what the composer can hold. */
+const TXT = Buffer.from('ledger line one\nledger line two\n')
+
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a file attached on the landing page reaches the agent too', async ({ page, shot }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: 'ledger.txt', mimeType: 'text/plain', buffer: TXT,
+    })
+    await expect(pane(page).getByText(/ledger\.txt/).first()).toBeVisible({ timeout: 10_000 })
+
+    await page.getByPlaceholder(/message/i).fill('reconcile this')
+    await page.keyboard.press('Enter')
+
+    // onSend passes (content, images, files). The fix for images stopped at the
+    // second argument and left this one on the floor — the same drop, one
+    // parameter over, which is why both are asserted here rather than in
+    // separate specs that can drift apart again.
+    await expect
+      .poll(() => agent.sent('INPUT').some(f => Array.isArray((f as { files?: unknown[] }).files) && (f as { files: unknown[] }).files.length === 1), { timeout: 15_000 })
+      .toBe(true)
+
+    await shot('file-attached')
+  })
 
   test('an image attached on the landing page reaches the agent', async ({ page, shot }) => {
     const agent = await mockAgent(page)
@@ -73,7 +100,8 @@ test.describe('phone', () => {
     await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
 
     // Carrying attachments across must not attach an empty array to every message.
-    const first = agent.sent('INPUT')[0] as { images?: unknown }
+    const first = agent.sent('INPUT')[0] as { images?: unknown; files?: unknown }
     expect(first.images, 'a plain message now carries an empty images field').toBeUndefined()
+    expect(first.files, 'a plain message now carries an empty files field').toBeUndefined()
   })
 })

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import type { FileAttachment } from '@/components/chat/types'
 // The transcript itself is NOT here: its single source of truth is the SDK's
 // per-session store (co:agent:{address}:session:{sessionId}). This store only
 // indexes conversations for the sidebar.
@@ -32,6 +33,10 @@ interface ChatState {
   // to be dropped here, silently, after the reader had already seen the
   // thumbnail sitting in the composer.
   pendingImages: string[] | null
+  // And files. #106 carried images across this navigation and stopped there,
+  // leaving the third argument of onSend(content, images, files) still on the
+  // floor — the same drop, one parameter over.
+  pendingFiles: FileAttachment[] | null
   _hasHydrated: boolean
 }
 
@@ -45,8 +50,8 @@ interface ChatActions {
   setApiKey: (apiKey: string) => void
   setUserProfile: (profile: UserProfile | null) => void
   clearActive: () => void
-  setPendingMessage: (message: string | null, images?: string[]) => void
-  consumePendingMessage: () => { message: string | null; images: string[] | null }
+  setPendingMessage: (message: string | null, images?: string[], files?: FileAttachment[]) => void
+  consumePendingMessage: () => { message: string | null; images: string[] | null; files: FileAttachment[] | null }
 }
 
 type ChatStore = ChatState & ChatActions
@@ -62,6 +67,7 @@ export const useChatStore = create<ChatStore>()(
       userProfile: null,
       pendingMessage: null,
       pendingImages: null,
+      pendingFiles: null,
       _hasHydrated: false,
 
       createConversation: (sessionId, agentAddress) => {
@@ -146,15 +152,20 @@ export const useChatStore = create<ChatStore>()(
         set({ activeSessionId: null })
       },
 
-      setPendingMessage: (message, images) => {
-        set({ pendingMessage: message, pendingImages: images?.length ? images : null })
+      setPendingMessage: (message, images, files) => {
+        set({
+          pendingMessage: message,
+          pendingImages: images?.length ? images : null,
+          pendingFiles: files?.length ? files : null,
+        })
       },
 
       consumePendingMessage: () => {
         const message = get().pendingMessage
         const images = get().pendingImages
-        set({ pendingMessage: null, pendingImages: null })
-        return { message, images }
+        const files = get().pendingFiles
+        set({ pendingMessage: null, pendingImages: null, pendingFiles: null })
+        return { message, images, files }
       },
     }),
     {


### PR DESCRIPTION
Finishes #106, which I only half-fixed.

## The half I missed

`ChatInput` calls `onSend(content, images, files)` — three arguments. #106 taught the landing page's handler to accept the second and carry it across the navigation, and stopped there. The signature was still:

```js
const handleSend = useCallback((content: string, images?: string[]) => {
```

So attaching a **file** on the landing page dropped it, in exactly the way images used to:

```
landing  CHIP=1  KEYS=["type","input_id","prompt"]
session  CHIP=1  KEYS=["type","input_id","prompt","files"]
```

The chip renders, the reader sends "reconcile this" with `ledger.txt` attached, and the agent receives the sentence with nothing to reconcile. Same silent loss, one parameter over — and for a customer whose agents read ledgers, the file is the message.

## Fix

`pendingFiles` travels beside `pendingMessage` and `pendingImages`, and the landing handler takes all three.

Both payloads are now asserted **in the same spec**, deliberately: separate specs for images and files are what let these drift apart in the first place. The "a plain message carries neither field" guard covers both too, since attaching empty arrays to every send would be a quiet protocol change.

## Verification

Stashing only the three source files — keeping the new test — fails it:

```
1) a file attached on the landing page reaches the agent too
```

Restored, then `tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 133 passed**.

A first attempt at that check stashed the test along with the fix and reported "3 passed", which proves nothing. Worth stating because a green run from a stash that removed the assertion looks identical to a green run from working code.

## Why this happened

I fixed images last pass by following one reported symptom to its cause and stopping when that symptom went away, rather than reading the call site I was fixing against. `onSend(trimmed, images, files)` was three lines from the code I changed.
