### PR TITLE
Show the agent's state above both panes, not inside one

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -336,13 +336,7 @@ export default function ChatSessionPage() {
             profile?.accepted_inputs ?? agentInfoMap[address]?.accepted_inputs
           )}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
-          notice={
-            agentInfoMap[address]?.online === false
-              ? <OfflineNotice />
-              : typeof balanceUsd === 'number' && isLowBalance(balanceUsd)
-                ? <LowBalanceNotice address={address} balanceUsd={balanceUsd} />
-                : null
-          }
+
         />
       </div>
   )
@@ -358,6 +352,16 @@ export default function ChatSessionPage() {
       chat={chatPane}
       hasDashboard={dashboardHtml !== null}
       chatAwaitsReader={awaitsReader}
+      agentNotice={
+        // Offline outranks a low balance: credit is irrelevant to an agent that
+        // cannot be reached, and two stacked notices read as noise rather than
+        // one thing to act on.
+        agentInfoMap[address]?.online === false
+          ? <OfflineNotice />
+          : typeof balanceUsd === 'number' && isLowBalance(balanceUsd)
+            ? <LowBalanceNotice address={address} balanceUsd={balanceUsd} />
+            : null
+      }
       dashboard={
         <DashboardPane
           html={dashboardHtml}

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -30,7 +30,6 @@ export function Chat({
   onPlanReviewResponse,
   className,
   statusBar,
-  notice,
   mode,
   ulwTurnsRemaining,
   ulwSetupActive,
@@ -230,8 +229,6 @@ export function Chat({
       )}
       {/* Status bar between messages and input */}
       <StatusBar thinkingItems={thinkingItems} sessionState={sessionState} />
-
-      {notice}
 
       {renderBottom()}
 

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -325,10 +325,6 @@ export interface ChatProps {
   onPlanReviewResponse?: (message: string) => void
   /** Custom status bar inside input (e.g., mode indicator) */
   statusBar?: React.ReactNode
-  /** Rendered directly above the composer. For the one thing that must still be
-   *  on screen when the reader scrolls back down to type — today, a balance that
-   *  is about to run out. */
-  notice?: React.ReactNode
   /** False only when the agent has declared it takes neither images nor files. */
   acceptsAttachments?: boolean
   /** ULW state for 3-state bottom panel */

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -26,6 +26,12 @@ interface WorkspaceShellProps {
   defaultMobileView?: 'chat' | 'home'
   /** True while the chat is holding a prompt the run cannot continue without. */
   chatAwaitsReader?: boolean
+  /** A standing fact about the agent — offline, nearly out of credit. Rendered
+   *  above both panes because it is true of the agent rather than of the
+   *  conversation, and on a phone the panes are exclusive: a notice living
+   *  inside the chat is invisible to a reader on Home, who is exactly the person
+   *  watching a dashboard that has quietly stopped updating. */
+  agentNotice?: React.ReactNode
   /** False until the agent's dashboard actually arrives; hides the pane until then. */
   hasDashboard?: boolean
 }
@@ -36,6 +42,7 @@ export function WorkspaceShell({
   defaultMobileView = 'chat',
   hasDashboard = false,
   chatAwaitsReader = false,
+  agentNotice,
 }: WorkspaceShellProps) {
   // Null until the reader picks a side; their choice then outranks the default forever.
   const [chosenView, chooseView] = useState<'chat' | 'home' | null>(null)
@@ -65,6 +72,8 @@ export function WorkspaceShell({
       {hasDashboard && slot && createPortal(
         <ViewSwitch view={mobileView} onChange={chooseView} attention={chatAwaitsReader ? 'chat' : null} />, slot,
       )}
+
+      {agentNotice}
 
       <div className="flex-1 flex min-h-0">
         {/* Chat pane */}

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -11,7 +11,7 @@
  * collapsing Home must not take the chat with it.
  */
 
-import { test, expect } from './fixtures'
+import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 
 test.describe('phone', () => {
@@ -158,5 +158,67 @@ test.describe('a run that stops while the reader is on Home', () => {
 
     // The marker earns its meaning by being absent the rest of the time.
     await expect(page.getByRole('tab', { name: /Chat/ }).locator('[data-attention]')).toHaveCount(0)
+  })
+})
+
+test.describe('what the agent needs the reader to know, from either pane', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  /** Settle in a conversation, switch to Home, and let the credit run down. */
+  async function watchingHome(page: import('@playwright/test').Page) {
+    await mockAgent(page, 'dashboard-drains')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('Working on it.')).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('tab', { name: 'Home' }).click()
+    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+  }
+
+  test('a balance running out is visible from Home', async ({ page, shot }) => {
+    await watchingHome(page)
+
+    // #88 gave prompts a marker on the other tab, which is right for something
+    // you must answer. This is a standing fact about the agent, and the reader on
+    // Home is exactly the person watching a dashboard that is about to stop
+    // updating — a breadcrumb pointing at the other pane is not the answer.
+    await expect(
+      page.getByText(/running low/i),
+      'the credit ran out while the reader watched the dashboard, and nothing said so',
+    ).toBeVisible({ timeout: 15_000 })
+
+    await shot('home-warned')
+  })
+
+  test('and still visible from Chat', async ({ page }) => {
+    await watchingHome(page)
+    await expect(page.getByText(/running low/i)).toBeVisible({ timeout: 15_000 })
+
+    // Moving it above the panes must not take it away from where it already was.
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await expect(page.getByText(/running low/i)).toBeVisible()
+    await expect(pane(page).getByPlaceholder(/message/i)).toBeVisible()
+
+    // #85 put this next to the composer precisely so scrolling could not hide
+    // it. Above the panes it satisfies that differently — it is outside the
+    // scrolling box entirely — but the property has to still hold, so it is
+    // asserted rather than argued.
+    await page.mouse.move(187, 300)
+    for (let i = 0; i < 5; i++) await page.mouse.wheel(0, -120)
+    await expect(page.getByText(/running low/i)).toBeInViewport()
+  })
+
+  test('a healthy agent shows no notice on either pane', async ({ page }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    await expect(page.getByText(/running low|may not be delivered/i)).toHaveCount(0)
+    await page.getByRole('tab', { name: 'Home' }).click()
+    await expect(page.getByText(/running low|may not be delivered/i)).toHaveCount(0)
   })
 })

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -108,7 +108,7 @@ export async function mockAgent(
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
-        if (scenario === 'dashboard' || scenario === 'dashboard-approval') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
+        if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
 
         // The connection goes away after it was working: a tunnel, a handover
         // between wifi and cellular, the screen locking. Closed here rather than
@@ -123,7 +123,7 @@ export async function mockAgent(
       // Credit is spent while the run goes on. The agent republishes its profile
       // with the new balance, which is the only way the reader learns before it
       // runs out — the number they saw on arrival is already stale.
-      if (scenario === 'balance-drains') {
+      if (scenario === 'balance-drains' || scenario === 'dashboard-drains') {
         send(ws, { type: 'thinking', id: 't1', status: 'done' })
         send(ws, { type: 'OUTPUT', result: 'Working on it.', session: { session_id: 'e2e-session' } })
         setTimeout(() => send(ws, { type: 'AGENT_PROFILE', ...profile, balance_usd: 0.35 }), 1200)


### PR DESCRIPTION
Priority 4 — where one pane hides the other.

## The finding

#88 established the rule: anything the agent needs the reader to know must reach them whichever pane they are on. It solved that for **prompts**, with a marker on the tab you are not looking at.

The two notices added since — offline (#105) and low balance (#111) — went into the chat pane, which on a phone is `hidden` while Home is showing. So:

```
reader on Home, balance falls to $0.35
visible page: "Scriptbot   Home   Chat"
```

That is the whole screen. The dashboard, and nothing else. The credit runs out, the run stops, and the person watching the dashboard is the last to know — while the dashboard itself quietly stops updating for the same reason.

## The fix, and why not a marker

A marker on the other tab is right for a prompt: there is something over there to answer. These are standing facts about the **agent**, not about the conversation — "offline" and "nearly out of credit" are as true of the dashboard as of the chat, and a breadcrumb pointing at the other pane is not the answer to either.

So the notice moved above both panes, into `WorkspaceShell`. It is now visible from Home and from Chat, and on desktop it sits above both at once.

`Chat`'s `notice` prop had no producer left afterwards, so it is gone rather than left as a slot nothing fills — that is #83's lesson applied to my own leftovers.

## One property I had to re-check, not re-argue

#85 put this notice next to the composer **specifically** so scrolling could not hide it. Above the panes satisfies that differently — it is outside the scrolling box entirely — but "differently" is not "still", so the spec now scrolls the transcript and asserts the notice is still in the viewport.

## Verification

| | before | after |
|---|---|---|
| a balance running out is visible from Home | FAILED, nothing on screen | ok |
| still visible from Chat, and survives scrolling | ok, guards the move | ok |
| a healthy agent shows nothing on either pane | ok, guards the other way | ok |

Checked by putting the notice back inside the chat pane: fails with *"the credit ran out while the reader watched the dashboard, and nothing said so"*.

`tsc` clean, `lint` 0 findings, `vitest` 56 passed, **full Playwright suite 152 passed**. Screenshot checked at 375px — the warning sits under the header, above the Deploy board.

A `dashboard-drains` scenario combines a dashboard with a draining balance, which is what made the state reachable at all.
