### PR TITLE
Use SDK chat presentation types

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -191,7 +191,7 @@ export default function ChatSessionPage() {
   // The SDK's per-session store is the transcript's single source of truth;
   // it hydrates synchronously from localStorage, so hookUI already carries
   // the persisted conversation on reload.
-  const displayUI = useMemo((): UI[] => dedupeUI(hookUI as UI[]), [hookUI])
+  const displayUI = useMemo((): UI[] => dedupeUI(hookUI), [hookUI])
 
   // Keep the sidebar title in sync with the first user message
   useEffect(() => {

--- a/components/chat/dedupe-ui.test.ts
+++ b/components/chat/dedupe-ui.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+import type { UI } from './types'
+import { dedupeUI } from './dedupe-ui'
+
+describe('SDK presentation de-duplication', () => {
+  test('merges updates with the same stable id', () => {
+    const items: UI[] = [
+      { id: 'call-1', type: 'tool_call', name: 'search', status: 'running' },
+      { id: 'call-1', type: 'tool_call', name: 'search', status: 'done', result: 'ok' },
+    ]
+
+    expect(dedupeUI(items)).toEqual([items[1]])
+  })
+
+  test('keeps SDK variants without a local allowlist', () => {
+    const item: UI = {
+      id: 'plan-1',
+      type: 'plan_review',
+      plan_content: 'ship it',
+    }
+
+    expect(dedupeUI([item])).toEqual([item])
+  })
+})

--- a/components/chat/dedupe-ui.ts
+++ b/components/chat/dedupe-ui.ts
@@ -1,165 +1,17 @@
-// Normalizes raw chat_items from the server (live stream or session replay)
-// into the deduped UI list rendered by chat-messages. Items merge by stable id
-// or content key; byte-identical screenshots merge into one bubble kept at its
-// latest position. The SDK does no dedupe — this is the only dedupe layer.
-import type { AgentUI, AskUserField, UI, UIType } from './types'
-
-const VALID_TYPES = new Set<UIType>([
-  'user',
-  'agent',
-  'thinking',
-  'tool_call',
-  'ask_user',
-  'approval_needed',
-  'onboard_required',
-  'onboard_success',
-  'intent',
-  'eval',
-  'compact',
-  'tool_blocked',
-  'ulw_turns_reached',
-  'plan_review',
-  'files_received',
-])
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
-}
-
-function stringValue(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value : fallback
-}
-
-function stringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined
-  const items = value.filter((item): item is string => typeof item === 'string')
-  return items.length ? items : undefined
-}
-
-function recordValue(value: unknown): Record<string, unknown> {
-  return isRecord(value) ? value : {}
-}
-
-function sanitizeFields(value: unknown): AskUserField[] | undefined {
-  if (!Array.isArray(value)) return undefined
-  const fields = value
-    .filter(isRecord)
-    .map((field): AskUserField => ({
-      name: stringValue(field.name),
-      label: stringValue(field.label || field.name),
-      type: field.type === 'password' ? 'password' : 'text',
-      placeholder: stringValue(field.placeholder),
-      required: field.required === true,
-      autocomplete: stringValue(field.autocomplete),
-    }))
-    .filter(field => field.name && field.label)
-  return fields.length ? fields : undefined
-}
-
-function statusValue(value: unknown): 'running' | 'done' | 'error' {
-  return value === 'running' || value === 'error' ? value : 'done'
-}
-
-function normalizeItem(rawItem: unknown, index: number): UI | null {
-  if (!isRecord(rawItem) || typeof rawItem.type !== 'string' || !VALID_TYPES.has(rawItem.type as UIType)) {
-    return null
-  }
-
-  const type = rawItem.type as UIType
-  const id = stringValue(rawItem.id, `recovered-${type}-${index}`)
-  const item = { ...rawItem, id, type } as Record<string, unknown>
-
-  switch (type) {
-    case 'user':
-      return {
-        ...item,
-        content: stringValue(item.content),
-        images: stringArray(item.images),
-      } as UI
-    case 'agent':
-      return {
-        ...item,
-        content: stringValue(item.content),
-        images: uniqueImages(stringArray(item.images)),
-      } as UI
-    case 'thinking':
-      return { ...item, status: statusValue(item.status), content: stringValue(item.content) } as UI
-    case 'tool_call':
-      return {
-        ...item,
-        name: stringValue(item.name, 'tool'),
-        args: recordValue(item.args),
-        status: statusValue(item.status),
-        result: stringValue(item.result),
-      } as UI
-    case 'ask_user':
-      return {
-        ...item,
-        text: stringValue(item.text || item.question),
-        options: stringArray(item.options) || [],
-        multi_select: item.multi_select === true,
-        input_type: stringValue(item.input_type),
-        fields: sanitizeFields(item.fields),
-      } as UI
-    case 'approval_needed':
-      return {
-        ...item,
-        tool: stringValue(item.tool, 'tool'),
-        arguments: recordValue(item.arguments),
-      } as UI
-    case 'onboard_required':
-      return { ...item, methods: stringArray(item.methods) || [] } as UI
-    case 'onboard_success':
-      return { ...item, level: stringValue(item.level), message: stringValue(item.message) } as UI
-    case 'intent':
-      return { ...item, status: item.status === 'understood' ? 'understood' : 'analyzing' } as UI
-    case 'eval':
-      return { ...item, status: item.status === 'done' ? 'done' : 'evaluating' } as UI
-    case 'compact':
-      return { ...item, status: statusValue(item.status) } as UI
-    case 'tool_blocked':
-      return {
-        ...item,
-        tool: stringValue(item.tool, 'tool'),
-        reason: stringValue(item.reason),
-        message: stringValue(item.message),
-      } as UI
-    case 'ulw_turns_reached':
-      return {
-        ...item,
-        turns_used: typeof item.turns_used === 'number' ? item.turns_used : 0,
-        max_turns: typeof item.max_turns === 'number' ? item.max_turns : 0,
-      } as UI
-    case 'plan_review':
-      return { ...item, plan_content: stringValue(item.plan_content) } as UI
-    case 'files_received':
-      return { ...item, files: Array.isArray(item.files) ? item.files.filter(isRecord) : [] } as UI
-  }
-}
+// De-duplicates SDK-normalized presentation items. Wire validation and field
+// defaults belong to @connectonion/react; this layer only applies UI merge rules.
+import type { AgentUI, UI } from './types'
 
 function uniqueImages(images?: string[]): string[] | undefined {
   if (!images?.length) return images
-  const seen = new Set<string>()
-  const result: string[] = []
-
-  for (const image of images) {
-    if (seen.has(image)) continue
-    seen.add(image)
-    result.push(image)
-  }
-
-  return result
+  return [...new Set(images)]
 }
 
 function dedupeKey(item: UI): string | null {
   if (item.type === 'agent' && item.images?.length) {
     return `agent-image:${item.images.join('|')}`
   }
-
-  if (item.id && item.id !== '__optimistic__') {
-    return `id:${item.id}`
-  }
-
+  if (item.id && item.id !== '__optimistic__') return `id:${item.id}`
   return null
 }
 
@@ -172,27 +24,21 @@ function mergeItems(previous: UI, next: UI): UI {
       images: uniqueImages([...(previous.images || []), ...(next.images || [])]),
     } as AgentUI
   }
