### PR TITLE
Make the share control reachable, and the modal a modal

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -46,12 +46,16 @@ export function ChatMessages({
   const handleScroll = () => {
     const el = scrollRef.current
     if (!el) return
-    // Only a gesture may disengage the stick, never our own pin. If the position
-    // is exactly where the pin put it, this event is the pin's echo; anything
-    // else is the reader.
-    if (Math.round(el.scrollTop) === pinnedTopRef.current) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80
-    stickToBottomRef.current = atBottom
+
+    // Only a gesture may disengage the stick, never our own pin: if the position
+    // is exactly where the pin put it, this event is the pin's echo. But the
+    // button is a display of where we are, not a decision about intent, so it
+    // updates either way — returning early from the whole handler left a button
+    // shown mid-stream still on screen after a pin had reached the bottom, with
+    // nothing to go back to.
+    const isPinEcho = Math.round(el.scrollTop) === pinnedTopRef.current
+    if (!isPinEcho) stickToBottomRef.current = atBottom
     setShowScrollDown(!atBottom)
   }
 

--- a/components/qr-share.tsx
+++ b/components/qr-share.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { QRCodeSVG } from 'qrcode.react'
 import { HiOutlineQrcode, HiOutlineX, HiOutlineClipboardCopy, HiOutlineClipboardCheck } from 'react-icons/hi'
 
@@ -18,6 +18,31 @@ const OO_CHAT_BASE = 'https://chat.openonion.ai'
  */
 export function QrShare({ address }: { address: string }) {
   const [open, setOpen] = useState(false)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const openerRef = useRef<HTMLButtonElement>(null)
+
+  // Announced, focusable, and dismissible. Without a dialog role and a focus
+  // move, opening this changed nothing a screen reader could perceive — the
+  // content was appended to the page, focus stayed on the button behind it, and
+  // Tab carried on through the page underneath. onboard-gate.tsx already does
+  // this properly; this one simply never did.
+  //
+  // Escape closes, unlike the invite gate, because dismissing this leaves a
+  // usable page — there the honest answer to "can I get out of this" is no.
+  useEffect(() => {
+    if (!open) return
+    // Captured now: by cleanup the ref may point somewhere else, and the whole
+    // point is to return focus to the button this was opened from.
+    const opener = openerRef.current
+    closeRef.current?.focus()
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      // Back where they were, not at the top of the document.
+      opener?.focus()
+    }
+  }, [open])
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
@@ -40,7 +65,12 @@ export function QrShare({ address }: { address: string }) {
       <button
         onClick={() => setOpen(true)}
         title="Scan to open on your phone"
-        aria-label="Show QR code"
+        // The visible word has to be inside the accessible name — WCAG 2.5.3.
+        // With the name "Show QR code" against a button reading "Share", a
+        // speech-input user saying "click Share" activates nothing, and there is
+        // no feedback to tell them why.
+        aria-label="Share — show QR code"
+        ref={openerRef}
         className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-[11px] font-medium text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
       >
         <HiOutlineQrcode className="w-3.5 h-3.5 text-neutral-400" />
@@ -53,8 +83,14 @@ export function QrShare({ address }: { address: string }) {
             className="absolute inset-0 bg-neutral-900/40 backdrop-blur-sm animate-in fade-in duration-200"
             onClick={() => setOpen(false)}
           />
-          <div className="relative w-full max-w-xs rounded-2xl border border-neutral-200 bg-white p-6 shadow-2xl animate-in zoom-in-95 fade-in duration-200">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qr-share-title"
+            className="relative w-full max-w-xs rounded-2xl border border-neutral-200 bg-white p-6 shadow-2xl animate-in zoom-in-95 fade-in duration-200"
+          >
             <button
+              ref={closeRef}
               onClick={() => setOpen(false)}
               aria-label="Close"
               className="absolute right-3 top-3 p-1.5 rounded-lg text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 transition-colors"
@@ -62,7 +98,7 @@ export function QrShare({ address }: { address: string }) {
               <HiOutlineX className="w-4 h-4" />
             </button>
 
-            <p className="text-center text-sm font-medium text-neutral-900">Scan to open on your phone</p>
+            <p id="qr-share-title" className="text-center text-sm font-medium text-neutral-900">Scan to open on your phone</p>
             <p className="mt-1 mb-5 text-center text-[11px] text-neutral-400">Point your camera at the code</p>
 
             <div className="flex justify-center">

--- a/e2e/label-in-name.spec.ts
+++ b/e2e/label-in-name.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Controls whose spoken name contains the word printed on them.
+ *
+ * WCAG 2.5.3. A speech-input user says "click Share"; if the accessible name is
+ * "Show QR code" the command matches nothing and nothing explains why. It is
+ * also the failure that hides a control from `getByRole` — which is how this was
+ * found: a probe looked for a button named Share, found none, and the button was
+ * sitting there in plain sight.
+ *
+ * Enumerated across the surfaces rather than asserted on the one control that
+ * was wrong, because the next `aria-label` someone adds to a labelled button is
+ * the one this needs to catch.
+ */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+/** Controls whose aria-label omits their own visible text. */
+function mismatches(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const out: string[] = []
+    for (const el of document.querySelectorAll('button, a')) {
+      const label = el.getAttribute('aria-label')
+      if (!label) continue
+      const text = (el as HTMLElement).innerText.replace(/\s+/g, ' ').trim()
+      // Icon-only controls have no visible text and are exactly what aria-label
+      // is for; only a control that prints a word must repeat that word.
+      if (!text) continue
+      if (!label.toLowerCase().includes(text.toLowerCase())) {
+        out.push(`"${text}" is announced as "${label}"`)
+      }
+    }
+    return [...new Set(out)]
+  })
+}
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('every labelled control says its own word', async ({ page }) => {
+    await mockAgent(page, 'busy')
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+    expect(await mismatches(page), 'on the landing page').toEqual([])
+
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText(/rebuilt the site|Read the page/i).first()).toBeVisible({ timeout: 20_000 })
+    expect(await mismatches(page), 'in a conversation').toEqual([])
+
+    await page.getByRole('button', { name: /menu/i }).first().click()
+    await expect(page.locator('aside')).toHaveCSS('visibility', 'visible')
+    expect(await mismatches(page), 'in the drawer').toEqual([])
+
+    await page.goto('/settings')
+    await expect(page.getByPlaceholder(/paste agent address/i)).toBeVisible({ timeout: 20_000 })
+    expect(await mismatches(page), 'in settings').toEqual([])
+  })
+
+  test('the share control can be reached by its own name', async ({ page, shot }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+
+    // The concrete case: this is what a screen reader or a speech command has to
+    // be able to find, and what `getByRole` could not.
+    const share = page.getByRole('button', { name: /share/i })
+    await expect(share, 'the button reading "Share" cannot be found by that name').toBeVisible()
+
+    await share.click()
+
+    // A modal that is not a dialog changes nothing a screen reader perceives:
+    // the content is appended, focus stays on the button behind it, and Tab
+    // carries on through the page underneath. The invite gate already does this
+    // properly; this one did not.
+    const modal = page.getByRole('dialog')
+    await expect(modal, 'the share modal is not announced as one').toBeVisible()
+    await expect(modal).toContainText(/scan to open/i)
+
+    // Focus has to move in, or a keyboard reader is still outside it.
+    await expect(page.getByRole('button', { name: /^close$/i })).toBeFocused()
+
+    await shot('qr')
+
+    // And Escape gets out, unlike the invite gate — dismissing this leaves a
+    // usable page, so refusing to close would be the wrong answer.
+    await page.keyboard.press('Escape')
+    await expect(modal).toHaveCount(0)
+    await expect(share, 'focus was dropped instead of returned').toBeFocused()
+  })
+})


