### PR TITLE
Do not adopt an address the URL made up

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -46,7 +46,7 @@ import type { UI, ApprovalMode } from '@/components/chat/types'
 import { dedupeUI } from '@/components/chat/dedupe-ui'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
-import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { useAgentInfo, shortAddress, isAgentAddress } from '@/hooks/use-agent-info'
 import { OnboardGate } from '@/components/chat/onboard-gate'
 import { acceptsAttachments } from '@/components/chat/skill-offers'
 import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
@@ -88,7 +88,12 @@ export default function ChatSessionPage() {
   // Keyed on the address so navigating between agents still adds each one.
   const addedFor = useRef<string | null>(null)
   useEffect(() => {
-    if (!address || addedFor.current === address) return
+    // A malformed address must not be adopted. The URL is how a broken address
+    // actually arrives — a shared link that clipped its last characters — and the
+    // agent list it lands in is read by the sidebar, Settings and the picker,
+    // where it is indistinguishable from a real agent that happens to be offline.
+    // #108 taught the two typed entry points to refuse these; this is the third.
+    if (!address || !isAgentAddress(address) || addedFor.current === address) return
     addedFor.current = address
     if (!agents.includes(address)) addAgent(address)
     // `agents` is deliberately not a dependency: reacting to it is the bug.

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -10,7 +10,7 @@ import { DashboardPane } from '@/components/dashboard/dashboard-pane'
 import type { ApprovalMode } from '@/components/chat/types'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
-import { useAgentInfo, shortAddress, agentInitial } from '@/hooks/use-agent-info'
+import { useAgentInfo, shortAddress, agentInitial, isAgentAddress } from '@/hooks/use-agent-info'
 import { QrShare } from '@/components/qr-share'
 import { bestOffers, UNIVERSAL_OPENER, acceptsAttachments } from '@/components/chat/skill-offers'
 import type { FileAttachment } from '@/components/chat/types'
@@ -55,7 +55,12 @@ export default function AgentLandingPage() {
   // Keyed on the address so navigating between agents still adds each one.
   const addedFor = useRef<string | null>(null)
   useEffect(() => {
-    if (!address || addedFor.current === address) return
+    // A malformed address must not be adopted. The URL is how a broken address
+    // actually arrives — a shared link that clipped its last characters — and the
+    // agent list it lands in is read by the sidebar, Settings and the picker,
+    // where it is indistinguishable from a real agent that happens to be offline.
+    // #108 taught the two typed entry points to refuse these; this is the third.
+    if (!address || !isAgentAddress(address) || addedFor.current === address) return
     addedFor.current = address
     if (!agents.includes(address)) addAgent(address)
     // `agents` is deliberately not a dependency: reacting to it is the bug.
@@ -412,6 +417,24 @@ export default function AgentLandingPage() {
         )}
       </div>
   )
+
+  // Before anything else: a link whose address is not an address. Rendering the
+  // agent shell for one shows a name, a balance and a Top up button for something
+  // that does not exist — and "offline" would be the wrong story, since the
+  // problem is the link, not the agent. Nothing here is actionable except going
+  // back to whoever sent it.
+  if (!isAgentAddress(address)) {
+    return (
+      <main className="flex h-dvh flex-col items-center justify-center gap-2 px-6 text-center">
+        <p className="text-sm font-medium text-neutral-900">That is not a valid agent link</p>
+        <p className="max-w-xs text-sm text-neutral-500">
+          An agent address is <span className="font-mono">0x</span> followed by 64 characters. This
+          one is incomplete — ask whoever shared it for the full link.
+        </p>
+        <p className="mt-1 max-w-full truncate font-mono text-[11px] text-neutral-400">{address}</p>
+      </main>
+    )
+  }
 
   return (
     <>

--- a/e2e/bad-address.spec.ts
+++ b/e2e/bad-address.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * A link with a broken address in it.
+ *
+ * #108 taught Settings and the root picker to refuse an address that is not one.
+ * The URL was never checked, and the URL is how a bad address actually arrives:
+ * a shared link that clipped its last characters, or one mangled by a mail
+ * client. Visiting it rendered a complete agent page — name, balance, Top up,
+ * openers — and the auto-add effect quietly wrote the broken string into the
+ * stored agent list, where it stays.
+ *
+ * So the validation added in #108 was bypassable by the one route most likely to
+ * carry the mistake.
+ */
+
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+const TRUNCATED = '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6'
+
+function storedAgents(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('oo-chat-storage')
+    return raw ? (JSON.parse(raw).state?.agents ?? []) : []
+  })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  for (const [label, address] of [
+    ['a truncated address', TRUNCATED],
+    ['nonsense', 'not-an-address'],
+  ] as const) {
+    test(`${label} in the URL is not silently adopted`, async ({ page }) => {
+      await mockAgent(page)
+      await page.goto(`/${address}`)
+      await page.waitForTimeout(3000)
+
+      // The list is what the sidebar, Settings and the picker all read. A broken
+      // string in there outlives the visit and cannot be told apart from a real
+      // agent that happens to be offline.
+      expect(await storedAgents(page), 'a broken address was written to the agent list').not.toContain(address)
+    })
+
+    test(`${label} in the URL says the link is wrong`, async ({ page, shot }) => {
+      await mockAgent(page)
+      await page.goto(`/${address}`)
+
+      // Not "offline" — the address is malformed, which is a different problem
+      // with a different fix, and only one of them is the reader's to act on.
+      await expect(
+        pane(page).getByText(/not a valid agent/i),
+        'a malformed link renders as a working agent page',
+      ).toBeVisible({ timeout: 20_000 })
+
+      await expect(pane(page).getByPlaceholder(/message/i)).toHaveCount(0)
+
+      await shot(label.replace(/\s+/g, '-'))
+    })
+  }
+
+  test('a real address is unaffected', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+
+    // The guard has to be exact: this is the whole product.
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(pane(page).getByPlaceholder(/message/i)).toBeVisible()
+    await expect.poll(() => storedAgents(page), { timeout: 10_000 }).toContain(AGENT_ADDRESS)
+  })
+})


### PR DESCRIPTION
Priority 1. Finishes what #108 started, on the route that actually carries the mistake.

## The finding

#108 taught Settings and the root picker to refuse an address that is not one. **The URL was never checked** — and the URL is how a broken address actually arrives: a shared link that clipped its last characters, or one mangled by a mail client.

Visiting `/not-an-address` rendered a complete agent page — name, `online`, `$4.20`, a Top up button, opener chips — and then:

```
AGENTS = ["not-an-address"]
```

The auto-add effect wrote the broken string into the stored agent list, which the sidebar, Settings and the picker all read, where it is indistinguishable from a real agent that happens to be offline and it stays forever.

So the validation added one pass ago was bypassable by the single most likely route. Typing junk was refused; being sent junk was adopted.

## Fix

Two parts, both from recognising the address is not one:

- **Do not adopt it.** The auto-add effect on both agent routes now checks first.
- **Say the link is wrong.** Not "offline" — the agent is not the problem, the link is, and only one of those is the reader's to act on. The page says an address is `0x` plus 64 characters, that this one is incomplete, and to ask whoever shared it for the full link. It shows the string it was given, so they can see where it was cut.

No composer is offered, because there is nothing to send a message to.

## Verification

| | before | after |
|---|---|---|
| a truncated address is not adopted | FAILED, written to the agent list | ok |
| nonsense is not adopted | FAILED | ok |
| a truncated address says the link is wrong | FAILED, rendered a working agent page | ok |
| nonsense says the link is wrong | FAILED | ok |
| a real address is unaffected | ok, guards the fix | ok |

That last one matters most: the guard has to be exact, because it stands in front of the whole product.

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 143 passed**. Screenshot checked at 375px.

## Left alone deliberately

The mobile header still shows the truncated string with a status dot, above a body that says the link is invalid. It comes from `ChatLayout`, the shared chrome every agent page and the sidebar drawer mount. Gating that is not a one-line change and would alter chrome used by every route in the app, which is not something to do at the end of a pass on the strength of a cosmetic inconsistency. The message itself is unambiguous; the header is a bad frame, not a broken flow.
