### PR TITLE
Give the conversation a floor on a laptop

### DIFF
--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -85,8 +85,13 @@ export function WorkspaceShell({
 
       <div className="flex-1 flex min-h-0">
         {/* Chat pane */}
+        {/* A floor on the chat, so the dashboard is what gives way when the
+            window is too narrow for both. Without it the dashboard's remembered
+            width won unconditionally — `shrink-0` — and at 1024px the
+            conversation was left 237px with a composer whose text field measured
+            0px. A phone gets 375px and works; a laptop was doing worse. */}
         <div className={cn(
-          'flex-1 min-w-0 flex-col',
+          'flex-1 min-w-0 lg:min-w-[360px] flex-col',
           mobileView === 'chat' || !hasDashboard ? 'flex' : 'hidden',
           'lg:flex'
         )}>
@@ -119,7 +124,10 @@ export function WorkspaceShell({
         <aside
           style={{ ['--pane' as string]: `${pane.width}px` }}
           className={cn(
-            'w-full border-l border-neutral-200 bg-neutral-50 flex-col shrink-0 lg:w-[var(--pane)]',
+            // shrink-0 on mobile, where the aside is the whole width; on a
+            // laptop it must be able to yield to the chat's floor, or the two
+            // together overflow the window.
+            'w-full border-l border-neutral-200 bg-neutral-50 flex-col shrink-0 lg:shrink lg:min-w-0 lg:w-[var(--pane)]',
             mobileView === 'home' ? 'flex' : 'hidden',
             dashboardOpen ? 'lg:flex' : 'lg:hidden'
           )}

--- a/e2e/desktop-split.spec.ts
+++ b/e2e/desktop-split.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * The two panes on a laptop.
+ *
+ * The dashboard is a resizable pane with a remembered width and `shrink-0`, so
+ * it never yields — every pixel the window lacks comes out of the chat. At
+ * 1024px, which is a MacBook Air at default scaling or any half-screen window,
+ * that left the conversation 237px: narrower than a phone, and the composer's
+ * textarea measured **0px wide and not visible**. There is no way to type a
+ * message on that screen.
+ *
+ * A phone gets 375px and works. A laptop got less and did not.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+/** Land on an agent that has a dashboard, at a given window width. */
+async function splitAt(page: import('@playwright/test').Page, width: number) {
+  await page.setViewportSize({ width, height: 800 })
+  await mockAgent(page, 'dashboard')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.locator('iframe')).toBeVisible({ timeout: 20_000 })
+}
+
+for (const width of [1024, 1180, 1280, 1440]) {
+  test(`a message can be typed at ${width}px`, async ({ page }) => {
+    await splitAt(page, width)
+
+    const field = page.getByPlaceholder(/message/i)
+    await expect(field, 'the composer has no field to type in').toBeVisible()
+
+    const box = await field.boundingBox()
+    // A low sanity floor, not a design target. The same composer on a 375px phone
+    // gives the field 137px, so anything near that is fine; my first version of
+    // this asserted 180px, which is a number I made up and which the phone itself
+    // would fail. The defect being guarded is 0px and invisible.
+    expect(box!.width, `the text field is ${Math.round(box!.width)}px wide`).toBeGreaterThan(100)
+
+    // And it must actually accept text, not merely exist.
+    await field.fill('reconcile the july ledger')
+    await expect(field).toHaveValue('reconcile the july ledger')
+  })
+}
+
+test('the dashboard gives way rather than the conversation', async ({ page, shot }) => {
+  await splitAt(page, 1024)
+
+  const [frame, main] = await Promise.all([
+    page.locator('iframe').boundingBox(),
+    page.locator('main').boundingBox(),
+  ])
+  const chat = main!.width - frame!.width
+
+  // The chat is the primary surface: it keeps its floor and the dashboard takes
+  // the shortfall. Both stay on screen — narrowing is not the same as hiding,
+  // and the dashboard has its own collapse control for that.
+  expect(chat, 'the conversation is narrower than a phone').toBeGreaterThanOrEqual(360)
+  expect(frame!.width, 'the dashboard vanished instead of narrowing').toBeGreaterThan(120)
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow, 'the split pushes the page sideways').toBeLessThanOrEqual(0)
+
+  await shot('1024')
+})
+
+test('a wide window still honours the remembered pane width', async ({ page }) => {
+  await splitAt(page, 1440)
+
+  // The floor must not become the layout. With room for both, the dashboard keeps
+  // the width the reader dragged it to.
+  const frame = await page.locator('iframe').boundingBox()
+  expect(frame!.width, 'the dashboard lost its width on a wide screen').toBeGreaterThan(400)
+})


### PR DESCRIPTION
Priority 4 — how the panes cooperate. Everything I have done on that has been phone-first; this is the laptop.

## The finding

The dashboard is a resizable pane with a remembered width and `shrink-0`. It never yields, so every pixel the window lacks comes out of the chat:

```
width   chat pane   text field
1024    237px       0px, not visible
1180    393px       150px
1280    493px       250px
```

At **1024px** — a MacBook Air at default scaling, or any half-screen window — **there is no field to type into**. The `+`, the mic, the send arrow and the mode chips are all still there, so the composer looks present; the textarea has simply collapsed to nothing.

A phone gets a 375px pane and works. A laptop was getting 237px and did not.

## Fix

A floor on the chat (`lg:min-w-[360px]`) and the dashboard allowed to yield on large screens (`lg:shrink lg:min-w-0`, keeping `shrink-0` on mobile where the aside is full width).

The chat is the primary surface, so the dashboard takes the shortfall — but it **narrows rather than vanishing**, because hiding it is a different decision and it already has its own collapse control. Both are asserted.

A remembered pane width still wins on a wide screen: the floor must not become the layout.

## A threshold I invented and had to correct

My first version asserted the text field was wider than **180px**. That number was made up, and measuring the same composer on a 375px phone gives **137px** — the phone itself would have failed my assertion.

The spec now uses a low sanity floor with that measurement written next to it, and puts the real structural guarantee where it belongs: the **pane** is at least 360px, which is what actually prevents the collapse. Guarding a defect of "0px and invisible" with a made-up design target would have been a worse test wearing a stricter number.

## Verification

| | before | after |
|---|---|---|
| a message can be typed at 1024px | FAILED, no field | ok |
| …at 1180 / 1280 / 1440 | ok | ok |
| the dashboard gives way, not the conversation | FAILED, 237px | ok |
| a wide window keeps the remembered width | ok, guards the floor | ok |

`tsc` clean, `lint` 0 findings, `vitest` 62 passed, **full Playwright suite 162 passed**. Screenshot checked at 1024: the composer is usable, the identity line no longer wraps mid-phrase, the opener chip fits one line, and the dashboard is narrower but present.

## Checked first, and clean

Before this I looked at the sidebar itself, since it is the thing called "not good enough", and at the balance surfaces. The desktop sidebar groups agents with their sessions, rails and online dots, and reads correctly with two agents and three conversations. Settings renders balances through the same `TopUp` component as the landing page, so the low and empty states from #85 are already consistent there.

I did not change either. Neither had a defect I could demonstrate, and redesigning a sidebar on my own taste is not the same as fixing one.