-
   return { ...previous, ...next } as UI
 }
 
-export function dedupeUI(items: unknown): UI[] {
-  if (!Array.isArray(items)) return []
+export function dedupeUI(items?: readonly UI[] | null): UI[] {
+  if (!items) return []
 
   const result: (UI | null)[] = []
   const seen = new Map<string, number>()
 
-  for (let index = 0; index < items.length; index++) {
-    const item = normalizeItem(items[index], index)
-    if (!item) continue
-
+  for (const item of items) {
     const key = dedupeKey(item)
-
     if (key && seen.has(key)) {
       const previousIndex = seen.get(key)!
       const merged = mergeItems(result[previousIndex]!, item)
       if (key.startsWith('agent-image:')) {
-        // byte-identical screenshots across turns: keep one bubble, at its latest position
         result[previousIndex] = null
         seen.set(key, result.length)
         result.push(merged)

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -15,10 +15,6 @@ export * from './messages'
 export type {
   FileAttachment,
   Message,
-  Activity,
-  StreamEvent,
-  StreamEventType,
-  AskUserEvent,
   PendingAskUser,
   PendingApproval,
   PendingOnboard,

--- a/components/chat/types-sdk.test.ts
+++ b/components/chat/types-sdk.test.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf, test } from 'vitest'
+import type { ChatItem } from '@connectonion/react'
+import type { ApprovalMode, UI, UIType } from './types'
+
+test('the component boundary is the SDK presentation contract', () => {
+  expectTypeOf<UI>().toEqualTypeOf<ChatItem>()
+  expectTypeOf<UIType>().toEqualTypeOf<ChatItem['type']>()
+  expectTypeOf<ApprovalMode>().toEqualTypeOf<
+    'safe' | 'plan' | 'accept_edits' | 'ulw'
+  >()
+})

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -1,23 +1,20 @@
 /**
  * @purpose TypeScript type definitions for oo-chat component library
  * @llm-note
- *   Dependencies: imports none | imported by [use-agent-stream.ts, chat-activity.tsx, index.ts, use-agent-sdk.ts, chat.tsx, chat-ask-user.tsx, chat-messages.tsx, chat-empty-state.tsx, chat-input.tsx, chat-message.tsx, use-chat.ts] | no test files found
+ *   Dependencies: imports the normalized ChatItem contract from @connectonion/react | imported by chat components and use-agent-sdk.ts
  *   Data flow: defines shared interfaces used across entire chat component library → no data transformation, pure type definitions
  *   State/Effects: no state or side effects, pure type definitions
- *   Integration: exposes {Message, StreamEventType, WsMessageType, AskUserEvent, StreamEvent, Activity, PendingAskUser, ChatProps, ChatMessageProps, ChatInputProps, ChatMessagesProps, ChatEmptyStateProps} | used by all chat components and hooks
+ *   Integration: exposes presentation aliases and component props; raw wire DTOs stay in the SDK
  *   Performance: compile-time only, zero runtime cost
  *   Errors: no error handling, pure TypeScript types
  *
  * Type Categories:
  *   Core Types:
  *     - Message: Chat message data (user/assistant/system)
- *     - Activity: Agent execution events (tool calls, LLM calls, thinking)
+ *     - UI: SDK-normalized messages and agent activity
  *     - PendingAskUser: Interactive question awaiting user response
  *
- *   Event Types:
- *     - StreamEventType: Agent activity events (thinking, tool_call, llm_call, etc.)
- *     - WsMessageType: WebSocket protocol messages (INPUT, OUTPUT, ERROR + StreamEventTypes)
- *     - StreamEvent: Full event payload with optional fields for different event types
+ *   Wire protocol types deliberately do not live in the component layer.
  *
  *   Component Props:
  *     - ChatProps: Main chat component props (messages, activities, ask_user)
@@ -27,17 +24,20 @@
  *     components/chat/
  *     ├── types.ts                  # THIS FILE - shared type definitions
  *     ├── use-chat.ts               # Uses Message type
- *     ├── use-agent-stream.ts       # Uses Message, Activity, StreamEvent, PendingAskUser
- *     ├── use-agent-sdk.ts          # Uses Message, Activity, PendingAskUser
+ *     ├── use-agent-sdk.ts          # Supplies normalized ChatItem[]
  *     ├── chat.tsx                  # Uses ChatProps
  *     ├── chat-message.tsx          # Uses ChatMessageProps, Message
  *     ├── chat-messages.tsx         # Uses ChatMessagesProps, Message
  *     ├── chat-input.tsx            # Uses ChatInputProps
  *     ├── chat-empty-state.tsx      # Uses ChatEmptyStateProps
- *     ├── chat-activity.tsx         # Uses Activity, StreamEvent
  *     ├── chat-ask-user.tsx         # Uses PendingAskUser
  *     └── index.ts                  # Re-exports all types
  */
+
+import type {
+  ApprovalMode as SDKApprovalMode,
+  ChatItem,
+} from '@connectonion/react'
 
 export interface FileAttachment {
   name: string
@@ -51,55 +51,6 @@ export interface Message {
   role: 'user' | 'assistant' | 'system'
   content: string
   createdAt?: Date
-}
-
-export type StreamEventType =
-  | 'user_input'
-  | 'thinking'
-  | 'llm_call'      // Backend sends this when LLM completes
-  | 'tool_call'     // Backend sends this BEFORE tool execution
-  | 'tool_result'   // Backend sends this AFTER tool execution
-  | 'assistant'
-  | 'error'
-  | 'complete'
-  | 'ask_user'
-
-export type WsMessageType = StreamEventType | 'OUTPUT' | 'ERROR' | 'INPUT'
-
-export interface AskUserEvent {
-  type: 'ask_user'
-  question: string
-  options?: string[]
-  multi_select?: boolean
-}
-
-export interface StreamEvent {
-  type: WsMessageType
-  id?: string  // Tool call ID for matching tool_call with tool_result
-  content?: string
-  kind?: 'intent' | 'plan' | 'reflect'
-  name?: string
-  args?: Record<string, unknown>
-  status?: 'success' | 'error' | 'not_found'
-  result?: string
-  timing_ms?: number
-  error?: string
-  source?: string
-  message?: string
-  tools_used?: string[]
-  llm_calls?: number
-  iterations?: number
-  // ask_user fields
-  question?: string
-  options?: string[]
-  multi_select?: boolean
-}
-
-export interface Activity {
-  id: string
-  type: StreamEventType  // Only streaming events, not protocol messages
-  data: StreamEvent
-  timestamp: Date
 }
 
 export interface PendingAskUser {
@@ -142,159 +93,33 @@ export interface PendingPlanReview {
 }
 
 // UI types (matches ConnectOnion SDK: connectonion-ts/src/connect.ts)
-export type UIType = 'user' | 'agent' | 'thinking' | 'tool_call' | 'ask_user' | 'approval_needed' | 'onboard_required' | 'onboard_success' | 'intent' | 'eval' | 'compact' | 'tool_blocked' | 'ulw_turns_reached' | 'plan_review' | 'files_received'
+export type UIType = ChatItem['type']
 
-/** Base UI with common fields */
-interface BaseUI {
-  id: string
-  type: UIType
-}
+export type UserUI = Extract<ChatItem, { type: 'user' }>
+export type AgentUI = Extract<ChatItem, { type: 'agent' }>
 
-/** User message */
-export interface UserUI extends BaseUI {
-  type: 'user'
-  content: string
-  images?: string[]
-  files?: FileAttachment[]
-}
+/** Thinking presentation item derived from the normalized SDK contract. */
+export type ThinkingUI = Extract<ChatItem, { type: 'thinking' }>
 
-/** Agent response */
-export interface AgentUI extends BaseUI {
-  type: 'agent'
-  content: string
-  images?: string[]
-}
+export type ToolCallUI = Extract<ChatItem, { type: 'tool_call' }>
+export type AskUserUI = Extract<ChatItem, { type: 'ask_user' }>
+export type ApprovalNeededUI = Extract<ChatItem, { type: 'approval_needed' }>
+export type OnboardRequiredUI = Extract<ChatItem, { type: 'onboard_required' }>
+export type OnboardSuccessUI = Extract<ChatItem, { type: 'onboard_success' }>
 
-/** Token usage info from LLM */
-export interface TokenUsage {
-  input_tokens?: number
-  output_tokens?: number
-  prompt_tokens?: number
-  completion_tokens?: number
-  total_tokens?: number
-  cost?: number
-}
-
-/** Thinking indicator */
-export interface ThinkingUI extends BaseUI {
-  type: 'thinking'
-  status: 'running' | 'done' | 'error'
-  content?: string
-  kind?: 'intent' | 'plan' | 'reflect'
-  model?: string
-  duration_ms?: number
-  context_percent?: number  // Context window usage percentage
-  usage?: TokenUsage
-}
-
-/** Tool execution (merged from tool_call + tool_result) */
-export interface ToolCallUI extends BaseUI {
-  type: 'tool_call'
-  name: string
-  args?: Record<string, unknown>
-  status: 'running' | 'done' | 'error'
-  result?: string
-  timing_ms?: number
-}
-
-/** Ask user */
-export interface AskUserUI extends BaseUI {
-  type: 'ask_user'
-  text: string
-  options?: string[]
-  multi_select?: boolean
-  input_type?: string
-  fields?: AskUserField[]
-  answered?: boolean
-  answer?: string
-}
-
-/** Approval needed for dangerous tool */
-export interface ApprovalNeededUI extends BaseUI {
-  type: 'approval_needed'
-  tool: string
-  arguments: Record<string, unknown>
-  description?: string
-  batch_remaining?: Array<{ tool: string; arguments: string }>
-}
-
-/** Onboard required for stranger */
-export interface OnboardRequiredUI extends BaseUI {
-  type: 'onboard_required'
-  methods: string[]
-  paymentAmount?: number
-  paymentAddress?: string  // Agent's address for payment transfer
-}
-
-/** Onboard success */
-export interface OnboardSuccessUI extends BaseUI {
-  type: 'onboard_success'
-  level: string
-  message: string
-}
-
-/** Intent analysis (user feels seen) */
-export interface IntentUI extends BaseUI {
-  type: 'intent'
-  status: 'analyzing' | 'understood'
-  ack?: string  // Acknowledgment message e.g., "checking the files in this directory"
-  is_build?: boolean  // Whether this is a build/code task
-}
-
-/** Evaluation result from eval plugin (structured) */
-export interface EvalUI extends BaseUI {
-  type: 'eval'
-  status: 'evaluating' | 'done'
-  passed?: boolean     // True if task completed successfully
-  summary?: string     // Brief explanation (1-2 sentences)
-  expected?: string    // What should happen
-  eval_path?: string   // Path to eval file (.co/evals/...)
-}
-
-/** Auto-compact event from auto_compact plugin */
-export interface CompactUI extends BaseUI {
-  type: 'compact'
-  status: 'compacting' | 'done' | 'error'
-  context_before?: number  // Context % before compact
-  context_after?: number   // Context % after compact
-  context_percent?: number // Current context % (when compacting)
-  message?: string
-  error?: string
-}
-
-/** Tool blocked (e.g., bash file creation blocked by prefer_write_tool) */
-export interface ToolBlockedUI extends BaseUI {
-  type: 'tool_blocked'
-  tool: string      // Tool that was blocked
-  reason: string    // Why it was blocked (e.g., 'file_creation')
-  message: string   // Human-readable message
-  command?: string  // The blocked command
-}
-
-/** ULW turns reached checkpoint */
-export interface UlwTurnsReachedUI extends BaseUI {
-  type: 'ulw_turns_reached'
-  turns_used: number
-  max_turns: number
-}
-
-/** Plan review - agent sends plan for user approval */
-export interface PlanReviewUI extends BaseUI {
-  type: 'plan_review'
-  plan_content: string
-}
-
-/** Files received by the agent */
-export interface FilesReceivedUI extends BaseUI {
-  type: 'files_received'
-  files: Array<{ name: string; path: string }>
-}
+export type IntentUI = Extract<ChatItem, { type: 'intent' }>
+export type EvalUI = Extract<ChatItem, { type: 'eval' }>
+export type CompactUI = Extract<ChatItem, { type: 'compact' }>
+export type ToolBlockedUI = Extract<ChatItem, { type: 'tool_blocked' }>
+export type UlwTurnsReachedUI = Extract<ChatItem, { type: 'ulw_turns_reached' }>
+export type PlanReviewUI = Extract<ChatItem, { type: 'plan_review' }>
+export type FilesReceivedUI = Extract<ChatItem, { type: 'files_received' }>
 
 /** Union of all UI types */
-export type UI = UserUI | AgentUI | ThinkingUI | ToolCallUI | AskUserUI | ApprovalNeededUI | OnboardRequiredUI | OnboardSuccessUI | IntentUI | EvalUI | CompactUI | ToolBlockedUI | UlwTurnsReachedUI | PlanReviewUI | FilesReceivedUI
+export type UI = ChatItem
 
 /** Approval mode (matches ConnectOnion SDK) */
-export type ApprovalMode = 'safe' | 'plan' | 'accept_edits' | 'ulw'
+export type ApprovalMode = SDKApprovalMode
 
 export interface SkillInfo {
   name: string

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -222,7 +222,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   // Each connect attempt to a non-onboarded agent emits a fresh onboard_required
   // (new UUID, so dedupeUI keeps them all) — keep only the latest card.
   const cleanUI = useMemo(() => {
-    let items = dedupeUI(ui as import('./types').UI[]) as ChatItem[]
+    let items = dedupeUI(ui)
     let lastOnboardIndex = -1
     for (let i = items.length - 1; i >= 0; i--) {
       if (items[i].type === 'onboard_required') { lastOnboardIndex = i; break }


### PR DESCRIPTION
## What changed

- make `@connectonion/react`'s `ChatItem` and `ApprovalMode` the component boundary
- remove duplicated raw stream event DTOs and 15 copied presentation interfaces
- reduce `dedupeUI` to UI-only stable-ID/image merge behavior
- remove runtime allowlists, field sanitizers, and status defaults that duplicated the SDK protocol layer
- add compile-time contract and runtime de-duplication tests

## Why

ACP/legacy conversion belongs in the SDK. oo-chat should render the stable presentation model, so a new SDK ChatItem cannot be silently discarded by a second application allowlist.

## Validation

- `npm test`: 65 tests passed
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm run build`: passed
- two independent expert reviews: final no findings

Dependency advisories discovered while validating this branch are isolated in Draft PR #124; review/merge that security fix before release.

Closes #122 when merged.

## Coordinated Drafts

- Host writer: https://github.com/openonion/connectonion/pull/842
- core TypeScript reader: https://github.com/openonion/connectonion-ts/pull/37
- React reader: https://github.com/openonion/connectonion-react/pull/12
- security fix: https://github.com/openonion/oo-chat/pull/124

No automatic merge; release only after the SDK readers and security fix are reviewed.