### PR DESCRIPTION
Two accessibility defects in the share control, and a regression I shipped in #116.

## The share button could not be found by its own name

Its visible text is `Share`; its accessible name was `Show QR code`. That is WCAG 2.5.3 *Label in Name*: a speech-input user says "click Share" and nothing happens, with no feedback explaining why.

It is also how I found it — a probe looked for a button named Share, found none, and the button was sitting in plain sight. `getByRole` and a speech command fail on exactly the same mismatch.

Fixed to `Share — show QR code`, and enumerated as a rule across landing, transcript, drawer and settings rather than asserted on the one control that was wrong. That sweep found **one** mismatch in the whole app, so this was an outlier and not a pattern.

## The share modal was not a modal

```
DIALOG 0
FOCUS  BUTTON:Share
```

No `role="dialog"`, no `aria-modal`, and focus stayed on the button behind it. Opening it changed nothing a screen reader could perceive: the content was appended to the page and Tab carried on through the page underneath.

`onboard-gate.tsx` already does this properly — role, `aria-modal`, `aria-labelledby`, focus moved in — so the app knows the pattern; this component simply never followed it. It now does, plus Escape to close and focus returned to the opener.

Escape closes here and deliberately does not on the invite gate: dismissing this leaves a usable page, whereas there the honest answer to "can I get out of this" is no.

## And a regression from #116

The full run failed `a way back down appears, and only while it is needed`, and my first instinct was to call it load — the machine took 31 minutes for a 19-minute suite. It was mine.

#116 made `handleScroll` return early on the pin's own echo, to stop the pin disengaging the stick. That early return skipped `setShowScrollDown` too, so a button shown mid-stream stayed on screen after a later pin had reached the bottom — offering a way back down to somewhere the reader already was.

The echo check now guards only the decision it was added for. The button is a display of where we are, not an inference about intent, so it updates either way.

## Verification

Both new guards checked by breaking them:

- restoring `aria-label="Show QR code"` → *"Share" is announced as "Show QR code"*
- removing `role="dialog"` → *the share modal is not announced as one*

`tsc` clean, `lint` 0 findings, `vitest` 62 passed. `scroll-follow` 9/9 across three repeats; `balance`, `dashboard` and the new spec 26 passed together.

The full local suite on this machine is currently unreliable — 31 minutes, with a `balance` timeout that passes cleanly on re-run — so **CI is the gate here**, as it was for #116, where it caught a regression my green local run had missed.

## Checked first, and clean

The pane floor from #117 holds through the paths it did not cover: a remembered 900px width on a 1024px window, and dragging the handle hard right, both cap at chat 365 / dashboard 371 with no overflow. No change needed.
