### PR TITLE
Fix mobile retry and onboarding UI

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -44,6 +44,7 @@ import { WorkspaceShell } from '@/components/dashboard/workspace-shell'
 import { DashboardPane } from '@/components/dashboard/dashboard-pane'
 import type { UI, ApprovalMode } from '@/components/chat/types'
 import { dedupeUI } from '@/components/chat/dedupe-ui'
+import { suppressRetryEcho, type RetryEcho } from '@/components/chat/retry-echo'
 import { useChatStore } from '@/store/chat-store'
 import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, isAgentAddress } from '@/hooks/use-agent-info'
@@ -171,6 +172,7 @@ export default function ChatSessionPage() {
 
   // Connection error state for retry functionality
   const [connectionError, setConnectionError] = useState<string | null>(null)
+  const [retryEcho, setRetryEcho] = useState<RetryEcho | null>(null)
 
   useEffect(() => {
     if (consumedRef.current === sessionId) return
@@ -191,7 +193,11 @@ export default function ChatSessionPage() {
   // The SDK's per-session store is the transcript's single source of truth;
   // it hydrates synchronously from localStorage, so hookUI already carries
   // the persisted conversation on reload.
-  const displayUI = useMemo((): UI[] => dedupeUI(hookUI as UI[]), [hookUI])
+  const canonicalUI = useMemo((): UI[] => dedupeUI(hookUI as UI[]), [hookUI])
+  const displayUI = useMemo(
+    (): UI[] => suppressRetryEcho(canonicalUI, retryEcho),
+    [canonicalUI, retryEcho]
+  )
 
   // Keep the sidebar title in sync with the first user message
   useEffect(() => {
@@ -208,9 +214,10 @@ export default function ChatSessionPage() {
     if (!conversation) {
       createConversation(sessionId, address)
     }
+    setRetryEcho(null)
     setConnectionError(null)
     send(content, images, files)
-  }, [conversation, sessionId, address, createConversation, send, setConnectionError])
+  }, [conversation, sessionId, address, createConversation, send])
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -220,13 +227,28 @@ export default function ChatSessionPage() {
 
   // Retry resends the last user message from the transcript — survives page reloads,
   // unlike transient state.
-  const lastUserMessage = useMemo(() => {
+  const lastUserItem = useMemo(() => {
     for (let i = displayUI.length - 1; i >= 0; i--) {
       const item = displayUI[i]
-      if (item.type === 'user' && 'content' in item) return item.content
+      if (item.type === 'user') return item
     }
-    return ''
+    return null
   }, [displayUI])
+
+  const handleRetry = useCallback(() => {
+    if (!lastUserItem) return
+    setRetryEcho(current => current?.sourceId === lastUserItem.id
+      && current.content === lastUserItem.content
+      ? current
+      : {
+          sourceId: lastUserItem.id,
+          content: lastUserItem.content,
+          knownUserCount: canonicalUI.filter(item => item.type === 'user').length,
+        }
+    )
+    setConnectionError(null)
+    send(lastUserItem.content)
+  }, [canonicalUI, lastUserItem, send])
 
   // Eager, exactly as the landing page does it. The gate is driven by
   // ONBOARD_REQUIRED, which the host sends in answer to CONNECT — so a route that
@@ -324,12 +346,12 @@ export default function ChatSessionPage() {
               sessionState={sessionState}
               isLoading={isLoading}
               connectionError={connectionError}
-              onRetry={lastUserMessage ? () => handleSend(lastUserMessage) : undefined}
+              onRetry={lastUserItem ? handleRetry : undefined}
               onReconnect={handleReconnect}
             />
           }
           connectionError={connectionError}
-          onRetry={lastUserMessage ? () => handleSend(lastUserMessage) : undefined}
+          onRetry={lastUserItem ? handleRetry : undefined}
           onDismissError={() => setConnectionError(null)}
           skills={skills}
           acceptsAttachments={acceptsAttachments(

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,12 +24,22 @@
  *     └── globals.css       # Imported Tailwind styles
  */
 
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import "./globals.css"
 
 export const metadata: Metadata = {
   title: "oo-chat - Open Source AI Chat Client",
   description: "An open-source chat client for AI agents powered by ConnectOnion",
+}
+
+// `env(safe-area-inset-*)` stays at zero on iOS unless the page opts into the
+// full viewport. The composer already reserves the bottom inset; this makes
+// that existing CSS effective instead of leaving the mode controls under
+// Safari's home-indicator/tool-bar area.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 }
 
 export default function RootLayout({

--- a/components/chat-layout.tsx
+++ b/components/chat-layout.tsx
@@ -38,7 +38,7 @@ export function ChatLayout({ children }: ChatLayoutProps) {
 
             pt-[env(safe-area-inset-top)]: nothing in this app handled insets, so on
             a notched phone the row sat under the status bar. */}
-        <header className="lg:hidden flex h-14 shrink-0 items-center gap-2 border-b border-neutral-200 bg-neutral-50 px-3 pt-[env(safe-area-inset-top)]">
+        <header className="lg:hidden flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center gap-2 border-b border-neutral-200 bg-neutral-50 px-3 pt-[env(safe-area-inset-top)]">
           <button
             onClick={() => setSidebarOpen(true)}
             className="-ml-1 grid h-11 w-11 shrink-0 place-items-center rounded-lg hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -8,6 +8,7 @@ import { User, Agent, Thinking, ToolCall, AskUser, OnboardRequired, OnboardSucce
 import { ChatAskUser } from './chat-ask-user'
 import { ChatUlwCheckpoint } from './chat-ulw-checkpoint'
 import type { ChatMessagesProps, OnboardRequiredUI, OnboardSuccessUI, IntentUI, EvalUI, CompactUI, ToolBlockedUI, UlwTurnsReachedUI, FilesReceivedUI } from './types'
+import { isOnboardGateCompleted } from './onboard-state'
 
 export function ChatMessages({
   ui = [],
@@ -137,9 +138,6 @@ export function ChatMessages({
         .pop()?.id
     : null
 
-  // Check if onboard was completed (has onboard_success event)
-  const hasOnboardSuccess = ui.some(item => item.type === 'onboard_success')
-
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
     <div
@@ -161,7 +159,7 @@ export function ChatMessages({
         aria-label="Conversation"
         className="mx-auto max-w-3xl space-y-1"
       >
-        {ui.map((item) => {
+        {ui.map((item, index) => {
           switch (item.type) {
             case 'user':
               return <User key={item.id} message={item} />
@@ -216,6 +214,10 @@ export function ChatMessages({
               // Rendered inline via tool card (exit_plan_and_implement)
               return null
             case 'onboard_required': {
+              // The success event is the canonical receipt for the gate directly
+              // before it. A later gate remains visible if re-verification is
+              // requested in the same transcript.
+              if (isOnboardGateCompleted(ui, index)) return null
               // Only show interactive form if this is the pending onboard
               const isPending = pendingOnboard !== null
               return (
@@ -223,7 +225,7 @@ export function ChatMessages({
                   key={item.id}
                   data={item as OnboardRequiredUI}
                   onSubmit={isPending && onOnboardSubmit ? onOnboardSubmit : () => {}}
-                  isCompleted={hasOnboardSuccess}
+                  isCompleted={false}
                 />
               )
             }

--- a/components/chat/mode-switcher.tsx
+++ b/components/chat/mode-switcher.tsx
@@ -164,17 +164,18 @@ export function ModeSwitcher({ mode, onModeChange, disabled, ulwTurnsRemaining }
 /** Banner shown when in Plan Mode */
 export function PlanModeBanner({ onExit }: { onExit?: () => void }) {
   return (
-    <div className="flex items-center justify-between px-4 py-2 bg-neutral-50 border-b border-neutral-200">
-      <div className="flex items-center gap-2">
-        <HiOutlineClipboardList className="w-4 h-4 text-neutral-600" />
-        <span className="text-sm text-neutral-700">
-          Plan Mode Active — Agent is researching before acting
+    <div className="flex items-center justify-between gap-3 px-3 py-2 bg-neutral-50 border-b border-neutral-200 sm:px-4">
+      <div className="flex min-w-0 items-center gap-2">
+        <HiOutlineClipboardList className="h-4 w-4 shrink-0 text-neutral-600" />
+        <span className="truncate text-xs font-medium text-neutral-700 sm:text-sm sm:font-normal">
+          <span className="sm:hidden">Plan Mode</span>
+          <span className="hidden sm:inline">Plan Mode Active — Agent is researching before acting</span>
         </span>
       </div>
       {onExit && (
         <button
           onClick={onExit}
-          className="text-xs text-neutral-600 hover:text-neutral-900"
+          className="shrink-0 whitespace-nowrap text-xs text-neutral-600 hover:text-neutral-900"
         >
           Exit Plan Mode
         </button>

--- a/components/chat/onboard-state.test.ts
+++ b/components/chat/onboard-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatItem } from '@connectonion/react'
+
+import type { UI } from './types'
+import { isOnboardGateCompleted } from './onboard-state'
+import { extractPendingStates } from './use-agent-sdk'
+
+describe('isOnboardGateCompleted', () => {
+  it('pairs a success with the preceding gate', () => {
+    const items = [
+      { id: 'gate', type: 'onboard_required', methods: ['invite_code'] },
+      { id: 'success', type: 'onboard_success', level: 'contact', message: 'Verified' },
+    ] as UI[]
+    expect(isOnboardGateCompleted(items, 0)).toBe(true)
+  })
+
+  it('keeps a later fresh gate visible', () => {
+    const items = [
+      { id: 'old-gate', type: 'onboard_required', methods: ['invite_code'] },
+      { id: 'success', type: 'onboard_success', level: 'contact', message: 'Verified' },
+      { id: 'fresh-gate', type: 'onboard_required', methods: ['invite_code'] },
+    ] as UI[]
+    expect(isOnboardGateCompleted(items, 0)).toBe(true)
+    expect(isOnboardGateCompleted(items, 2)).toBe(false)
+    expect(extractPendingStates(items as ChatItem[]).pendingOnboard).toEqual({
+      methods: ['invite_code'],
+      paymentAmount: undefined,
+      paymentAddress: undefined,
+    })
+  })
+})

--- a/components/chat/onboard-state.ts
+++ b/components/chat/onboard-state.ts
@@ -1,0 +1,10 @@
+import type { UI } from './types'
+
+/** A success completes only the gate immediately before it, not future gates. */
+export function isOnboardGateCompleted(items: UI[], gateIndex: number): boolean {
+  for (let index = gateIndex + 1; index < items.length; index++) {
+    if (items[index].type === 'onboard_required') return false
+    if (items[index].type === 'onboard_success') return true
+  }
+  return false
+}

--- a/components/chat/retry-echo.test.ts
+++ b/components/chat/retry-echo.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import type { UI } from './types'
+import { suppressRetryEcho } from './retry-echo'
+
+const user = (id: string, content: string): UI => ({ id, type: 'user', content })
+
+describe('suppressRetryEcho', () => {
+  it('hides only the new user item created by an explicit retry', () => {
+    const items: UI[] = [
+      user('original', 'inspect the Humanitix tab'),
+      { id: 'thinking', type: 'thinking', content: 'trying', status: 'error' },
+      user('retry', 'inspect the Humanitix tab'),
+    ]
+
+    expect(suppressRetryEcho(items, {
+      sourceId: 'original',
+      content: 'inspect the Humanitix tab',
+      knownUserCount: 1,
+    }).map(item => item.id)).toEqual(['original', 'thinking'])
+  })
+
+  it('does not collapse a repeated message unless retry is explicitly armed', () => {
+    const items = [user('first', 'try again'), user('second', 'try again')]
+    expect(suppressRetryEcho(items, null)).toEqual(items)
+  })
+
+  it('preserves earlier identical turns and removes only the post-click echo', () => {
+    const items = [
+      user('first', 'try again'),
+      { id: 'reply', type: 'agent', content: 'failed' } as UI,
+      user('source', 'try again'),
+      user('echo', 'try again'),
+    ]
+
+    expect(suppressRetryEcho(items, {
+      sourceId: 'source',
+      content: 'try again',
+      knownUserCount: 2,
+    }).filter(item => item.type === 'user').map(item => item.id)).toEqual(['first', 'source'])
+  })
+
+  it('keeps every echo hidden across successive retries of the same turn', () => {
+    const retry = {
+      sourceId: 'original',
+      content: 'inspect the tab',
+      knownUserCount: 1,
+    }
+    const items = [
+      user('original', 'inspect the tab'),
+      user('first-echo', 'inspect the tab'),
+      { id: 'first-error', type: 'thinking', content: 'failed', status: 'error' } as UI,
+      user('second-echo', 'inspect the tab'),
+    ]
+
+    expect(suppressRetryEcho(items, retry).map(item => item.id)).toEqual([
+      'original',
+      'first-error',
+    ])
+  })
+})

--- a/components/chat/retry-echo.ts
+++ b/components/chat/retry-echo.ts
@@ -1,0 +1,38 @@
+import type { UI } from './types'
+
+export interface RetryEcho {
+  sourceId: string
+  content: string
+  knownUserCount: number
+}
+
+/**
+ * Retry resends an existing turn, but the SDK also appends an optimistic user
+ * item. Hide exactly that retry-created echo. Ordinary repeated messages are
+ * untouched because this filter is only armed by the Retry action.
+ */
+export function suppressRetryEcho(items: UI[], retry: RetryEcho | null): UI[] {
+  if (!retry) return items
+
+  let userIndex = 0
+  const sourceIsKnown = items.some(item => {
+    if (item.type !== 'user') return false
+    const isKnownSource = userIndex < retry.knownUserCount && item.id === retry.sourceId
+    userIndex += 1
+    return isKnownSource
+  })
+  if (!sourceIsKnown) return items
+
+  userIndex = 0
+
+  return items.filter(item => {
+    if (item.type !== 'user') return true
+
+    const isRetryEcho = userIndex >= retry.knownUserCount
+      && item.content === retry.content
+
+    userIndex += 1
+    if (!isRetryEcho) return true
+    return false
+  })
+}

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -75,14 +75,13 @@ interface UseAgentSDKReturn {
 /**
  * Extract pending states from SDK UI.
  */
-function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser | null, pendingApproval: PendingApproval | null, pendingOnboard: PendingOnboard | null, pendingUlwTurnsReached: PendingUlwTurnsReached | null, pendingPlanReview: PendingPlanReview | null } {
+export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser | null, pendingApproval: PendingApproval | null, pendingOnboard: PendingOnboard | null, pendingUlwTurnsReached: PendingUlwTurnsReached | null, pendingPlanReview: PendingPlanReview | null } {
   let pendingAskUser: PendingAskUser | null = null
   let pendingApproval: PendingApproval | null = null
   let pendingOnboard: PendingOnboard | null = null
   let pendingUlwTurnsReached: PendingUlwTurnsReached | null = null
   let pendingPlanReview: PendingPlanReview | null = null
   const toolStatuses = new Map<string, string>()
-  let hasOnboardSuccess = false
 
   for (const item of ui) {
     if (item.type === 'tool_call') {
@@ -116,18 +115,17 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
         }
       }
     } else if (item.type === 'onboard_required') {
-      if (!hasOnboardSuccess) {
-        pendingOnboard = {
-          methods: item.methods,
-          paymentAmount: item.paymentAmount,
-          // Third place this field was dropped: the host publishes it, the SDK
-          // parsed everything but this, and the derivation here forwarded
-          // everything but this. A gate can ask for money and say where now.
-          paymentAddress: item.paymentAddress,
-        }
+      // Pending state follows event order: success closes the preceding gate,
+      // while a later onboard_required starts a fresh verification round.
+      pendingOnboard = {
+        methods: item.methods,
+        paymentAmount: item.paymentAmount,
+        // Third place this field was dropped: the host publishes it, the SDK
+        // parsed everything but this, and the derivation here forwarded
+        // everything but this. A gate can ask for money and say where now.
+        paymentAddress: item.paymentAddress,
       }
     } else if (item.type === 'onboard_success') {
-      hasOnboardSuccess = true
       pendingOnboard = null
     } else if (item.type === 'ulw_turns_reached') {
       pendingUlwTurnsReached = {


### PR DESCRIPTION
Partially addresses #120.

## What changed

- Hide only user-message echoes created by the explicit Retry action, including successive retries and retries separated by thinking/error events.
- Keep ordinary repeated user messages intact.
- Pair onboarding success with its preceding gate, while allowing a later verification gate to become visible and actionable.
- Opt into iOS safe-area layout and keep the mobile header's 56px content row outside the top inset.
- Keep the Plan Mode banner and exit action usable on narrow screens.

## Scope

This is the oo-chat UI portion of #120. oo-chat uses `@connectonion/react` through `useAgentForHuman`; the idle/reconnect `mode_change` protocol fix belongs in the separate `openonion/connectonion-react` repository. This PR intentionally does not close #120.

## Validation

- `npm test`: 68/68 passed
- full ESLint: passed
- `tsc --noEmit`: passed
- `git diff --check`: passed
- independent second-session review: SHIP after two blocker-fix rounds

A production build was not run in the isolated `/tmp` worktree because Turbopack rejects its external `node_modules` symlink; the source-level checks above passed.