### PR TITLE
Make the scroll failure say what it saw

### DIFF
--- a/e2e/scroll-follow.spec.ts
+++ b/e2e/scroll-follow.spec.ts
@@ -59,6 +59,53 @@ async function wheelUp(page: import('@playwright/test').Page) {
   }
 }
 
+/** Everything about the scroller, for a failure message.
+ *
+ *  #113 is a rare, load-only failure: the transcript rests ~100px above the
+ *  bottom and stays there. It has now cost three attempts — twice I "fixed" it
+ *  from a guess and once I could not reproduce it at all (clean in eight isolated
+ *  runs and at 4x CPU throttle; it appears only under full-suite contention).
+ *
+ *  So the assertion carries its own diagnosis. When this next fails, the message
+ *  says whether the content was still growing, where the scroll sat, and whether
+ *  the gap moved during the poll — which is the difference between "the pin never
+ *  ran" and "the pin ran against a stale height", and neither can be told from
+ *  `Expected: <= 4  Received: 100`. */
+async function scrollerState(page: import('@playwright/test').Page) {
+  return page.locator(SCROLLER).first().evaluate(el => ({
+    scrollTop: Math.round(el.scrollTop),
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+    gap: Math.round(el.scrollHeight - el.scrollTop - el.clientHeight),
+  }))
+}
+
+/** Poll the gap and, if it never closes, say what it was doing. */
+async function expectSettledAtBottom(page: import('@playwright/test').Page) {
+  const seen: string[] = []
+  try {
+    await expect
+      .poll(async () => {
+        const s = await scrollerState(page)
+        seen.push(`gap=${s.gap} top=${s.scrollTop} h=${s.scrollHeight}`)
+        return s.gap
+      }, { timeout: 10_000 })
+      .toBeLessThanOrEqual(4)
+  } catch (error) {
+    const unique = [...new Set(seen)]
+    throw new Error(
+      `the transcript never settled at the bottom (#113).\n` +
+      `client height ${(await scrollerState(page)).clientHeight}px\n` +
+      `distinct states while polling (${unique.length} of ${seen.length} samples):\n  ` +
+      unique.slice(-8).join('\n  ') + `\n` +
+      (unique.length === 1
+        ? 'It never moved: the pin did not run, or ran and was overwritten once.'
+        : 'It moved: content was still growing while the poll ran.') +
+      `\n\noriginal: ${(error as Error).message}`,
+    )
+  }
+}
+
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
@@ -78,13 +125,7 @@ test.describe('phone', () => {
     // and the reader is looking at the middle of a finished answer.
     await expect(page.getByText('The last line is the one that matters.')).toBeVisible({ timeout: 20_000 })
 
-    // Polled, not read once. "Settles at the bottom" is an eventual state: under
-    // load the observer coalesces and the last pin can land a frame after the
-    // text is on screen, which showed up as 100px adrift in a full-suite run and
-    // never in isolation. A poll still fails if it never settles.
-    await expect
-      .poll(() => distanceFromBottom(page), { timeout: 10_000 })
-      .toBeLessThanOrEqual(4)
+    await expectSettledAtBottom(page)
 
     await shot('followed')
   })
@@ -119,9 +160,7 @@ test.describe('phone', () => {
     // Wait for the transcript to actually be at the bottom before asking whether
     // a way back down is offered — while it is still settling the button is
     // correct to be there, and the question being asked is the other one.
-    await expect
-      .poll(() => distanceFromBottom(page), { timeout: 10_000 })
-      .toBeLessThanOrEqual(4)
+    await expectSettledAtBottom(page)
 
     const button = page.getByRole('button', { name: /scroll to bottom/i })
     // Nothing to go back to while already there — a permanent button is clutter.


### PR DESCRIPTION
#113 is the item I named as the obvious next one. I did not fix it. I made it diagnosable, and in doing so identified the mechanism — which is more than the two attempts that came before, both of which were guesses I reported as fixes.

## Why not a fix

I could not reproduce it on demand:

- eight consecutive isolated runs of `scroll-follow`: clean
- 4x CPU throttle: clean (8x is simply too slow to finish)
- it appears only under full-suite contention

My earlier "fails 1 run in 3 on main" was measured right after clearing `.next` with the disk at 3.5G, and does not hold on a healthy machine. That overstatement is in #113 and is now corrected there.

**Fixing what I cannot reproduce is precisely how I got this wrong twice.** So this pass buys the next attempt the thing it has been missing.

## What the assertion says now

`Expected: <= 4  Received: 100` cannot distinguish "the pin never ran" from "the pin ran against a stale height", and those want opposite fixes. The poll now records what it sees and, on failure, reports it:

```
the transcript never settled at the bottom (#113).
client height 468px
distinct states while polling (1 of 12 samples):
  gap=100 top=544 h=1112
It never moved: the pin did not run, or ran and was overwritten once.
```

Verified by forcing the symptom — pinning to `scrollHeight - clientHeight - 100` — and reading the message it produces.

My first attempt at that check sabotaged it with `scrollTop = scrollHeight - 100`, and the test **passed**: that value exceeds the maximum `scrollTop`, so the browser clamps it to the bottom. A sabotage that does not sabotage looks exactly like a diagnostic that works.

## The mechanism, from a real capture

The full run reproduced it, so the diagnostic caught its first live occurrence — the output above.

- final height **1112**, client **468** → the correct resting position is **644**
- actual **544**, one distinct value across twelve samples in ten seconds

544 is exactly `1012 - 468`: the clamped maximum for a content height of 1012. The pin ran while the content was 1012 tall, then it grew the last 100px, **and no further pin ran**. The content is not still growing when the assertion fails — 1112 is the height every passing run reaches. It is one missed callback, not a race that needs more waiting.

That also explains why #98's `requestAnimationFrame` re-pin does not cover it: both reads happen before the layout that produces 1112, so the re-pin re-reads 1012 and changes nothing.

#113 now carries this, plus the fix I would try (re-pin while `scrollHeight` keeps changing, stop when stable) and a reproduction recipe.

## Verification

`tsc` clean, `lint` 0 findings, `vitest` 56 passed. Full local suite: **152 passed, 2 failed** — both #113, both now printing the diagnosis, on a 20-minute run. CI has been green on this spec throughout; it builds once rather than running a dev server.

`git status` confirms this changes one test file.
