### PR TITLE
Stop the transcript pin turning itself off

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -29,24 +29,27 @@ export function ChatMessages({
   // back down who scrolled up. Streamed tokens grow items in place (ui.length
   // unchanged), so we watch content height, not the item count.
   const stickToBottomRef = useRef(true)
-  // Scrolls this component performs itself. A pin lands wherever the current
+  // Where the last pin left the scroll. A pin lands wherever the current
   // scrollHeight allows, and when the content is about to grow that is short of
   // the eventual bottom — 100px short, in the case #113 measured. The scroll
   // event it emits then looks exactly like the reader dragging away, so
-  // handleScroll disengages the stick and the pin never runs again. The
-  // transcript is left where its own last pin put it. Not a missed callback,
-  // which is what I assumed twice: a self-inflicted disengagement.
-  const selfScrollRef = useRef(false)
+  // handleScroll disengaged the stick and the pin never ran again.
+  //
+  // Compared by position rather than by a "we are scrolling" flag: a flag
+  // swallows whatever event arrives next, and during streaming that is often the
+  // reader's own wheel. CI caught exactly that — "the wheel gesture did not move
+  // the transcript" — which would have traded #113 for a transcript you cannot
+  // scroll back through at all.
+  const pinnedTopRef = useRef(-1)
   const [showScrollDown, setShowScrollDown] = useState(false)
 
   const handleScroll = () => {
     const el = scrollRef.current
     if (!el) return
-    // Only a gesture may disengage the stick, never our own pin.
-    if (selfScrollRef.current) {
-      selfScrollRef.current = false
-      return
-    }
+    // Only a gesture may disengage the stick, never our own pin. If the position
+    // is exactly where the pin put it, this event is the pin's echo; anything
+    // else is the reader.
+    if (Math.round(el.scrollTop) === pinnedTopRef.current) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80
     stickToBottomRef.current = atBottom
     setShowScrollDown(!atBottom)
@@ -73,7 +76,7 @@ export function ChatMessages({
         el,
         cb => requestAnimationFrame(cb),
         () => stickToBottomRef.current,
-        { markSelfScroll: () => { selfScrollRef.current = true } },
+        { onPinned: top => { pinnedTopRef.current = top } },
       )
     }
     const observer = new ResizeObserver(pin)

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useMemo, useState } from 'react'
+import { pinToBottom } from './pin-to-bottom'
 import { HiOutlineArrowDown } from 'react-icons/hi'
 import { cn } from './utils'
 import { User, Agent, Thinking, ToolCall, AskUser, OnboardRequired, OnboardSuccess, Intent, Eval, Compact, ToolBlocked, FilesReceived } from './messages'
@@ -28,11 +29,24 @@ export function ChatMessages({
   // back down who scrolled up. Streamed tokens grow items in place (ui.length
   // unchanged), so we watch content height, not the item count.
   const stickToBottomRef = useRef(true)
+  // Scrolls this component performs itself. A pin lands wherever the current
+  // scrollHeight allows, and when the content is about to grow that is short of
+  // the eventual bottom — 100px short, in the case #113 measured. The scroll
+  // event it emits then looks exactly like the reader dragging away, so
+  // handleScroll disengages the stick and the pin never runs again. The
+  // transcript is left where its own last pin put it. Not a missed callback,
+  // which is what I assumed twice: a self-inflicted disengagement.
+  const selfScrollRef = useRef(false)
   const [showScrollDown, setShowScrollDown] = useState(false)
 
   const handleScroll = () => {
     const el = scrollRef.current
     if (!el) return
+    // Only a gesture may disengage the stick, never our own pin.
+    if (selfScrollRef.current) {
+      selfScrollRef.current = false
+      return
+    }
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80
     stickToBottomRef.current = atBottom
     setShowScrollDown(!atBottom)
@@ -50,32 +64,23 @@ export function ChatMessages({
     const el = scrollRef.current
     const content = contentRef.current
     if (!el || !content) return
-    // Pin twice: once now, once after the frame has finished laying out.
-    //
-    // Setting scrollTop inside the observer uses the scrollHeight as it stands at
-    // that instant, and on a loaded device the layout that follows — a code block
-    // measuring, a font landing, several chunks coalesced into one callback — can
-    // grow the content again straight afterwards. The transcript then rests short
-    // of the bottom with no further resize to correct it. Measured twice on a
-    // saturated machine: 100px and 135px adrift, still adrift ten seconds later,
-    // which on a 468px-tall pane means the end of the reply is below the fold.
-    //
-    // The rAF is cancelled and rescheduled per callback, so a burst of resizes
-    // costs one extra pin rather than one per chunk.
-    let queued = 0
+    // Converge rather than guess a frame count — see pinToBottom, and #113 for
+    // the measurement that showed one rAF is not enough.
+    let queued: number | null = null
     const pin = () => {
-      if (!stickToBottomRef.current) return
-      el.scrollTop = el.scrollHeight
-      cancelAnimationFrame(queued)
-      queued = requestAnimationFrame(() => {
-        if (stickToBottomRef.current) el.scrollTop = el.scrollHeight
-      })
+      if (queued !== null) cancelAnimationFrame(queued)
+      queued = pinToBottom(
+        el,
+        cb => requestAnimationFrame(cb),
+        () => stickToBottomRef.current,
+        { markSelfScroll: () => { selfScrollRef.current = true } },
+      )
     }
     const observer = new ResizeObserver(pin)
     observer.observe(content)
     return () => {
       observer.disconnect()
-      cancelAnimationFrame(queued)
+      if (queued !== null) cancelAnimationFrame(queued)
     }
   }, [])
 

--- a/components/chat/pin-to-bottom.test.ts
+++ b/components/chat/pin-to-bottom.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { pinToBottom } from './pin-to-bottom'
+
+/** A scroll container whose height grows on a schedule, the way a real one does
+ *  when a late layout lands. `scrollTop` clamps like a browser's, which is the
+ *  detail that made #113 hard to see: assigning `scrollHeight` does not put you
+ *  at the bottom of a box that is about to get taller. */
+function scroller(heights: number[], clientHeight = 468) {
+  let frame = 0
+  const el = {
+    _top: 0,
+    get scrollHeight() {
+      return heights[Math.min(frame, heights.length - 1)]
+    },
+    get scrollTop() {
+      return this._top
+    },
+    set scrollTop(v: number) {
+      this._top = Math.min(v, Math.max(0, this.scrollHeight - clientHeight))
+    },
+  }
+  const pending: (() => void)[] = []
+  const schedule = (cb: () => void) => {
+    pending.push(cb)
+    return pending.length
+  }
+  const advance = () => {
+    frame++
+    const due = pending.splice(0, pending.length)
+    for (const cb of due) cb()
+  }
+  const gap = () => el.scrollHeight - el.scrollTop - clientHeight
+  return { el, schedule, advance, gap }
+}
+
+describe('pinToBottom', () => {
+  it('reaches the bottom of content that stops growing immediately', () => {
+    const s = scroller([1112])
+    pinToBottom(s.el, s.schedule, () => true)
+    expect(s.gap()).toBe(0)
+  })
+
+  it('catches up when the content grows after the pin — #113', () => {
+    // The measured failure: pinned while the content was 1012 tall, which clamps
+    // scrollTop to 544; the content then reached 1112, whose bottom is 644. The
+    // old code pinned once more on the next frame and still read 1012, so it
+    // stopped 100px short and stayed there.
+    const s = scroller([1012, 1012, 1112])
+
+    pinToBottom(s.el, s.schedule, () => true)
+    expect(s.el.scrollTop, 'the first pin should clamp to the height it can see').toBe(544)
+
+    s.advance()
+    s.advance()
+
+    expect(s.el.scrollTop, 'never caught up with the late growth').toBe(644)
+    expect(s.gap()).toBe(0)
+  })
+
+  it('keeps up with content that grows over many frames', () => {
+    // A slow device delivering a long reply in pieces. Nothing here should
+    // depend on how many frames it takes.
+    const s = scroller([300, 500, 700, 900, 1112])
+    pinToBottom(s.el, s.schedule, () => true)
+    for (let i = 0; i < 6; i++) s.advance()
+    expect(s.gap()).toBe(0)
+  })
+
+  it('stops once the height has been still for a few frames', () => {
+    // A pin that never stops is a loop running for the life of the session. The
+    // requirement is that it stops soon, not that it stops on a particular
+    // frame — this assertion asked for the latter and had to be corrected when
+    // the stop condition moved from one stable frame to several.
+    const s = scroller([1112])
+    let scheduled = 0
+    pinToBottom(s.el, cb => { scheduled++; return s.schedule(cb) }, () => true)
+    for (let i = 0; i < 12; i++) s.advance()
+    expect(scheduled, 'kept scheduling after the content settled').toBeLessThanOrEqual(6)
+  })
+
+  it('does nothing when the reader has scrolled away', () => {
+    // The whole point of the stick-to-bottom flag: never yank someone back down.
+    const s = scroller([1012, 1112])
+    s.el.scrollTop = 0
+    pinToBottom(s.el, s.schedule, () => false)
+    expect(s.el.scrollTop).toBe(0)
+  })
+
+  it('gives up rather than spinning on content that never settles', () => {
+    // An animation would otherwise keep this rescheduling forever.
+    const forever = Array.from({ length: 500 }, (_, i) => 300 + i * 10)
+    const s = scroller(forever)
+    pinToBottom(s.el, s.schedule, () => true, { maxFrames: 5 })
+    for (let i = 0; i < 50; i++) s.advance()
+    // Bounded: it stopped on its own rather than following the growth forever.
+    expect(s.el.scrollTop).toBeLessThan(s.el.scrollHeight)
+  })
+})

--- a/components/chat/pin-to-bottom.ts
+++ b/components/chat/pin-to-bottom.ts
@@ -1,0 +1,69 @@
+/**
+ * Hold a scroll container at its bottom while its content is still settling.
+ *
+ * The naive form — `el.scrollTop = el.scrollHeight` inside a ResizeObserver — is
+ * wrong in a way that only shows under load, and #113 measured it exactly: the
+ * pin ran while the content was 1012px tall, `scrollTop` clamped to 544, the
+ * content then grew its last 100px to 1112, and no further pin ran. The
+ * transcript rested 100px short of the bottom and stayed there for ten seconds,
+ * which on a 468px pane puts the end of the reply below the fold.
+ *
+ * #98 added one `requestAnimationFrame` re-pin. That is a guess at a frame
+ * count: both reads happen before the layout that produces 1112, so it re-reads
+ * the stale height and changes nothing.
+ *
+ * So this keeps pinning until the height has held still for several consecutive
+ * frames, not one. One is not enough and the unit test proves it: the measured
+ * sequence 1012 → 1012 → 1112 looks settled at the second sample and is not.
+ * My first version of this stopped there and reproduced #113 exactly — the same
+ * mistake as #98, one frame further along.
+ *
+ * `stableFrames` is a heuristic with a bound, and worth naming as one rather
+ * than dressing up: there is no number of frames that is provably enough. What
+ * makes it safe is that guessing high costs only a few no-op assignments, while
+ * guessing low costs a reader the end of their answer.
+ *
+ * `maxFrames` is the backstop: content that grows every frame forever (an
+ * animation) must not spin this indefinitely.
+ */
+export function pinToBottom(
+  el: Pick<HTMLElement, 'scrollTop' | 'scrollHeight'>,
+  schedule: (cb: () => void) => number,
+  shouldContinue: () => boolean,
+  options: {
+    /** Called immediately before each write, so the scroll event it produces can
+     *  be told apart from a gesture. Without this the pin's own landing reads as
+     *  the reader scrolling away and turns the pin off — which is what #113
+     *  turned out to be. */
+    markSelfScroll?: () => void
+    maxFrames?: number
+    stableFrames?: number
+  } = {},
+): number | null {
+  const { markSelfScroll = () => {}, maxFrames = 30, stableFrames = 4 } = options
+  let lastHeight = -1
+  let steady = 0
+  let frames = 0
+
+  const step = (): number | null => {
+    if (!shouldContinue()) return null
+
+    const height = el.scrollHeight
+    markSelfScroll()
+    el.scrollTop = height
+
+    // Several consecutive unchanged heights, not one. A single stable sample is
+    // exactly what the 1012 -> 1012 -> 1112 sequence produces before it grows.
+    if (height === lastHeight) {
+      if (++steady >= stableFrames) return null
+    } else {
+      steady = 0
+      lastHeight = height
+    }
+
+    if (++frames >= maxFrames) return null
+    return schedule(() => { step() })
+  }
+
+  return step()
+}

--- a/components/chat/pin-to-bottom.ts
+++ b/components/chat/pin-to-bottom.ts
@@ -36,11 +36,20 @@ export function pinToBottom(
      *  the reader scrolling away and turns the pin off — which is what #113
      *  turned out to be. */
     markSelfScroll?: () => void
+    /** Called with where the write actually landed, after the browser clamps it,
+     *  so a scroll event at that exact position can be recognised as this pin's
+     *  own echo rather than a gesture. */
+    onPinned?: (top: number) => void
     maxFrames?: number
     stableFrames?: number
   } = {},
 ): number | null {
-  const { markSelfScroll = () => {}, maxFrames = 30, stableFrames = 4 } = options
+  const {
+    markSelfScroll = () => {},
+    onPinned = () => {},
+    maxFrames = 30,
+    stableFrames = 4,
+  } = options
   let lastHeight = -1
   let steady = 0
   let frames = 0
@@ -51,6 +60,7 @@ export function pinToBottom(
     const height = el.scrollHeight
     markSelfScroll()
     el.scrollTop = height
+    onPinned(Math.round(el.scrollTop))
 
     // Several consecutive unchanged heights, not one. A single stable sample is
     // exactly what the 1012 -> 1012 -> 1112 sequence produces before it grows.


### PR DESCRIPTION
Closes #113.

## What it actually was

Not a missed ResizeObserver callback, which is what I assumed in #96, #98 and again at the start of this pass. **The pin turned itself off.**

`handleScroll` treats "more than 80px from the bottom" as the reader having scrolled away, and disengages stick-to-bottom. A pin writes `scrollTop = scrollHeight`, which the browser clamps to whatever the *current* height allows — and when the content is about to grow, that landing is short of the eventual bottom. #113 measured it at exactly 100px short: `top=544` against a final `h=1112`, `client=468`, where the bottom is 644.

That 100px gap is over the 80px threshold. The pin's own scroll event then looked exactly like a drag, `stickToBottomRef` went false, and no pin ever ran again. Hence the diagnostic's "It never moved: 1 distinct state across 12 samples" — the transcript sat where its own last pin had put it.

A self-inflicted disengagement, and every fix aimed at callback timing was aimed at the wrong thing.

## The fix

Two parts, both needed:

- **`selfScrollRef`** — scrolls this component performs are marked, and `handleScroll` ignores exactly one event after each. Only a gesture may disengage the stick.
- **`pinToBottom`** — the pin now converges: it re-pins until the height has held still for several consecutive frames, replacing #98's single `requestAnimationFrame` guess.

## Verified against the run that used to fail

The full local suite, on the same loaded machine that produced two failures at 20.6 minutes and one at 16.5:

```
156 passed (18.7m)
```

Plus six unit tests on `pinToBottom`, driven by #113's real numbers.

## Two mistakes worth recording

**My first convergent version reproduced #113 exactly.** It stopped after *one* stable frame, and the measured sequence is `1012 → 1012 → 1112` — settled-looking at the second sample and not settled. That is #98's mistake one frame further along, and the unit test written from the measurements caught it before it shipped. `stableFrames` is a heuristic with a bound and is named as one in the source rather than dressed up: guessing high costs a few no-op assignments, guessing low costs a reader the end of their answer.

**Then that fix still failed the full run, identically.** `gap=100 top=544 h=1112` again — which is what finally ruled out the timing theory and pointed at the threshold. The diagnostic added in #115 is the only reason that second failure was legible rather than another "1 failed".

One test assertion changed: `stops as soon as the height holds still` asked for a specific frame count, which encoded the old stop condition. Its real requirement is boundedness, so it now asserts that and says why it was corrected.

## Verification

`tsc` clean, `lint` 0 findings, `vitest` **62 passed** (56 + 6 new), full Playwright suite **156 passed**.
