### PR TITLE
Refuse an address that is not one, in Settings too

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { HiOutlinePlus, HiOutlineStatusOnline, HiOutlineStatusOffline } from 're
 import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
-import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
+import { useAgentInfo, shortAddress, agentInitial, isAgentAddress, ADDRESS_ERROR } from '@/hooks/use-agent-info'
 
 export default function Home() {
   const router = useRouter()
@@ -27,8 +27,8 @@ export default function Home() {
   const handleAddAgent = (address: string) => {
     const trimmed = address.trim()
     if (!trimmed) return
-    if (!/^0x[0-9a-fA-F]{64}$/.test(trimmed)) {
-      setAddressError('Enter a valid agent address (0x + 64 hex characters)')
+    if (!isAgentAddress(trimmed)) {
+      setAddressError(ADDRESS_ERROR)
       return
     }
     addAgent(trimmed)

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -21,7 +21,7 @@ import {
 import { ChatLayout } from '@/components/chat-layout'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
-import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { useAgentInfo, shortAddress, isAgentAddress, ADDRESS_ERROR } from '@/hooks/use-agent-info'
 import { TopUp } from '@/components/agent-address'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 
@@ -52,6 +52,7 @@ export default function SettingsPage() {
   const [importKeyInput, setImportKeyInput] = useState('')
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const [newAgentAddress, setNewAgentAddress] = useState('')
+  const [addAgentError, setAddAgentError] = useState('')
   const [showApiKey, setShowApiKey] = useState(false)
 
   const handleImportKey = useCallback(() => {
@@ -65,6 +66,14 @@ export default function SettingsPage() {
     e.preventDefault()
     const trimmed = newAgentAddress.trim()
     if (!trimmed) return
+    // The root picker has always checked this; Settings added whatever was typed,
+    // so a truncated paste became a permanent entry that shows as offline forever
+    // and navigates to a route that cannot resolve.
+    if (!isAgentAddress(trimmed)) {
+      setAddAgentError(ADDRESS_ERROR)
+      return
+    }
+    setAddAgentError('')
     addAgent(trimmed)
     setNewAgentAddress('')
   }, [newAgentAddress, addAgent])
@@ -366,7 +375,7 @@ export default function SettingsPage() {
                 <input
                   type="text"
                   value={newAgentAddress}
-                  onChange={(e) => setNewAgentAddress(e.target.value)}
+                  onChange={(e) => { setNewAgentAddress(e.target.value); if (addAgentError) setAddAgentError('') }}
                   placeholder="Paste agent address (0x...)"
                   className="flex-1 px-4 py-2.5 rounded-xl bg-white border border-neutral-200 text-neutral-900 focus:border-neutral-400 focus:ring-2 focus:ring-neutral-200/50 outline-none font-mono text-xs transition-all placeholder:text-neutral-400"
                 />
@@ -378,6 +387,12 @@ export default function SettingsPage() {
                   Add
                 </button>
               </form>
+              {/* Validating silently would be no better than not validating: the
+                  reader pastes, presses Add, nothing appears, and nothing says
+                  why. */}
+              {addAgentError && (
+                <p role="alert" className="mt-2 text-xs text-red-600">{addAgentError}</p>
+              )}
             </div>
           </section>
         </main>

--- a/e2e/add-agent.spec.ts
+++ b/e2e/add-agent.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Adding an agent by pasting its address.
+ *
+ * The root picker checks the address is `0x` plus 64 hex characters and says so
+ * when it is not. Settings ran `addAgent(trimmed)` on whatever was typed, with
+ * no check and no message — so a truncated paste, an email, or a sentence became
+ * a permanent entry in the agent list, showing as offline forever and navigating
+ * to a route that cannot resolve.
+ *
+ * Pasting an address out of an email is how these get added, and a paste that
+ * clipped the last few characters looks exactly like one that did not.
+ */
+
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** The agents the store has persisted — what the sidebar and pickers list. */
+function storedAgents(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('oo-chat-storage')
+    return raw ? (JSON.parse(raw).state?.agents ?? []) : []
+  })
+}
+
+/** Settings, with one agent already known. */
+async function settings(page: import('@playwright/test').Page) {
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+  await page.goto('/settings')
+  await expect(page.getByPlaceholder(/paste agent address/i)).toBeVisible({ timeout: 20_000 })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  for (const [label, value] of [
+    ['a sentence', 'please add my agent'],
+    ['a truncated paste', '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6'],
+    ['an email', 'ops@example.com'],
+  ] as const) {
+    test(`settings refuses ${label}`, async ({ page, shot }) => {
+      await settings(page)
+      const before = await storedAgents(page)
+
+      await page.getByPlaceholder(/paste agent address/i).fill(value)
+      await page.keyboard.press('Enter')
+      await page.waitForTimeout(1500)
+
+      expect(await storedAgents(page), `"${value}" became an agent`).toEqual(before)
+      await expect(
+        pane(page).getByText(/valid agent address/i),
+        'refused it silently — the reader is left thinking it worked',
+      ).toBeVisible()
+
+      // Scrolled into view before the shot: the add form sits at the bottom of a
+      // long page, so a message rendered below it is only useful if the reader is
+      // actually looking there when they press Add.
+      await pane(page).getByText(/valid agent address/i).scrollIntoViewIfNeeded()
+      await expect(pane(page).getByText(/valid agent address/i)).toBeInViewport()
+
+      await shot('refused')
+    })
+  }
+
+  test('settings still accepts a real address', async ({ page, shot }) => {
+    await settings(page)
+    const other = '0x' + 'a'.repeat(64)
+
+    await page.getByPlaceholder(/paste agent address/i).fill(other)
+    await page.keyboard.press('Enter')
+
+    await expect.poll(() => storedAgents(page), { timeout: 10_000 }).toContain(other)
+    // And the complaint clears once the input is good.
+    await expect(pane(page).getByText(/valid agent address/i)).toHaveCount(0)
+
+    await shot('added')
+  })
+
+  test('the root picker still refuses junk', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto('/')
+
+    // The check that already existed. Sharing it must not lose it.
+    const add = page.getByRole('button', { name: /add.*agent/i }).first()
+    if (await add.count()) await add.click()
+    const field = page.getByPlaceholder(/0x/i).first()
+    await expect(field).toBeVisible({ timeout: 15_000 })
+    await field.fill('not-an-address')
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByText(/valid agent address/i)).toBeVisible()
+    expect(await storedAgents(page)).not.toContain('not-an-address')
+  })
+})

--- a/hooks/use-agent-info.ts
+++ b/hooks/use-agent-info.ts
@@ -102,3 +102,16 @@ export function agentInitial(label: string, address: string): string {
   const alpha = address.slice(2).match(/[a-f]/i)
   return (alpha ? alpha[0] : address.slice(2, 3)).toUpperCase()
 }
+
+/** An agent address is `0x` followed by 64 hex characters — a public key.
+ *
+ *  One definition because there were two: the root picker checked this and
+ *  Settings did not, so the same paste was refused in one place and became a
+ *  permanent agent in the other. A paste that clipped the last few characters
+ *  looks exactly like one that did not, which is the case this catches. */
+export function isAgentAddress(value: string) {
+  return /^0x[0-9a-fA-F]{64}$/.test(value)
+}
+
+/** Shown when it is not. Shared so both surfaces refuse in the same words. */
+export const ADDRESS_ERROR = 'Enter a valid agent address (0x + 64 hex characters)'


### PR DESCRIPTION
Priority 3 — Settings.

## The finding

The root picker checks a pasted address is `0x` plus 64 hex characters and says so when it is not. **Settings ran `addAgent(trimmed)` on whatever was typed**, with no check and no message:

```
AGENTS  ["0xe2e7e57a…3e6f9a", "please add my agent"]
ERROR_SHOWN  0
```

`"please add my agent"` is now a permanent entry in the agent list. It shows in the sidebar and in Settings forever, reports as offline, and navigating to it produces a route that cannot resolve. Nothing told the reader it went wrong.

The case that actually happens is the second one in the spec: a paste that clipped the last few characters. It looks exactly like a paste that did not, and pasting an address out of an email is how these get added.

## Fix

One definition of what an agent address is, shared by both surfaces, refusing in the same words. Settings renders the message under the form and clears it as soon as the reader starts correcting the input.

Validating silently would have been no better than not validating — the reader pastes, presses Add, and nothing happens with no explanation. The message is asserted to be **in the viewport**, not merely present: the add form sits at the bottom of a long Settings page, so a complaint rendered below it is only useful if the reader is looking there.

## Verification

| | before | after |
|---|---|---|
| refuses a sentence | FAILED, became an agent | ok |
| refuses a truncated paste | FAILED, became an agent | ok |
| refuses an email | FAILED, became an agent | ok |
| still accepts a real address | ok, guards the fix | ok |
| the root picker still refuses junk | ok, guards the shared helper | ok |

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 138 passed**. Screenshots checked at 375px: the refusal renders in red directly under the form with the bad value still in the field to correct, and a valid address adds cleanly.

## Also checked, and clean

Before this I checked something I had introduced: #106 and #107 added `pendingImages` and `pendingFiles` to a store whose `pendingMessage` is deliberately excluded from persistence. If mine were persisted, a stale attachment could resurface on a later send.

They are not. `partialize` is an allowlist naming five fields, so anything new is excluded by default. No bug — recording it because "I added a field next to one with a persistence rule" is exactly the kind of thing worth checking rather than assuming.
