### PR TITLE
Tell a reader on Home that the connection dropped

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -50,7 +50,7 @@ import { useAgentInfo, shortAddress, isAgentAddress } from '@/hooks/use-agent-in
 import { OnboardGate } from '@/components/chat/onboard-gate'
 import { InvalidAddress } from '@/components/invalid-address'
 import { acceptsAttachments } from '@/components/chat/skill-offers'
-import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
+import { LowBalanceNotice, isLowBalance, OfflineNotice, DisconnectedNotice } from '@/components/agent-address'
 
 export default function ChatSessionPage() {
   const params = useParams()
@@ -352,6 +352,9 @@ export default function ChatSessionPage() {
       chat={chatPane}
       hasDashboard={dashboardHtml !== null}
       chatAwaitsReader={awaitsReader}
+      hiddenChatNotice={
+        sessionState === 'disconnected' ? <DisconnectedNotice onReconnect={handleReconnect} /> : null
+      }
       agentNotice={
         // Offline outranks a low balance: credit is irrelevant to an agent that
         // cannot be reached, and two stacked notices read as noise rather than

--- a/components/agent-address.tsx
+++ b/components/agent-address.tsx
@@ -133,3 +133,25 @@ export function OfflineNotice() {
     </div>
   )
 }
+
+/** The connection to the agent is gone, said where a reader on Home can see it.
+ *
+ *  The composer's status bar already reports this — "disconnected · reconnect" —
+ *  so this exists only for the pane that cannot show that. A dashboard whose
+ *  socket has dropped stops updating and gives no sign of it, which looks
+ *  exactly like an agent with nothing to report. */
+export function DisconnectedNotice({ onReconnect }: { onReconnect?: () => void }) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-2 border-t border-neutral-200 bg-neutral-50 px-4 py-2 text-[11px] text-neutral-600">
+      <span>The connection to this agent dropped.</span>
+      {onReconnect && (
+        <button
+          onClick={onReconnect}
+          className="inline-flex min-h-6 items-center font-semibold underline underline-offset-2 hover:text-neutral-900"
+        >
+          Reconnect
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -32,6 +32,12 @@ interface WorkspaceShellProps {
    *  inside the chat is invisible to a reader on Home, who is exactly the person
    *  watching a dashboard that has quietly stopped updating. */
   agentNotice?: React.ReactNode
+  /** Shown only while the chat pane is hidden — for facts the chat already
+   *  reports in its own chrome, which a reader on Home therefore cannot see.
+   *  A dropped connection is the case: the composer's status bar says
+   *  "disconnected · reconnect", and repeating that above the panes for a reader
+   *  who can already read it would be noise. */
+  hiddenChatNotice?: React.ReactNode
   /** False until the agent's dashboard actually arrives; hides the pane until then. */
   hasDashboard?: boolean
 }
@@ -43,6 +49,7 @@ export function WorkspaceShell({
   hasDashboard = false,
   chatAwaitsReader = false,
   agentNotice,
+  hiddenChatNotice,
 }: WorkspaceShellProps) {
   // Null until the reader picks a side; their choice then outranks the default forever.
   const [chosenView, chooseView] = useState<'chat' | 'home' | null>(null)
@@ -74,6 +81,7 @@ export function WorkspaceShell({
       )}
 
       {agentNotice}
+      {hasDashboard && mobileView !== 'chat' && hiddenChatNotice}
 
       <div className="flex-1 flex min-h-0">
         {/* Chat pane */}

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -222,3 +222,66 @@ test.describe('what the agent needs the reader to know, from either pane', () =>
     await expect(page.getByText(/running low|may not be delivered/i)).toHaveCount(0)
   })
 })
+
+test.describe('a connection that drops while the reader is on Home', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  async function droppedOnHome(page: import('@playwright/test').Page) {
+    await mockAgent(page, 'dashboard-drop')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText(/disconnected/i).first()).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('tab', { name: 'Home' }).click()
+    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+  }
+
+  test('says the connection dropped', async ({ page, shot }) => {
+    await droppedOnHome(page)
+
+    // The dashboard cannot update over a dead socket, so it sits there looking
+    // like an agent with nothing to report. The composer's status bar says
+    // "disconnected · reconnect" — to a reader on Home that is inside the pane
+    // they cannot see.
+    await expect(
+      page.getByText(/connection to this agent dropped/i),
+      'the socket died and the dashboard reader was told nothing',
+    ).toBeVisible({ timeout: 15_000 })
+
+    await shot('home-disconnected')
+  })
+
+  test('and offers the way back', async ({ page }) => {
+    await droppedOnHome(page)
+    const back = page.getByRole('button', { name: /^reconnect$/i })
+    await expect(back).toBeVisible({ timeout: 15_000 })
+
+    await back.click()
+    // Recovering must work from here, not just send them to the other pane.
+    await expect(page.getByText(/connection to this agent dropped/i)).toHaveCount(0, { timeout: 15_000 })
+  })
+
+  test('the chat pane is not told twice', async ({ page }) => {
+    await droppedOnHome(page)
+    await page.getByRole('tab', { name: 'Chat' }).click()
+
+    // The composer already reports this. Repeating it above the panes for a
+    // reader who can read it there is noise, and noise is what teaches people to
+    // stop reading notices.
+    await expect(page.getByText(/connection to this agent dropped/i)).toHaveCount(0)
+    await expect(page.getByText(/disconnected/i).first()).toBeVisible()
+  })
+
+  test('a healthy connection says nothing on Home', async ({ page }) => {
+    await mockAgent(page, 'dashboard')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('tab', { name: 'Chat' }).click()
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('tab', { name: 'Home' }).click()
+
+    await expect(page.getByText(/connection to this agent dropped/i)).toHaveCount(0)
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -108,7 +108,7 @@ export async function mockAgent(
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
-        if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
+        if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains' || scenario === 'dashboard-error' || scenario === 'dashboard-drop') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
 
         // The connection goes away after it was working: a tunnel, a handover
         // between wifi and cellular, the screen locking. Closed here rather than
@@ -149,14 +149,14 @@ export async function mockAgent(
       // Once, then the tunnel ends. A scenario that drops every socket can show
       // the disconnected state but never whether the way back out of it works —
       // reconnect would reopen straight into another drop.
-      if (scenario === 'drop' && !dropped) {
+      if ((scenario === 'drop' || scenario === 'dashboard-drop') && !dropped) {
         dropped = true
         send(ws, { type: 'thinking', id: 't1', status: 'done' })
         setTimeout(() => ws.close({ code: 1006, reason: 'connection lost' }), 800)
         return
       }
 
-      if (scenario === 'error') {
+      if (scenario === 'error' || scenario === 'dashboard-error') {
         send(ws, { type: 'ERROR', message: 'the agent ran out of credits' })
         return
       }


### PR DESCRIPTION
Priority 4, third member of the family #88 started.

## The rule, and the member that was missing

#88: anything the agent needs the reader to know must reach them whichever pane they are on. Prompts got a marker (#88); offline and low balance moved above both panes (#112). This pass I checked the rest of that family rather than one more instance.

Two results:

- **An agent error already reaches a Home reader.** Measured, not assumed — `Error: the agent ran out of credits · Retry` is on screen with Home selected. No change needed.
- **A dropped connection does not.** With Home showing, the entire visible page is `Scriptbot Home Chat`. Switching to Chat reveals `disconnected · reconnect` in the composer's status bar.

The dashboard cannot update over a dead socket, so it sits there looking exactly like an agent with nothing to report.

## Why this one is not `agentNotice`

The composer's status bar already reports it. Repeating that above the panes for a reader who can read it there is noise, and noise is what teaches people to stop reading notices.

So it renders **only while the chat pane is hidden** — `hiddenChatNotice`, which is precisely the reason it exists. Offline and low balance keep the always-visible slot from #112, because nothing else reports those.

## Verification

| | before | after |
|---|---|---|
| says the connection dropped, from Home | FAILED, blank page | ok |
| offers a working Reconnect from Home | FAILED | ok |
| the chat pane is not told twice | ok, guards the design | ok |
| a healthy connection says nothing | ok, guards the other way | ok |

Removing the conditional render fails the first with *"the socket died and the dashboard reader was told nothing"*.

`tsc` clean, `lint` 0 findings, `vitest` 56 passed. Screenshot checked at 375px — the notice sits under the header with Reconnect, above the stale dashboard.

## The one failing test in my full run, and a correction

The full local suite came back **153 passed, 1 failed**: `scroll-follow`, which this change does not touch, with the transcript 100px above the bottom.

I checked whether it was mine instead of assuming. On clean `main` at `009c061`, that spec alone fails roughly 1 run in 3 — so it is pre-existing, not this branch.

But that means **#98 did not fix it and I reported that it did.** The `requestAnimationFrame` re-pin reduced the rate; it does not cover layout that settles more than one frame late, which is what a loaded machine does. Filed as #113 with the measurements and where I would start.

Twice now I have called that failure something it was not — "a settling artifact" in #96, "fixed" in #98. The tell was identical both times and I missed it both times: the poll runs its **full** 10s timeout. A test that fails slowly is reporting a state, not a race.
