### PR TITLE
chore: make React the only oo-chat SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 oo-chat is an open-source web chat client for ConnectOnion agents, built with Next.js 16.
 You connect to an agent by its `0x…` address; the live conversation runs over a WebSocket
-through the `@connectonion/react` hooks (`../connectonion-react`), which sit on the
-`connectonion` TypeScript SDK (`../connectonion-ts`). oo-chat is a thin front end —
-routing, layout, and rendering the SDK's streamed event list — while the SDK owns the agent
-connection, the protocol, and per-session persistence.
+through `@connectonion/react` (`../connectonion-react`). oo-chat is a thin front end —
+routing, layout, and rendering the SDK's streamed event list — while the React SDK owns
+the agent connection, protocol normalization, and per-session persistence.
 
 There is one connection path: **remote agent over WebSocket via the SDK**. The "modes" in the
 UI (`safe` / `plan` / `accept_edits` / `ulw`) are trust/approval levels, not connection types.
@@ -119,12 +118,11 @@ and are unused.
 
 ## Dependencies
 
-- `@connectonion/react`: the React layer — `useAgentForHuman`, `useVoiceInput`, the
-  Zustand session store, browser identity. This is what oo-chat imports.
-- `connectonion`: the TypeScript SDK underneath it — agent connection, WebSocket protocol,
-  `fetchAgentInfo`. A peer of `@connectonion/react`, so exactly one copy is installed.
-  Both are pinned by semver; symlinking either to a local checkout hides breakage that
-  only shows up against the published package (see DEPLOY.md).
+- `@connectonion/react`: oo-chat's only SDK boundary — `useAgentForHuman`,
+  `useVoiceInput`, `fetchAgentInfo`, the agent connection and WebSocket protocol, browser
+  identity, and the Zustand session store. It is pinned by semver; symlinking it to a
+  local checkout hides breakage that only appears against the published package (see
+  DEPLOY.md).
 - `zustand`: state + localStorage persistence (sidebar index, SDK session store).
 - `bip39` + `tweetnacl`: browser BIP39/Ed25519 user identity.
 - `react-icons`: UI icons. `clsx` + `tailwind-merge`: conditional classes.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ streamed tool calls, approvals, plan reviews, and autonomous "ultra-long work" r
 included.
 
 oo-chat is a thin front end: the heavy lifting (connecting to an agent, the
-WebSocket protocol, streaming, and per-session persistence) lives in the
-`connectonion` TypeScript SDK ([`../connectonion-ts`](https://github.com/openonion/connectonion-ts)).
+WebSocket protocol, streaming, and per-session persistence) lives in
+[`@connectonion/react`](https://github.com/openonion/connectonion-react).
 oo-chat handles routing, layout, and rendering the SDK's event stream.
 
 ## How it works (30-second version)
@@ -80,11 +80,11 @@ docs/                             # ARCHITECTURE.md, DEPLOY.md
 
 ## The SDK
 
-The SDK is two packages: `@connectonion/react` (the hooks oo-chat imports) on top of
-`connectonion` (the agent connection and WebSocket protocol). Both are pinned by semver in
-`package.json`.
+oo-chat has one SDK boundary: `@connectonion/react`. It includes the hooks, agent
+connection, WebSocket protocol, browser identity, and session persistence. The published
+version is pinned by semver in `package.json`.
 
-Symlinking either to a local checkout for development typechecks against unreleased code
+Symlinking it to a local checkout for development typechecks against unreleased code
 and hides breakage that only appears against the published package — verify on a preview
 deploy, not a local build. Publishing the SDK and shipping oo-chat is documented in
 [`docs/DEPLOY.md`](docs/DEPLOY.md).
@@ -92,10 +92,8 @@ deploy, not a local build. Publishing the SDK and shipping oo-chat is documented
 ## Related projects
 
 - [`../connectonion-react`](https://github.com/openonion/connectonion-react) — the React
-  hooks (`@connectonion/react` on npm): `useAgentForHuman`, `useVoiceInput`, session
-  persistence.
-- [`../connectonion-ts`](https://github.com/openonion/connectonion-ts) — the TypeScript SDK
-  underneath (`connectonion` on npm): `RemoteAgent`, the WebSocket protocol, `fetchAgentInfo`.
+  SDK (`@connectonion/react` on npm): `useAgentForHuman`, `useVoiceInput`, `RemoteAgent`,
+  the WebSocket protocol, browser identity, and session persistence.
 - `../chat-ui` (`@connectonion/chat-ui`) — source registry for the chat components.
   When fixing design issues in `components/chat/`, mirror the change into
   `../chat-ui/registry/` to keep them in sync.

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -92,7 +92,7 @@ export interface PendingPlanReview {
   plan_content: string
 }
 
-// UI types (matches ConnectOnion SDK: connectonion-ts/src/connect.ts)
+// UI types come from @connectonion/react's normalized ChatItem contract.
 export type UIType = ChatItem['type']
 
 export type UserUI = Extract<ChatItem, { type: 'user' }>

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -356,7 +356,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     if (typeof sdkSetMode === 'function') {
       sdkSetMode(newMode, options)
     } else {
-      console.warn('setMode not available in SDK - rebuild connectonion-ts')
+      console.warn('setMode not available in SDK - rebuild @connectonion/react')
     }
   }, [sdkSetMode])
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,11 +4,11 @@ oo-chat is a thin Next.js front end. The SDK does the real work: connecting to a
 the WebSocket protocol, and saving the transcript. oo-chat just routes, lays out, and
 renders the SDK's stream of events.
 
-The SDK is two packages. oo-chat imports **only** from `@connectonion/react`
-(`../connectonion-react`) — the React hooks. Those sit on `connectonion`
-(`../connectonion-ts`), which owns the connection and the protocol and is installed as a
-peer. `connectonion/react` was the old single-package shape and no longer exists as of
-`connectonion@0.3.0`.
+oo-chat has one SDK boundary: `@connectonion/react` (`../connectonion-react`). It owns
+the React hooks, connection, protocol normalization, browser identity, and transcript
+persistence. The standalone `connectonion` TypeScript package is not installed by
+React applications. `connectonion/react` was the old package subpath and no longer
+exists as of `connectonion@0.3.0`.
 
 ## One picture
 
@@ -77,8 +77,8 @@ owner (the SDK); the sidebar store just lists conversations:
 | `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
 
 oo-chat imports `useAgentForHuman`, `fetchAgentInfo`, and `useVoiceInput` from
-`@connectonion/react` (`../connectonion-react`), which re-exports `fetchAgentInfo` from the
-core package. Shipping either package is in [DEPLOY.md](./DEPLOY.md).
+`@connectonion/react` (`../connectonion-react`). Shipping that package is documented in
+[DEPLOY.md](./DEPLOY.md).
 
 ## Home — the agent's dashboard
 
@@ -182,8 +182,8 @@ Credits are spent by the **agent** you connect to (it runs `co/*` on managed key
 deducts from *its* OpenOnion account), not by your browser identity. Balance is
 per-address and gated by that address's private key, so the frontend — which only holds
 its own key — can't query an agent's balance directly. Instead the agent reports it:
-the host publishes a `balance_usd` snapshot in its ANNOUNCE profile / `/info`
-(`connectonion`), the SDK surfaces it on `AgentInfo` (`fetchAgentInfo`), and oo-chat
+the host publishes a `balance_usd` snapshot in its ANNOUNCE profile / `/info`, the SDK
+surfaces it on `AgentInfo` (`fetchAgentInfo`), and oo-chat
 shows it **per agent in Settings** (a startup snapshot, refreshed when the agent
 restarts — not a live figure). Non-`co/*` agents publish no balance and simply show none.
 
@@ -196,8 +196,8 @@ the auth/profile backend). The relay URL is an SDK default. `next.config.ts` is 
 
 ## Reference — the WebSocket protocol
 
-*Skip this unless you're working on the agent connection itself.* The SDK
-(`connectonion-ts/src/connect/`) owns it — the React layer only consumes it; here's the shape.
+*Skip this unless you're working on the agent connection itself.* The React SDK
+(`connectonion-react/src/connect/`) owns it; here's the shape.
 
 **Connect → run → settle:** the SDK sends a signed `CONNECT` (a stranger may first
 hit an `ONBOARD_REQUIRED` trust gate), then `INPUT { prompt }`. The agent streams

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,30 +1,27 @@
-# Deploy: SDK → npm → oo-chat → Vercel
+# Deploy: React SDK → npm → oo-chat → Vercel
 
-oo-chat's SDK is **two packages in two repos**:
+oo-chat has **one SDK dependency**:
 
 | Package | Repo | What it is |
 |---|---|---|
-| `@connectonion/react` | `../connectonion-react` (`openonion/connectonion-react`) | the hooks oo-chat imports — `useAgentForHuman`, `useVoiceInput`, the Zustand session store, browser identity |
-| `connectonion` | `../connectonion-ts` (`openonion/connectonion-ts`) | the layer underneath — `RemoteAgent`, the WebSocket protocol, `fetchAgentInfo`, types |
+| `@connectonion/react` | `../connectonion-react` (`openonion/connectonion-react`) | hooks, `RemoteAgent`, WebSocket protocol, browser identity, and the Zustand session store |
 
-**oo-chat imports from `@connectonion/react`, not from `connectonion`.** The React layer
-used to live at `connectonion/react`; it was split out in `connectonion@0.3.0` and that
-subpath no longer exists. If you are about to write `from 'connectonion/react'`, that is the
-old shape — use `@connectonion/react`.
+**oo-chat imports and installs `@connectonion/react`, not the standalone `connectonion`
+TypeScript client.** The React layer used to live at `connectonion/react`; it was split
+out in `connectonion@0.3.0` and that subpath no longer exists. If you are about to write
+`from 'connectonion/react'`, that is the old shape — use `@connectonion/react`.
 
-`connectonion` is a **peer** of `@connectonion/react`, so an app installs exactly one copy of
-each and `npm install` fails loudly on an incompatible pair.
-
-A change to either package only reaches production once it's published to npm and oo-chat is
-bumped to that version. This is the full chain.
+A React SDK change only reaches production once it is published to npm and oo-chat is
+bumped to that version. The standalone TypeScript client has its own non-React consumers
+and is not part of this deployment chain.
 
 ## The dependency, two ways
 
 `oo-chat/package.json` declares published npm versions — that is what Vercel installs and
 builds against.
 
-For local development it is tempting to symlink `node_modules/connectonion` (or
-`node_modules/@connectonion/react`) to the sibling checkout so SDK edits show up immediately.
+For local development it is tempting to symlink `node_modules/@connectonion/react` to
+the sibling checkout so SDK edits show up immediately.
 
 > ⚠️ **A symlinked package makes local builds pass while Vercel fails.** The symlink points
 > at your *working* copy, which may contain unpublished changes; Vercel installs the
@@ -43,14 +40,14 @@ Increment the patch by 1; when a segment would hit two digits, roll up:
 0.2.3 → 0.2.4    0.2.9 → 0.3.0    0.9.9 → 1.0.0
 ```
 
-The two packages version independently. `@connectonion/react` declares the core range it
-needs (`"connectonion": ">=0.2.2"`); bump that range when it starts using something new.
+The React SDK and oo-chat version independently. Bump oo-chat's dependency only after the
+required React SDK version is published.
 
 ## Steps
 
-### 1. Publish the package you changed
+### 1. Publish the React SDK
 
-Both repos publish the same way: **push a `v*` tag**, and
+The React repository publishes when you **push a `v*` tag**.
 `.github/workflows/publish.yml` verifies the tag matches `package.json`, runs the tests,
 builds, and publishes to npm.
 
@@ -59,21 +56,18 @@ exchanges a short-lived OIDC token for publish rights, and the release carries a
 attestation. There is nothing to rotate and no secret to leak.
 
 ```bash
-cd ../connectonion-react          # or ../connectonion-ts
+cd ../connectonion-react
 npx tsc --noEmit
 npx jest
 
 # bump version in package.json, then:
-git add -A && git commit -m "v0.2.4"
-git tag v0.2.4
-git push origin main && git push origin v0.2.4
+git add -A && git commit -m "v0.3.4"
+git tag v0.3.4
+git push origin main && git push origin v0.3.4
 
 gh run watch --repo openonion/connectonion-react --exit-status
 npm view @connectonion/react version    # should show the new version
 ```
-
-If you changed **both** packages, publish `connectonion` first — `@connectonion/react` builds
-against it.
 
 > The `publish.yml` in `connectonion-react` packs the tarball and installs it into a clean
 > project before publishing. That gate exists because `@connectonion/react@0.2.2` went to npm
@@ -85,7 +79,7 @@ against it.
 
 ```bash
 cd ../oo-chat
-npm pkg set dependencies."@connectonion/react"="^0.2.4"
+npm pkg set dependencies."@connectonion/react"="^0.3.4"
 npm install                            # updates package-lock.json to the registry tarball
 npm run build                          # MUST pass — this is what Vercel will run
 ```
@@ -100,7 +94,7 @@ grep -A2 '"node_modules/@connectonion/react"' package-lock.json   # expect a reg
 
 ```bash
 git add package.json package-lock.json
-git commit -m "Update @connectonion/react to v0.2.4"
+git commit -m "Update @connectonion/react to v0.3.4"
 git push                               # push the branch; merge the PR to main
 ```
 
@@ -118,10 +112,9 @@ never commit a `file:../connectonion-react` dependency — `npm i <path>` rewrit
 | Thing | Value |
 |-------|-------|
 | React repo | `openonion/connectonion-react` → npm `@connectonion/react` |
-| SDK repo | `openonion/connectonion-ts` → npm `connectonion` |
 | oo-chat repo | `openonion/oo-chat` |
 | Vercel project | `oo-chat` |
 | Publish trigger | git tag `v*` → GitHub Actions → npm (OIDC, no token) |
 | Deploy trigger | push to `main` → Vercel production; branch push → preview |
 | What oo-chat imports | `@connectonion/react` only |
-| Prod dependencies | `"@connectonion/react": "^X.Y.Z"` + `"connectonion": "^X.Y.Z"` (its peer) |
+| SDK dependency | `"@connectonion/react": "^X.Y.Z"` |

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -6,8 +6,8 @@
  * the states worth screenshotting — an approval prompt, a blocked run, an error —
  * are exactly the ones a healthy agent rarely produces on demand.
  *
- * The frames below are the ones `connectonion`'s RemoteAgent actually handles
- * (see connectonion-ts src/connect/remote-agent.ts): CONNECT/INPUT inbound,
+ * The frames below are the ones `@connectonion/react`'s RemoteAgent actually handles
+ * (see connectonion-react src/connect/remote-agent.ts): CONNECT/INPUT inbound,
  * CONNECTED, AGENT_PROFILE, the streamed chat-item events, and OUTPUT/ERROR. The
  * SDK still opens a real WebSocket and runs its real parser — only the far end is
  * ours — so a protocol change breaks these tests, which is the point.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
         "clsx": "^2.1.1",
-        "connectonion": "^0.3.1",
         "next": "^16.2.12",
         "prism-react-renderer": "^2.4.1",
         "qrcode.react": "^4.2.0",
@@ -53,26 +52,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.67.1.tgz",
-      "integrity": "sha512-ZLYZLog5ttur2OXkBxoCr8C+bsIGG//OwKYoDw4ZOlwdKF6u+qqQ7y+R4x9zqgQJBbdg5qZs6RHA7L+QpSrHUA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -797,15 +776,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2373,19 +2343,10 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/prismjs": {
@@ -2921,18 +2882,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2954,18 +2903,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3205,12 +3142,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3381,6 +3312,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3549,18 +3481,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3577,23 +3497,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/connectonion": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/connectonion/-/connectonion-0.3.1.tgz",
-      "integrity": "sha512-3GmjZtUOzfgmFCjpmNR7YvrzjurZ0ilrEMVbZTdl+AlEixm5kIX+5IUX20TnPArY9pNRfIgbmqBkGauZIghZxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.67.0",
-        "@google/generative-ai": "^0.24.1",
-        "dotenv": "^16.0.0",
-        "openai": "^4.0.0",
-        "tweetnacl": "^1.0.3",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3804,15 +3707,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3858,22 +3752,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4017,6 +3900,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4026,6 +3910,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4070,6 +3955,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4082,6 +3968,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4927,15 +4814,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -5106,47 +4984,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/fsevents": {
@@ -5168,6 +5011,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5231,6 +5075,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5255,6 +5100,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5342,6 +5188,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5413,6 +5260,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5425,6 +5273,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5440,6 +5289,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5571,15 +5421,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -6277,19 +6118,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6732,6 +6560,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7613,27 +7442,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -7788,26 +7596,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
@@ -7825,48 +7613,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -8015,51 +7761,6 @@
       "engines": {
         "node": ">=12.20.0"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -9524,12 +9225,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -9719,6 +9414,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -10389,15 +10085,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -10627,7 +10314,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",
     "clsx": "^2.1.1",
-    "connectonion": "^0.3.1",
     "next": "^16.2.12",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
## Summary

Make `@connectonion/react` the only SDK boundary installed and documented by oo-chat.

## Why

`@connectonion/react@0.3.x` owns the browser connection layer and has React as its only peer dependency. oo-chat source imports all SDK behavior from that package, but `package.json` and several repository documents still described the retired two-package runtime stack.

That stale dependency pulled unused provider SDKs into the frontend and incorrectly made the standalone TypeScript client look like an oo-chat release prerequisite.

## Changes

- remove the unused `connectonion` dependency and its transitive lockfile entries;
- update architecture, deployment, contributor, and README guidance to the React-only boundary;
- point source and E2E comments at `@connectonion/react`'s normalized contract and connection implementation;
- keep runtime UI and protocol behavior unchanged.

The standalone `connectonion` TypeScript client remains available for non-React consumers; this PR only removes it from the React application's dependency chain.

## Validation

- clean `npm ci`: 582 packages installed, 0 vulnerabilities;
- `npm ls @connectonion/react connectonion --all`: only `@connectonion/react@0.3.2` is installed;
- `npm test`: 65/65 passed;
- `npm run lint`: passed;
- `npm run build`: passed, including TypeScript and all production routes;
- `git diff --check`: passed.

## Review

- simplicity review: no new abstraction; removes one unused direct dependency and its provider SDK subtree;
- correctness review: current source imports, package peer metadata, onboarding docs, and a clean consumer build all agree on the React-only boundary;
- lockfile noise introduced by regeneration was removed and the resulting lockfile was verified with another clean install.

Closes #126.
