### PR TITLE
Let the older chats be reached

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -32,6 +32,12 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const pathname = usePathname()
   const { agents, conversations, deleteConversation, removeAgent } = useChatStore()
   const infoMap = useAgentInfo(agents)
+  // Agents whose full history is showing. The sidebar lists the newest eight and
+  // offered "N older chats →" as a link to the agent's landing page — which lists
+  // none of them. Measured: zero session links there. So the rest were
+  // unreachable from the interface, and the reader was told where their history
+  // was and found an empty room. It expands here instead, where they are looking.
+  const [showAllFor, setShowAllFor] = useState<Set<string>>(new Set())
 
   // Track which agents are expanded (all expanded by default)
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set())
@@ -261,25 +267,25 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                       </div>
                     </div>
 
-                    {/* Sessions (expanded) — newest 8; the agent page lists the rest */}
+                    {/* Sessions (expanded) — newest 8, with the rest one press away. The list
+                        area scrolls, so showing all of them is safe. */}
                     {expanded && sessions.length > 0 && (
                       <div className="ml-5 mt-0.5 mb-1 pl-2 border-l border-neutral-200">
                         <SessionList
-                          sessions={sessions.slice(0, 8)}
+                          sessions={showAllFor.has(address) ? sessions : sessions.slice(0, 8)}
                           agentAddress={address}
                           activeSessionId={activeSessionId}
                           variant="sidebar"
                           onDelete={handleDeleteSession}
                           onSelect={onClose}
                         />
-                        {sessions.length > 8 && (
-                          <Link
-                            href={`/${address}`}
-                            onClick={onClose}
-                            className="block px-3 py-1.5 text-xs text-neutral-400 hover:text-neutral-700 transition-colors"
+                        {sessions.length > 8 && !showAllFor.has(address) && (
+                          <button
+                            onClick={() => setShowAllFor(prev => new Set(prev).add(address))}
+                            className="block w-full px-3 py-1.5 text-left text-xs text-neutral-400 hover:text-neutral-700 transition-colors"
                           >
-                            {sessions.length - 8} older chats →
-                          </Link>
+                            {sessions.length - 8} older chats
+                          </button>
                         )}
                       </div>
                     )}

--- a/e2e/many-sessions.spec.ts
+++ b/e2e/many-sessions.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * A sidebar after weeks of use.
+ *
+ * Everything else in this suite runs with one to three conversations. With
+ * forty, the sidebar shows the newest eight and offers "32 older chats →" —
+ * pointing at the agent's landing page, which lists **none**. Measured: zero
+ * session links in `main`. The source said "the agent page lists the rest"; it
+ * does not, and those conversations were unreachable from the interface
+ * entirely. For a customer months in, that is their history gone.
+ */
+
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+const TOTAL = 40
+
+/** Seed a history rather than send forty messages. */
+async function withManySessions(page: import('@playwright/test').Page) {
+  await page.addInitScript(([addr, total]) => {
+    const conversations = Array.from({ length: total as number }, (_, i) => ({
+      sessionId: `s-${i}`,
+      agentAddress: addr,
+      title: `conversation number ${i}`,
+      createdAt: new Date(2026, 6, 1 + (i % 28)).toISOString(),
+    }))
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations, activeSessionId: null, agents: [addr],
+        openonionApiKey: 'e2e-token', userProfile: null,
+      },
+      version: 0,
+    }))
+  }, [AGENT_ADDRESS, TOTAL] as const)
+
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
+  await page.getByRole('button', { name: /menu/i }).first().click()
+  const drawer = page.locator('aside')
+  await expect(drawer).toHaveCSS('visibility', 'visible')
+  return drawer
+}
+
+const sessionRows = (drawer: ReturnType<typeof pane>) => drawer.locator('a[href*="/s-"]')
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('the newest few are shown, and the rest are offered', async ({ page, shot }) => {
+    const drawer = await withManySessions(page)
+
+    await expect(sessionRows(drawer)).toHaveCount(8)
+    await expect(drawer.getByText(/32 older chats/i)).toBeVisible()
+
+    await shot('collapsed')
+  })
+
+  test('the older ones can actually be reached', async ({ page, shot }) => {
+    const drawer = await withManySessions(page)
+
+    // The promise the sidebar makes. It used to lead to a page listing none of
+    // them, which is worse than not offering: the reader is told where their
+    // history is and finds an empty room.
+    await drawer.getByText(/32 older chats/i).click()
+
+    await expect(
+      sessionRows(drawer),
+      'the older conversations are still not listed anywhere',
+    ).toHaveCount(TOTAL)
+
+    await shot('expanded')
+  })
+
+  test('and one of them opens', async ({ page }) => {
+    const drawer = await withManySessions(page)
+    await drawer.getByText(/32 older chats/i).click()
+
+    // Listing is not reaching. The oldest conversation has to open.
+    const oldest = drawer.getByRole('link', { name: 'conversation number 39' })
+    await oldest.scrollIntoViewIfNeeded()
+    await oldest.click()
+
+    await expect(page).toHaveURL(/\/s-39$/)
+  })
+
+  test('a short history offers nothing to expand', async ({ page }) => {
+    await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+    await page.getByRole('button', { name: /menu/i }).first().click()
+
+    // The control earns its place by being absent when there is nothing behind it.
+    await expect(page.locator('aside').getByText(/older chats/i)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Priority 3 — the sidebar, after weeks of use.

## The finding

Every other spec in this suite runs with one to three conversations. With forty, the sidebar shows the newest eight and offers:

```
32 older chats →
```

It linked to the agent's landing page. That page lists **none** of them — measured, zero session links in `main`. The source comment said *"the agent page lists the rest"*; it does not, and never did.

So thirty-two conversations were unreachable from the interface entirely. Worse than not offering: the reader is told where their history is and finds an empty room. For a customer months in, that is their history gone.

## Fix

It expands in place, where they are already looking. The agent list area is `flex-1 overflow-y-auto`, so showing the full history just scrolls — Add Agent and Settings stay pinned at the bottom.

The control still disappears when there is nothing behind it.

## Verification

| | before | after |
|---|---|---|
| newest eight shown, rest offered | ok | ok |
| the older ones can actually be reached | FAILED, 8 of 40 | ok |
| and one of them opens | FAILED | ok |
| a short history offers nothing to expand | ok, guards the control | ok |

Reverting to `sessions.slice(0, 8)` fails it with *"the older conversations are still not listed anywhere"*.

`tsc` clean, `lint` 0 findings, `vitest` 62 passed. Screenshot checked at 375px.

## Checked first, and clean

I swept the modal family, since #118 fixed one of them and finding the next one two passes later is the habit I have been trying to break:

- `confirm-dialog.tsx` uses **`role="alertdialog"`** — the more precise role for a destructive confirm — moves focus in, and closes on Escape. My grep for `role="dialog"` had flagged it as missing a role; the runtime check corrected that.
- `ui/modal.tsx` and `onboard-gate.tsx` both declare role and `aria-modal`.

QrShare, fixed in #118, was the only defective one. No change needed here.
