### PR TITLE
Apply the address rule to every route that takes one

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -48,6 +48,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, isAgentAddress } from '@/hooks/use-agent-info'
 import { OnboardGate } from '@/components/chat/onboard-gate'
+import { InvalidAddress } from '@/components/invalid-address'
 import { acceptsAttachments } from '@/components/chat/skill-offers'
 import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
 
@@ -345,6 +346,11 @@ export default function ChatSessionPage() {
         />
       </div>
   )
+
+  // #109 guarded adoption on this route but left it rendering a working session:
+  // a forwarded session link with a clipped address showed "Connected — send a
+  // message" and a composer, and the reader typed into nothing.
+  if (!isAgentAddress(address)) return <InvalidAddress address={address} />
 
   return (
     <>

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { HiChevronDown, HiChevronUp } from 'react-icons/hi2'
 import { ChatInput, ModeStatusBar, useAgentSDK } from '@/components/chat'
 import { OnboardGate } from '@/components/chat/onboard-gate'
+import { InvalidAddress } from '@/components/invalid-address'
 import { WorkspaceShell } from '@/components/dashboard/workspace-shell'
 import { DashboardPane } from '@/components/dashboard/dashboard-pane'
 import type { ApprovalMode } from '@/components/chat/types'
@@ -418,23 +419,8 @@ export default function AgentLandingPage() {
       </div>
   )
 
-  // Before anything else: a link whose address is not an address. Rendering the
-  // agent shell for one shows a name, a balance and a Top up button for something
-  // that does not exist — and "offline" would be the wrong story, since the
-  // problem is the link, not the agent. Nothing here is actionable except going
-  // back to whoever sent it.
-  if (!isAgentAddress(address)) {
-    return (
-      <main className="flex h-dvh flex-col items-center justify-center gap-2 px-6 text-center">
-        <p className="text-sm font-medium text-neutral-900">That is not a valid agent link</p>
-        <p className="max-w-xs text-sm text-neutral-500">
-          An agent address is <span className="font-mono">0x</span> followed by 64 characters. This
-          one is incomplete — ask whoever shared it for the full link.
-        </p>
-        <p className="mt-1 max-w-full truncate font-mono text-[11px] text-neutral-400">{address}</p>
-      </main>
-    )
-  }
+  // Before anything else: a link whose address is not an address.
+  if (!isAgentAddress(address)) return <InvalidAddress address={address} />
 
   return (
     <>

--- a/components/chat-layout.tsx
+++ b/components/chat-layout.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation'
 import { HiOutlineMenu } from 'react-icons/hi'
 import { Sidebar } from './sidebar'
 import Link from 'next/link'
-import { useAgentInfo, shortAddress } from '@/hooks/use-agent-info'
+import { useAgentInfo, shortAddress, isAgentAddress } from '@/hooks/use-agent-info'
 import { cn } from './chat/utils'
 
 interface ChatLayoutProps {
@@ -15,7 +15,11 @@ interface ChatLayoutProps {
 export function ChatLayout({ children }: ChatLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const params = useParams()
-  const address = typeof params?.address === 'string' ? params.address : null
+  // A malformed address is not an agent, so the header must not claim one: an
+  // online dot and a name above a page that says the link is invalid contradict
+  // each other, and the reader has no way to tell which half to believe.
+  const raw = typeof params?.address === 'string' ? params.address : null
+  const address = raw && isAgentAddress(raw) ? raw : null
   const agentInfoMap = useAgentInfo(address ? [address] : [])
   const agentInfo = address ? agentInfoMap[address] : undefined
 

--- a/components/invalid-address.tsx
+++ b/components/invalid-address.tsx
@@ -1,0 +1,26 @@
+/**
+ * @purpose Stand in for an agent page when the address in the URL is not an address.
+ * @llm-note Rendering the agent shell for one shows a name, a balance and a Top up
+ *   button for something that does not exist, and the auto-add effect used to write
+ *   the broken string into the stored agent list (#109).
+ *
+ *   "Offline" would be the wrong story: the agent is not the problem, the link is,
+ *   and only one of those is the reader's to act on. Nothing here is actionable
+ *   except going back to whoever sent it, so that is what it says.
+ *
+ *   One component because there are two routes under [address] and #109 fixed only
+ *   the first — a forwarded *session* link with a clipped address still rendered a
+ *   working composer. Shared so a third route cannot disagree with the other two.
+ */
+export function InvalidAddress({ address }: { address: string }) {
+  return (
+    <main className="flex h-dvh flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-sm font-medium text-neutral-900">That is not a valid agent link</p>
+      <p className="max-w-xs text-sm text-neutral-500">
+        An agent address is <span className="font-mono">0x</span> followed by 64 characters. This
+        one is incomplete — ask whoever shared it for the full link.
+      </p>
+      <p className="mt-1 max-w-full truncate font-mono text-[11px] text-neutral-400">{address}</p>
+    </main>
+  )
+}

--- a/e2e/bad-address.spec.ts
+++ b/e2e/bad-address.spec.ts
@@ -24,6 +24,30 @@ function storedAgents(page: import('@playwright/test').Page) {
   })
 }
 
+/** Every route that takes an address, and a URL that exercises it.
+ *
+ *  Enumerated from the filesystem rather than listed by hand: #109 fixed
+ *  /[address] and left /[address]/[sessionId] rendering a working composer for
+ *  the same broken link, because the rule was applied to the route I happened to
+ *  be looking at. A new route under [address] now fails this until it handles a
+ *  malformed address too. */
+const ADDRESS_ROUTES: [string, (a: string) => string][] = [
+  ['/[address]', a => `/${a}`],
+  ['/[address]/[sessionId]', a => `/${a}/some-session`],
+]
+
+test('every route under [address] is covered by this spec', async () => {
+  const { execSync } = await import('node:child_process')
+  const found = execSync("find app -path '*[[]address[]]*' -name 'page.tsx' | sort", { encoding: 'utf8' })
+    .split('\n').filter(Boolean)
+    .map(f => f.replace(/^app/, '').replace(/\/page\.tsx$/, ''))
+
+  expect(
+    found.sort(),
+    'a route under [address] is not exercised with a malformed address — add it to ADDRESS_ROUTES',
+  ).toEqual(ADDRESS_ROUTES.map(([r]) => r).sort())
+})
+
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
@@ -42,9 +66,10 @@ test.describe('phone', () => {
       expect(await storedAgents(page), 'a broken address was written to the agent list').not.toContain(address)
     })
 
-    test(`${label} in the URL says the link is wrong`, async ({ page, shot }) => {
+    for (const [route, url] of ADDRESS_ROUTES) {
+    test(`${label} at ${route} says the link is wrong`, async ({ page, shot }) => {
       await mockAgent(page)
-      await page.goto(`/${address}`)
+      await page.goto(url(address))
 
       // Not "offline" — the address is malformed, which is a different problem
       // with a different fix, and only one of them is the reader's to act on.
@@ -55,8 +80,9 @@ test.describe('phone', () => {
 
       await expect(pane(page).getByPlaceholder(/message/i)).toHaveCount(0)
 
-      await shot(label.replace(/\s+/g, '-'))
+      await shot(`${label.replace(/\s+/g, '-')}${route.includes('sessionId') ? '-session' : ''}`)
     })
+    }
   }
 
   test('a real address is unaffected', async ({ page }) => {


### PR DESCRIPTION
Last pass I flagged a habit: four passes running, each one finished the previous one because I fixed the symptom I had measured rather than the rule I was enforcing. This pass applies the rule everywhere and leaves a guard so the next route cannot skip it.

## What #109 left

#109 guarded adoption on both agent routes but only rendered the "bad link" page on one. So a forwarded **session** link with a clipped address still rendered a working session:

```
BODY          Scriptbot · Connected — send a message · What can you do? · …
COMPOSER      1
SAYS_INVALID  false
```

The reader types into nothing. Same bug, one route over — exactly the shape I said I would stop shipping.

## The rule, applied

- **One component.** `InvalidAddress` replaces the JSX #109 inlined into the landing page, so a third route cannot disagree with the other two about what a bad link says.
- **Both routes render it.** `/[address]` and `/[address]/[sessionId]`.
- **The header stops claiming an agent.** `ChatLayout` read `params.address` unconditionally, so an online dot and a name sat above a page saying the link was invalid — two halves of the screen contradicting each other with no way to tell which to believe. It now falls back to the app identity.

## The guard against the next one

The spec enumerates routes **from the filesystem** and fails if one is not exercised with a malformed address:

```
a route under [address] is not exercised with a malformed address — add it to ADDRESS_ROUTES
```

Verified by adding a throwaway `app/[address]/reports/page.tsx`: the test fails until that route is covered. This is the part meant to break the habit — a rule that only exists in my attention gets applied to whatever I am looking at.

## A wrong conclusion I caught

The session screenshot showed the header naming **Scriptbot**, a real previously-visited agent, and I started writing that up as "worse than #109". It is a mock artifact: `mockAgent` answers for *every* address, so the lookup succeeded. Against the real relay the lookup returns nothing and the header would show the shortened raw string.

The header fix is still right — it should not claim an agent for an address that is not one, in either environment — but the reason I nearly gave for it was false.

## Verification

| | before | after |
|---|---|---|
| bad address at `/[address]` | ok, from #109 | ok |
| bad address at `/[address]/[sessionId]` | FAILED, working composer | ok |
| neither is adopted into the agent list | ok, from #109 | ok |
| a real address is unaffected | ok, guards the fix | ok |
| every `[address]` route is exercised | new | ok |

Both new guards checked by breaking them: stashing the session-page change fails the session case; adding an uncovered route fails the enumeration.

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 146 passed**. Screenshots checked at 375px on both routes.
