### PR TITLE
Cover the balance warning tracking a balance that changes

### DIFF
--- a/e2e/balance.spec.ts
+++ b/e2e/balance.spec.ts
@@ -11,7 +11,7 @@
  * so the one number that means "this is about to stop" looked like chrome.
  */
 
-import { test, expect } from './fixtures'
+import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
 /** Below this the agent is one or two turns from refusing. */
@@ -100,5 +100,53 @@ test.describe('phone', () => {
     expect(overflow, 'the warning pushes the page sideways').toBeLessThanOrEqual(0)
 
     await shot('warning')
+  })
+})
+
+test.describe('a balance that changes while you watch', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  /** Reply, then republish the profile as credit is spent, then after a top-up. */
+  async function drain(page: import('@playwright/test').Page) {
+    await mockAgent(page, 'balance-drains')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('Working on it.')).toBeVisible({ timeout: 20_000 })
+  }
+
+  test('the warning arrives when the credit does not last the run', async ({ page, shot }) => {
+    await drain(page)
+
+    // The number shown on arrival is already stale by the time it matters. #85
+    // put this warning in front of the composer so a run cannot quietly stop for
+    // want of credit — which only works if it tracks the balance rather than
+    // reading it once at mount.
+    await expect(pane(page).getByText(/running low/i)).toHaveCount(0)
+    await expect(
+      pane(page).getByText(/running low — \$0\.35 left/i),
+      'the balance fell below the threshold and nothing said so',
+    ).toBeVisible({ timeout: 15_000 })
+
+    await shot('drained')
+  })
+
+  test('and it clears once the credit is back', async ({ page }) => {
+    await drain(page)
+    await expect(pane(page).getByText(/running low/i)).toBeVisible({ timeout: 15_000 })
+
+    // A warning that outlives what it warns about teaches the reader to ignore
+    // the next one.
+    await expect(pane(page).getByText(/running low/i)).toHaveCount(0, { timeout: 15_000 })
+  })
+
+  test('the live figure outranks the one fetched at page load', async ({ page }) => {
+    await drain(page)
+
+    // The directory still says $4.20 — it was fetched over HTTP before any of
+    // this happened. Reading that in preference to the socket's profile would
+    // show a comfortable balance while the agent runs dry, and it is the kind of
+    // swap a refactor makes for a plausible-sounding reason.
+    await expect(pane(page).getByText(/\$0\.35 left/)).toBeVisible({ timeout: 15_000 })
+    await expect(pane(page).getByText(/\$4\.20 left/)).toHaveCount(0)
   })
 })

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -119,6 +119,18 @@ export async function mockAgent(
       }
 
       if (msg.type !== 'INPUT') return
+
+      // Credit is spent while the run goes on. The agent republishes its profile
+      // with the new balance, which is the only way the reader learns before it
+      // runs out — the number they saw on arrival is already stale.
+      if (scenario === 'balance-drains') {
+        send(ws, { type: 'thinking', id: 't1', status: 'done' })
+        send(ws, { type: 'OUTPUT', result: 'Working on it.', session: { session_id: 'e2e-session' } })
+        setTimeout(() => send(ws, { type: 'AGENT_PROFILE', ...profile, balance_usd: 0.35 }), 1200)
+        // …and then the reader tops up, which the agent republishes in turn.
+        setTimeout(() => send(ws, { type: 'AGENT_PROFILE', ...profile, balance_usd: 20 }), 3200)
+        return
+      }
 
       // An agent that starts open and gates partway through. There is a
       // conversation behind this one, so it must keep the in-transcript card


### PR DESCRIPTION
Priority 2 — is the balance flow correct and complete?

#85 put a warning in front of the composer so a run cannot quietly stop for want of credit. It was only ever tested with a balance that was already low **on arrival**. Credit is spent during the run, so the number shown when the page loaded is stale by the time it matters — and none of the mechanism that keeps it current had a test.

## Result: it works, in both directions

The agent republishes its profile as credit is spent, and:

```
T0     lowNotice=0   $4.20 from the directory
T2000  lowNotice=1   "Running low — $0.35 left."
T5000  lowNotice=0   after a top-up, cleared
```

The warning arrives when the balance crosses the threshold mid-run, and clears once the credit is back. A warning that outlives what it warns about teaches the reader to ignore the next one, so both halves matter.

Reporting this as a measured result rather than an assumption, and leaving the guard.

## Why it is worth pinning

The chain is: agent re-sends `AGENT_PROFILE` → SDK updates `profile` → the page prefers `profile.balance_usd` over the HTTP-fetched `agentInfoMap` value. That last precedence is the fragile link, and swapping it is exactly the change someone makes for a plausible-sounding reason — the cached map is right there, and reading it looks like a simplification.

So one test states the precedence directly: the directory still says `$4.20` throughout, and the notice must show `$0.35`.

Checked by making that swap:

```
const balanceUsd = agentInfoMap[address]?.balance_usd ?? profile?.balance_usd
```

fails with *"the balance fell below the threshold and nothing said so"* — the agent runs dry while the screen shows a comfortable balance. Restored.

## Verification

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 149 passed**. `git status` confirms test files only. Screenshot checked at 375px: the warning sits above the composer mid-conversation with the live figure.

A `balance-drains` scenario now republishes the profile at $0.35 and then at $20, which is what made any of this observable.
