### PR TITLE
fix(chat): render social media cards and disabled choices

### DIFF
--- a/components/chat/ask-user-disabled.test.tsx
+++ b/components/chat/ask-user-disabled.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { ChatAskUser } from './chat-ask-user'
+import { DISABLED_OPTION_PREFIX, normalizeAskUserOptions } from './ask-user-options'
+import { AskUserCard } from './messages/tools/ask-user-card'
+import type { PendingAskUser, ToolCallUI } from './types'
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function render(node: React.ReactElement) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(node))
+  return container
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+const disabled = `${DISABLED_OPTION_PREFIX}1. Jinpeng Li — Already connected`
+const enabled = 'Connect with 2. Jinpeng Li — Send invitation'
+const pending: PendingAskUser = {
+  question: 'Choose one person.',
+  options: [disabled, enabled],
+  disabled_options: [disabled],
+  multi_select: false,
+}
+
+function optionButton(element: HTMLElement, text: string): HTMLButtonElement {
+  const button = [...element.querySelectorAll('button')]
+    .find(candidate => candidate.textContent?.includes(text))
+  if (!button) throw new Error(`Missing option button: ${text}`)
+  return button
+}
+
+describe('disabled ask-user options', () => {
+  test('normalizes the server marker without changing enabled answer values', () => {
+    expect(normalizeAskUserOptions([disabled, enabled], [disabled])).toEqual([
+      { value: disabled, label: '1. Jinpeng Li — Already connected', disabled: true },
+      { value: enabled, label: enabled, disabled: false },
+    ])
+  })
+
+  test('renders a disabled native button in the inline tool card', () => {
+    const onResponse = vi.fn()
+    const toolCall = {
+      id: 'ask-user-1',
+      type: 'tool_call',
+      name: 'ask_user',
+      status: 'running',
+      args: { question: pending.question },
+    } as unknown as ToolCallUI
+    const element = render(
+      <AskUserCard
+        toolCall={toolCall}
+        pendingAskUser={pending}
+        onAskUserResponse={onResponse}
+      />,
+    )
+
+    const unavailable = optionButton(element, 'Already connected')
+    expect(unavailable.disabled).toBe(true)
+    expect(unavailable.textContent).not.toContain(DISABLED_OPTION_PREFIX)
+    act(() => unavailable.click())
+    expect(onResponse).not.toHaveBeenCalled()
+    expect(element.querySelector('input[placeholder="Something else..."]')).toBeNull()
+
+    act(() => optionButton(element, 'Send invitation').click())
+    expect(onResponse).toHaveBeenCalledWith(enabled)
+  })
+
+  test('applies the same disabled behaviour to the standalone prompt', () => {
+    const onResponse = vi.fn()
+    const element = render(<ChatAskUser askUser={pending} onResponse={onResponse} />)
+
+    const unavailable = optionButton(element, 'Already connected')
+    expect(unavailable.disabled).toBe(true)
+    expect(unavailable.textContent).not.toContain(DISABLED_OPTION_PREFIX)
+    act(() => unavailable.click())
+    expect(onResponse).not.toHaveBeenCalled()
+    expect(element.querySelector('input[placeholder="Custom answer..."]')).toBeNull()
+  })
+})

--- a/components/chat/ask-user-options.ts
+++ b/components/chat/ask-user-options.ts
@@ -1,0 +1,22 @@
+export const DISABLED_OPTION_PREFIX = '__OOCHAT_DISABLED__::'
+
+export interface AskUserOption {
+  value: string
+  label: string
+  disabled: boolean
+}
+
+export function normalizeAskUserOptions(
+  options: string[] | undefined,
+  disabledOptions: string[] | undefined = undefined,
+): AskUserOption[] {
+  const disabledValues = new Set(disabledOptions || [])
+  return (options || []).map(value => {
+    const prefixed = value.startsWith(DISABLED_OPTION_PREFIX)
+    return {
+      value,
+      label: prefixed ? value.slice(DISABLED_OPTION_PREFIX.length) : value,
+      disabled: prefixed || disabledValues.has(value),
+    }
+  })
+}

--- a/components/chat/chat-ask-user.tsx
+++ b/components/chat/chat-ask-user.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-icons/hi'
 import { cn } from './utils'
 import { ASK_USER_SKIP_ANSWER, SkipButton } from './ask-user-skip'
+import { normalizeAskUserOptions, type AskUserOption } from './ask-user-options'
 import type { PendingAskUser } from './types'
 
 interface ChatAskUserProps {
@@ -24,11 +25,15 @@ interface ChatAskUserProps {
 export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps) {
   const { multi_select, input_type, fields } = askUser
   const question = typeof askUser.question === 'string' ? askUser.question : ''
-  const options = Array.isArray(askUser.options) ? askUser.options : []
+  const options = normalizeAskUserOptions(
+    Array.isArray(askUser.options) ? askUser.options : [],
+    Array.isArray(askUser.disabled_options) ? askUser.disabled_options : [],
+  )
   const [selected, setSelected] = useState<string[]>([])
   const [textInput, setTextInput] = useState('')
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({})
   const hasOptions = options.length > 0
+  const hasDisabledOptions = options.some(option => option.disabled)
   // input_type is the real signal; the phrase match is the fallback for agents that
   // ask in prose without setting it. It only ever matched Chinese phrasing, so an
   // agent asking "your username and password" in English got a plain text box
@@ -39,22 +44,23 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
     ? fields
     : isCredentialPrompt
       ? [
-          { name: 'username', label: 'Username', type: 'text' as const, required: true, autocomplete: 'username' },
+          { name: 'username', label: 'Email or username', type: 'text' as const, required: true, autocomplete: 'username' },
           { name: 'password', label: 'Password', type: 'password' as const, required: true, autocomplete: 'current-password' },
         ]
       : []
   const hasFieldForm = formFields.length > 0
   const hasMissingRequiredField = formFields.some(field => field.required && !fieldValues[field.name]?.trim())
 
-  const handleOptionClick = (option: string) => {
+  const handleOptionClick = (option: AskUserOption) => {
+    if (option.disabled) return
     if (multi_select) {
       setSelected(prev =>
-        prev.includes(option)
-          ? prev.filter(o => o !== option)
-          : [...prev, option]
+        prev.includes(option.value)
+          ? prev.filter(o => o !== option.value)
+          : [...prev, option.value]
       )
     } else {
-      onResponse(option)
+      onResponse(option.value)
     }
   }
 
@@ -137,14 +143,17 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
           <div className="space-y-1.5">
             <div className="grid grid-cols-1 gap-1.5">
               {options.map((option, idx) => {
-                const isSelected = selected.includes(option)
+                const isSelected = selected.includes(option.value)
                 return (
                   <button
                     key={idx}
                     onClick={() => handleOptionClick(option)}
+                    disabled={option.disabled}
                     className={cn(
                       'group flex w-full items-center gap-3 rounded-md border px-3 py-2.5 text-left text-sm transition-all duration-200',
-                      isSelected
+                      option.disabled
+                        ? 'cursor-not-allowed border-neutral-200 bg-neutral-100 text-neutral-400 opacity-75'
+                        : isSelected
                         ? 'border-neutral-300 bg-neutral-50 text-neutral-900'
                         : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:text-neutral-900'
                     )}
@@ -161,7 +170,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
                       )}
                     </div>
                     <span className={cn(isSelected ? 'font-bold' : 'font-medium')}>
-                      {option}
+                      {option.label}
                     </span>
                   </button>
                 )
@@ -189,7 +198,7 @@ export function ChatAskUser({ askUser, onResponse, className }: ChatAskUserProps
         )}
 
         {/* Input Fallback */}
-        {!hasFieldForm && (
+        {!hasFieldForm && !hasDisabledOptions && (
         <div className="space-y-3 pt-1">
           {hasOptions && (
             <div className="flex items-center gap-2 px-1">

--- a/components/chat/messages/agent.tsx
+++ b/components/chat/messages/agent.tsx
@@ -6,22 +6,25 @@ import remarkGfm from 'remark-gfm'
 import { HiOutlineArrowDownTray } from 'react-icons/hi2'
 import type { AgentUI } from '../types'
 import { downloadImage, imageFileName } from '../utils'
+import { extractLinkedInEmbeds, LinkedInEmbeds } from './linkedin-embed'
 
 export function Agent({ message }: { message: AgentUI }) {
-  const content = typeof message.content === 'string' ? message.content : ''
+  const rawContent = typeof message.content === 'string' ? message.content : ''
+  const { text: content, embeds } = extractLinkedInEmbeds(rawContent)
   // The SDK strips base64 payloads from persisted sessions — items can carry
   // image entries that no longer render. Filter them so no phantom gap remains.
   const images = (Array.isArray(message.images) ? message.images : [])
     .filter(src => src.startsWith('data:') || src.startsWith('http') || src.startsWith('blob:'))
   const hasImages = images.length > 0
   const hasText = content.trim().length > 0
+  const hasEmbeds = embeds.length > 0
 
-  if (!hasText && !hasImages) return null
+  if (!hasText && !hasImages && !hasEmbeds) return null
 
   // Image-only items are tool output (e.g. take_screenshot streams an
   // agent_image event with no text) — render the image plainly, without the
   // avatar bubble that would make it look like the agent "said" something.
-  if (!hasText) {
+  if (!hasText && !hasEmbeds) {
     return (
       <div className="py-2 pl-11">
         <AgentImages images={images} />
@@ -59,6 +62,7 @@ export function Agent({ message }: { message: AgentUI }) {
 
         {/* Images - displayed below text */}
         {hasImages && <AgentImages images={images} />}
+        {hasEmbeds && <LinkedInEmbeds embeds={embeds} />}
       </div>
     </div>
   )

--- a/components/chat/messages/agent.tsx
+++ b/components/chat/messages/agent.tsx
@@ -7,10 +7,12 @@ import { HiOutlineArrowDownTray } from 'react-icons/hi2'
 import type { AgentUI } from '../types'
 import { downloadImage, imageFileName } from '../utils'
 import { extractLinkedInEmbeds, LinkedInEmbeds } from './linkedin-embed'
+import { extractRedNoteMedia, RedNoteMediaCards } from './rednote-media'
 
 export function Agent({ message }: { message: AgentUI }) {
   const rawContent = typeof message.content === 'string' ? message.content : ''
-  const { text: content, embeds } = extractLinkedInEmbeds(rawContent)
+  const { text: contentWithoutLinkedIn, embeds } = extractLinkedInEmbeds(rawContent)
+  const { text: content, media: redNoteMedia } = extractRedNoteMedia(contentWithoutLinkedIn)
   // The SDK strips base64 payloads from persisted sessions — items can carry
   // image entries that no longer render. Filter them so no phantom gap remains.
   const images = (Array.isArray(message.images) ? message.images : [])
@@ -18,13 +20,14 @@ export function Agent({ message }: { message: AgentUI }) {
   const hasImages = images.length > 0
   const hasText = content.trim().length > 0
   const hasEmbeds = embeds.length > 0
+  const hasRedNoteMedia = redNoteMedia.length > 0
 
-  if (!hasText && !hasImages && !hasEmbeds) return null
+  if (!hasText && !hasImages && !hasEmbeds && !hasRedNoteMedia) return null
 
   // Image-only items are tool output (e.g. take_screenshot streams an
   // agent_image event with no text) — render the image plainly, without the
   // avatar bubble that would make it look like the agent "said" something.
-  if (!hasText && !hasEmbeds) {
+  if (!hasText && !hasEmbeds && !hasRedNoteMedia) {
     return (
       <div className="py-2 pl-11">
         <AgentImages images={images} />
@@ -63,6 +66,7 @@ export function Agent({ message }: { message: AgentUI }) {
         {/* Images - displayed below text */}
         {hasImages && <AgentImages images={images} />}
         {hasEmbeds && <LinkedInEmbeds embeds={embeds} />}
+        {hasRedNoteMedia && <RedNoteMediaCards media={redNoteMedia} />}
       </div>
     </div>
   )

--- a/components/chat/messages/linkedin-embed.test.ts
+++ b/components/chat/messages/linkedin-embed.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest'
+import { extractLinkedInEmbeds } from './linkedin-embed'
+
+function directive(payload: Record<string, unknown>): string {
+  return `[[linkedin_embed]]${JSON.stringify(payload)}[[/linkedin_embed]]`
+}
+
+describe('LinkedIn embed directives', () => {
+  test('extracts and canonicalizes a valid full-post embed', () => {
+    const content = [
+      'Here is the complete post.',
+      directive({
+        provider: 'linkedin',
+        url: 'https://linkedin.com/embed/feed/update/urn:li:ugcPost:123/?collapsed=0#fragment',
+        post_url: 'https://linkedin.com/posts/jinpeng_activity-123?trackingId=abc#comments',
+        title: '  LinkedIn embedded post  ',
+        width: 503.6,
+        height: 960,
+      }),
+    ].join('\n\n')
+
+    expect(extractLinkedInEmbeds(content)).toEqual({
+      text: 'Here is the complete post.',
+      embeds: [{
+        url: 'https://www.linkedin.com/embed/feed/update/urn:li:ugcPost:123?collapsed=0',
+        postUrl: 'https://www.linkedin.com/posts/jinpeng_activity-123',
+        title: 'LinkedIn embedded post',
+        width: 504,
+        height: 960,
+      }],
+    })
+  })
+
+  test.each([
+    'http://www.linkedin.com/embed/feed/update/urn:li:activity:123',
+    'https://www.linkedin.com.evil.example/embed/feed/update/urn:li:activity:123',
+    'https://evil.linkedin.com/embed/feed/update/urn:li:activity:123',
+    'https://user@www.linkedin.com/embed/feed/update/urn:li:activity:123',
+    'https://www.linkedin.com:444/embed/feed/update/urn:li:activity:123',
+    'https://www.linkedin.com/feed/update/urn:li:activity:123',
+    'https://www.linkedin.com/embed/feed/update/urn:li:activity:123?collapsed=1',
+    'https://www.linkedin.com/embed/feed/update/urn:li:activity:123?theme=dark',
+    'https://www.linkedin.com/embed/feed/update/urn:li:activity:123?collapsed=0&collapsed=0',
+  ])('rejects an untrusted or unsupported embed URL: %s', url => {
+    const result = extractLinkedInEmbeds(`Keep me\n\n${directive({ provider: 'linkedin', url })}`)
+
+    expect(result).toEqual({ text: 'Keep me', embeds: [] })
+  })
+
+  test('removes malformed transport directives without exposing them as chat text', () => {
+    const result = extractLinkedInEmbeds('Visible\n\n[[linkedin_embed]]not-json[[/linkedin_embed]]')
+
+    expect(result).toEqual({ text: 'Visible', embeds: [] })
+  })
+
+  test('bounds dimensions, defaults metadata, and de-duplicates repeated embeds', () => {
+    const payload = {
+      provider: 'linkedin',
+      url: 'https://www.linkedin.com/embed/feed/update/urn:li:share:456',
+      post_url: 'https://www.linkedin.com/in/not-a-post',
+      width: 10,
+      height: 9999,
+    }
+    const repeated = directive(payload)
+    const result = extractLinkedInEmbeds(`${repeated}\n${repeated}`)
+
+    expect(result).toEqual({
+      text: '',
+      embeds: [{
+        url: 'https://www.linkedin.com/embed/feed/update/urn:li:share:456',
+        postUrl: undefined,
+        title: 'LinkedIn post',
+        width: 280,
+        height: 1800,
+      }],
+    })
+  })
+})

--- a/components/chat/messages/linkedin-embed.test.ts
+++ b/components/chat/messages/linkedin-embed.test.ts
@@ -53,6 +53,18 @@ describe('LinkedIn embed directives', () => {
     expect(result).toEqual({ text: 'Visible', embeds: [] })
   })
 
+  test.each(['share', 'ugcPost'])('keeps a supported %s full-post link', urnType => {
+    const result = extractLinkedInEmbeds(directive({
+      provider: 'linkedin',
+      url: 'https://www.linkedin.com/embed/feed/update/urn:li:activity:123',
+      post_url: `https://www.linkedin.com/feed/update/urn:li:${urnType}:456?trackingId=abc`,
+    }))
+
+    expect(result.embeds[0].postUrl).toBe(
+      `https://www.linkedin.com/feed/update/urn:li:${urnType}:456`,
+    )
+  })
+
   test('bounds dimensions, defaults metadata, and de-duplicates repeated embeds', () => {
     const payload = {
       provider: 'linkedin',

--- a/components/chat/messages/linkedin-embed.tsx
+++ b/components/chat/messages/linkedin-embed.tsx
@@ -1,0 +1,145 @@
+export interface LinkedInEmbedData {
+  url: string
+  postUrl?: string
+  title: string
+  width: number
+  height: number
+}
+
+const DIRECTIVE_PATTERN = /\[\[linkedin_embed\]\]([\s\S]*?)\[\[\/linkedin_embed\]\]/g
+const EMBED_PATH = /^\/embed\/feed\/update\/urn:li:(activity|share|ugcPost):\d+\/?$/i
+const ACTIVITY_PATH = /^\/feed\/update\/urn:li:activity:\d+\/?$/i
+const POST_PATH = /^\/posts\/[^/]+\/?$/i
+
+function normalizeLinkedInPostUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  try {
+    const parsed = new URL(value.trim())
+    const isLinkedInHost = parsed.hostname === 'linkedin.com' || parsed.hostname === 'www.linkedin.com'
+    const isPostPath = ACTIVITY_PATH.test(parsed.pathname) || POST_PATH.test(parsed.pathname)
+    if (
+      parsed.protocol !== 'https:'
+      || !isLinkedInHost
+      || !isPostPath
+      || parsed.port
+      || parsed.username
+      || parsed.password
+    ) return undefined
+
+    parsed.hostname = 'www.linkedin.com'
+    parsed.pathname = parsed.pathname.replace(/\/$/, '')
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function boundedDimension(value: unknown, fallback: number, minimum: number, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.max(minimum, Math.min(Math.round(value), maximum))
+}
+
+function normalizeEmbed(value: unknown): LinkedInEmbedData | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const data = value as Record<string, unknown>
+  if (data.provider !== 'linkedin' || typeof data.url !== 'string') return null
+
+  try {
+    const parsed = new URL(data.url.trim())
+    const isLinkedInHost = parsed.hostname === 'linkedin.com' || parsed.hostname === 'www.linkedin.com'
+    if (
+      parsed.protocol !== 'https:'
+      || !isLinkedInHost
+      || !EMBED_PATH.test(parsed.pathname)
+      || parsed.port
+      || parsed.username
+      || parsed.password
+    ) return null
+
+    const queryEntries = [...parsed.searchParams.entries()]
+    if (
+      queryEntries.length > 1
+      || (queryEntries.length === 1
+        && (queryEntries[0][0] !== 'collapsed' || queryEntries[0][1] !== '0'))
+    ) return null
+
+    parsed.hostname = 'www.linkedin.com'
+    parsed.pathname = parsed.pathname.replace(/\/$/, '')
+    parsed.search = queryEntries.length ? 'collapsed=0' : ''
+    parsed.hash = ''
+
+    return {
+      url: parsed.toString(),
+      postUrl: normalizeLinkedInPostUrl(data.post_url),
+      title: typeof data.title === 'string' && data.title.trim()
+        ? data.title.trim().slice(0, 160)
+        : 'LinkedIn post',
+      width: boundedDimension(data.width, 504, 280, 1200),
+      height: boundedDimension(data.height, 900, 320, 1800),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function extractLinkedInEmbeds(content: string): {
+  text: string
+  embeds: LinkedInEmbedData[]
+} {
+  const embeds: LinkedInEmbedData[] = []
+  const seen = new Set<string>()
+  const text = content.replace(DIRECTIVE_PATTERN, (_directive, raw: string) => {
+    try {
+      const embed = normalizeEmbed(JSON.parse(raw))
+      if (embed && !seen.has(embed.url)) {
+        seen.add(embed.url)
+        embeds.push(embed)
+      }
+    } catch {
+      // Directives are transport metadata. Never render malformed or untrusted payloads as text.
+    }
+    return ''
+  }).trim()
+
+  return { text, embeds }
+}
+
+export function LinkedInEmbeds({ embeds }: { embeds: LinkedInEmbedData[] }) {
+  if (!embeds.length) return null
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {embeds.map(embed => (
+        <div
+          key={embed.url}
+          className="w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
+          style={{ maxWidth: embed.width }}
+        >
+          <iframe
+            src={embed.url}
+            title={embed.title}
+            width={embed.width}
+            height={embed.height}
+            loading="lazy"
+            referrerPolicy="strict-origin-when-cross-origin"
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            className="block w-full border-0"
+          />
+          {embed.postUrl && (
+            <a
+              href={embed.postUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="block border-t border-neutral-100 px-4 py-3 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+            >
+              Open this post on LinkedIn
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/chat/messages/linkedin-embed.tsx
+++ b/components/chat/messages/linkedin-embed.tsx
@@ -8,7 +8,7 @@ export interface LinkedInEmbedData {
 
 const DIRECTIVE_PATTERN = /\[\[linkedin_embed\]\]([\s\S]*?)\[\[\/linkedin_embed\]\]/g
 const EMBED_PATH = /^\/embed\/feed\/update\/urn:li:(activity|share|ugcPost):\d+\/?$/i
-const ACTIVITY_PATH = /^\/feed\/update\/urn:li:activity:\d+\/?$/i
+const ACTIVITY_PATH = /^\/feed\/update\/urn:li:(activity|share|ugcPost):\d+\/?$/i
 const POST_PATH = /^\/posts\/[^/]+\/?$/i
 
 function normalizeLinkedInPostUrl(value: unknown): string | undefined {

--- a/components/chat/messages/rednote-media.test.tsx
+++ b/components/chat/messages/rednote-media.test.tsx
@@ -1,0 +1,159 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+import { extractRedNoteMedia, RedNoteMediaCards } from './rednote-media'
+
+function directive(payload: Record<string, unknown>): string {
+  return `[[rednote_media]]${JSON.stringify(payload)}[[/rednote_media]]`
+}
+
+function video(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'video-1',
+    kind: 'video',
+    playable: true,
+    mime_type: 'video/mp4',
+    url: 'http://localhost:8000/evidence/v1/session-1/video-1?token=video-token',
+    poster_url: 'http://localhost:8000/evidence/v1/session-1/poster-1?token=poster-token',
+    width: 720,
+    height: 1280,
+    duration_ms: 12600,
+    caption: 'RedNote video',
+    ordinal: 1,
+    ...overrides,
+  }
+}
+
+function image(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'image-1',
+    kind: 'image',
+    playable: true,
+    mime_type: 'image/png',
+    url: 'http://localhost:8000/evidence/v1/session-1/image-1?token=image-token',
+    width: 1200,
+    height: 900,
+    ordinal: 0,
+    caption: 'First RedNote image',
+    ...overrides,
+  }
+}
+
+describe('RedNote media directives', () => {
+  test('extracts a playable video and removes transport metadata from the message', () => {
+    const result = extractRedNoteMedia([
+      'Here is the selected post.',
+      directive({
+        provider: 'rednote',
+        group_id: 'group-1',
+        title: 'Morning walk',
+        author: 'Nigel',
+        post_url: 'https://rednote.com/explore/post-1?xsec_token=abc#comments',
+        items: [video()],
+        verification: {
+          url: 'http://localhost:8000/evidence/v1/session-1/proof-1?token=proof-token',
+          mime_type: 'image/png',
+          content: 'RedNote post verification screenshot.',
+        },
+      }),
+    ].join('\n\n'))
+
+    expect(result.text).toBe('Here is the selected post.')
+    expect(result.media).toEqual([{
+      groupId: 'group-1',
+      title: 'Morning walk',
+      author: 'Nigel',
+      postUrl: 'https://www.rednote.com/explore/post-1?xsec_token=abc',
+      items: [{
+        id: 'video-1',
+        kind: 'video',
+        url: 'http://localhost:8000/evidence/v1/session-1/video-1?token=video-token',
+        mimeType: 'video/mp4',
+        posterUrl: 'http://localhost:8000/evidence/v1/session-1/poster-1?token=poster-token',
+        caption: 'RedNote video',
+        width: 720,
+        height: 1280,
+        durationMs: 12600,
+        ordinal: 1,
+      }],
+      verification: {
+        url: 'http://localhost:8000/evidence/v1/session-1/proof-1?token=proof-token',
+        caption: 'RedNote post verification screenshot.',
+      },
+    }])
+  })
+
+  test('renders native playback controls, poster, source, and post link', () => {
+    const { media } = extractRedNoteMedia(directive({
+      provider: 'rednote',
+      group_id: 'group-1',
+      title: 'Playable post',
+      post_url: 'https://www.rednote.com/explore/post-1',
+      items: [video()],
+    }))
+    const markup = renderToStaticMarkup(<RedNoteMediaCards media={media} />)
+
+    expect(markup).toContain('<video controls=""')
+    expect(markup).toContain('poster="http://localhost:8000/evidence/v1/session-1/poster-1?token=poster-token"')
+    expect(markup).toContain('<source src="http://localhost:8000/evidence/v1/session-1/video-1?token=video-token" type="video/mp4"/>')
+    expect(markup).toContain('Open this post on RedNote')
+  })
+
+  test('keeps image and video items in ordinal order and renders the verification image', () => {
+    const { media } = extractRedNoteMedia(directive({
+      provider: 'rednote',
+      group_id: 'mixed-post',
+      items: [video(), image()],
+      verification: {
+        url: 'http://localhost:8000/evidence/v1/session-1/proof-1?token=proof-token',
+        mime_type: 'image/webp',
+        content: 'Proof after opening the post',
+      },
+    }))
+
+    expect(media[0].items.map(item => item.kind)).toEqual(['image', 'video'])
+    const markup = renderToStaticMarkup(<RedNoteMediaCards media={media} />)
+    expect(markup.indexOf('image-token')).toBeLessThan(markup.indexOf('video-token'))
+    expect(markup).toContain('alt="First RedNote image"')
+    expect(markup).toContain('Verification screenshot')
+    expect(markup).toContain('alt="Proof after opening the post"')
+  })
+
+  test('renders an image-only post instead of dropping its card', () => {
+    const result = extractRedNoteMedia(directive({
+      provider: 'rednote',
+      group_id: 'image-post',
+      title: 'Photo post',
+      items: [image()],
+    }))
+
+    expect(result.media).toHaveLength(1)
+    expect(renderToStaticMarkup(<RedNoteMediaCards media={result.media} />)).toContain('<img')
+  })
+
+  test.each([
+    video({ url: 'https://example.com/video.mp4?token=abc' }),
+    video({ url: 'javascript:alert(1)' }),
+    video({ url: 'http://user@localhost:8000/evidence/v1/session/video?token=abc' }),
+    video({ playable: false }),
+    video({ kind: 'audio' }),
+    image({ mime_type: 'image/svg+xml' }),
+  ])('rejects an unsafe or non-playable media item', item => {
+    const result = extractRedNoteMedia(`Keep me\n${directive({
+      provider: 'rednote',
+      items: [item],
+    })}`)
+
+    expect(result).toEqual({ text: 'Keep me', media: [] })
+  })
+
+  test('drops malformed directives and ignores duplicate videos', () => {
+    const valid = directive({
+      provider: 'rednote',
+      group_id: 'group-1',
+      items: [video(), video()],
+    })
+    expect(extractRedNoteMedia(`Visible\n[[rednote_media]]bad-json[[/rednote_media]]`))
+      .toEqual({ text: 'Visible', media: [] })
+    expect(extractRedNoteMedia(valid).media[0].items).toHaveLength(1)
+  })
+})

--- a/components/chat/messages/rednote-media.tsx
+++ b/components/chat/messages/rednote-media.tsx
@@ -1,0 +1,255 @@
+export interface RedNoteMediaItem {
+  id: string
+  kind: 'image' | 'video'
+  url: string
+  mimeType: string
+  posterUrl?: string
+  caption: string
+  width: number
+  height: number
+  durationMs?: number
+  ordinal: number
+}
+
+export interface RedNoteVerification {
+  url: string
+  caption: string
+}
+
+export interface RedNoteMediaData {
+  groupId: string
+  title: string
+  author?: string
+  postUrl?: string
+  items: RedNoteMediaItem[]
+  verification?: RedNoteVerification
+}
+
+const DIRECTIVE_PATTERN = /\[\[rednote_media\]\]([\s\S]*?)\[\[\/rednote_media\]\]/g
+const EVIDENCE_PATH = /^\/evidence\/v1\/[^/]+\/[^/]+\/?$/
+const POST_PATH = /^\/explore\/[^/]+\/?$/
+const IMAGE_TYPES = new Set(['image/gif', 'image/jpeg', 'image/png', 'image/webp'])
+const VIDEO_TYPES = new Set(['video/mp4', 'video/webm'])
+
+function shortText(value: unknown, fallback: string, maxLength: number): string {
+  return typeof value === 'string' && value.trim()
+    ? value.trim().slice(0, maxLength)
+    : fallback
+}
+
+function boundedNumber(value: unknown, fallback: number, minimum: number, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.max(minimum, Math.min(Math.round(value), maximum))
+}
+
+function normalizeEvidenceUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  try {
+    const parsed = new URL(value.trim())
+    const queryEntries = [...parsed.searchParams.entries()]
+    if (
+      !['http:', 'https:'].includes(parsed.protocol)
+      || !EVIDENCE_PATH.test(parsed.pathname)
+      || parsed.username
+      || parsed.password
+      || queryEntries.length !== 1
+      || queryEntries[0][0] !== 'token'
+      || !queryEntries[0][1]
+    ) return undefined
+
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function normalizePostUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  try {
+    const parsed = new URL(value.trim())
+    const trustedHost = parsed.hostname === 'rednote.com' || parsed.hostname === 'www.rednote.com'
+    if (
+      parsed.protocol !== 'https:'
+      || !trustedHost
+      || !POST_PATH.test(parsed.pathname)
+      || parsed.port
+      || parsed.username
+      || parsed.password
+    ) return undefined
+
+    parsed.hostname = 'www.rednote.com'
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeMediaItem(value: unknown, index: number): RedNoteMediaItem | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const item = value as Record<string, unknown>
+  const url = normalizeEvidenceUrl(item.url)
+  const mimeType = typeof item.mime_type === 'string' ? item.mime_type.trim().toLowerCase() : ''
+  const kind = item.kind === 'video' ? 'video' : item.kind === 'image' ? 'image' : null
+  const validType = kind === 'video' ? VIDEO_TYPES.has(mimeType) : IMAGE_TYPES.has(mimeType)
+  if (!url || !kind || !validType || (kind === 'video' && item.playable !== true)) {
+    return null
+  }
+
+  return {
+    id: shortText(item.id, `${kind}-${index + 1}`, 160),
+    kind,
+    url,
+    mimeType,
+    posterUrl: normalizeEvidenceUrl(item.poster_url),
+    caption: shortText(item.caption, 'RedNote video', 240),
+    width: boundedNumber(item.width, 720, 160, 3840),
+    height: boundedNumber(item.height, 1280, 160, 3840),
+    durationMs: typeof item.duration_ms === 'number' && Number.isFinite(item.duration_ms)
+      ? Math.max(0, Math.round(item.duration_ms))
+      : undefined,
+    ordinal: boundedNumber(item.ordinal, index, 0, 10_000),
+  }
+}
+
+function normalizeVerification(value: unknown): RedNoteVerification | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const data = value as Record<string, unknown>
+  const url = normalizeEvidenceUrl(data.url)
+  const mimeType = typeof data.mime_type === 'string' ? data.mime_type.trim().toLowerCase() : ''
+  if (!url || !IMAGE_TYPES.has(mimeType)) return undefined
+  return {
+    url,
+    caption: shortText(data.content, 'RedNote post verification screenshot', 240),
+  }
+}
+
+function normalizeMedia(value: unknown): RedNoteMediaData | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const data = value as Record<string, unknown>
+  if (data.provider !== 'rednote' || !Array.isArray(data.items)) return null
+
+  const seen = new Set<string>()
+  const items = data.items
+    .slice(0, 8)
+    .map(normalizeMediaItem)
+    .filter((item): item is RedNoteMediaItem => {
+      if (!item || seen.has(item.url)) return false
+      seen.add(item.url)
+      return true
+    })
+    .sort((left, right) => left.ordinal - right.ordinal)
+  if (!items.length) return null
+
+  return {
+    groupId: shortText(data.group_id, items[0].id, 160),
+    title: shortText(data.title, 'RedNote post', 240),
+    author: typeof data.author === 'string' && data.author.trim()
+      ? data.author.trim().slice(0, 160)
+      : undefined,
+    postUrl: normalizePostUrl(data.post_url),
+    items,
+    verification: normalizeVerification(data.verification),
+  }
+}
+
+export function extractRedNoteMedia(content: string): {
+  text: string
+  media: RedNoteMediaData[]
+} {
+  const media: RedNoteMediaData[] = []
+  const seen = new Set<string>()
+  const text = content.replace(DIRECTIVE_PATTERN, (_directive, raw: string) => {
+    try {
+      const normalized = normalizeMedia(JSON.parse(raw))
+      if (normalized) {
+        const key = `${normalized.groupId}:${normalized.items.map(item => item.url).join('|')}`
+        if (!seen.has(key)) {
+          seen.add(key)
+          media.push(normalized)
+        }
+      }
+    } catch {
+      // This block carries display metadata and should never appear as chat text.
+    }
+    return ''
+  }).trim()
+
+  return { text, media }
+}
+
+export function RedNoteMediaCards({ media }: { media: RedNoteMediaData[] }) {
+  if (!media.length) return null
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {media.map(card => (
+        <section
+          key={`${card.groupId}:${card.items[0].url}`}
+          className="w-full max-w-lg overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
+        >
+          <div className="border-b border-neutral-100 px-4 py-3">
+            <h3 className="text-sm font-semibold text-neutral-900">{card.title}</h3>
+            {card.author && <p className="mt-0.5 text-xs text-neutral-500">{card.author}</p>}
+          </div>
+          <div className="flex flex-col gap-px bg-neutral-100">
+            {card.items.map(item => item.kind === 'video' ? (
+                <video
+                  key={item.url}
+                  controls
+                  playsInline
+                  preload="metadata"
+                  poster={item.posterUrl}
+                  aria-label={item.caption}
+                  className="block max-h-[36rem] w-full bg-black object-contain"
+                  style={{ aspectRatio: `${item.width} / ${item.height}` }}
+                >
+                  <source src={item.url} type={item.mimeType} />
+                  Your browser does not support video playback.
+                </video>
+              ) : (
+                // This URL is a signed server evidence asset, so Next image optimisation is not used.
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={item.url}
+                  src={item.url}
+                  alt={item.caption}
+                  loading="lazy"
+                  className="block max-h-[36rem] w-full bg-white object-contain"
+                  style={{ aspectRatio: `${item.width} / ${item.height}` }}
+                />
+              ))}
+          </div>
+          {card.verification && (
+            <details className="border-t border-neutral-100 px-4 py-3">
+              <summary className="cursor-pointer text-xs font-medium text-neutral-600">
+                Verification screenshot
+              </summary>
+              {/* This is a signed, short-lived server evidence URL. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={card.verification.url}
+                alt={card.verification.caption}
+                loading="lazy"
+                className="mt-3 max-h-80 w-full rounded-lg border border-neutral-200 object-contain"
+              />
+            </details>
+          )}
+          {card.postUrl && (
+            <a
+              href={card.postUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="block border-t border-neutral-100 px-4 py-3 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+            >
+              Open this post on RedNote
+            </a>
+          )}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/components/chat/messages/tools/ask-user-card.tsx
+++ b/components/chat/messages/tools/ask-user-card.tsx
@@ -19,6 +19,7 @@ import {
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import { ASK_USER_SKIP_ANSWER, SkipButton } from '../../ask-user-skip'
+import { normalizeAskUserOptions, type AskUserOption } from '../../ask-user-options'
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -49,21 +50,26 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
 
   const question = (args?.question as string) || ''
   const isPending = !!pendingAskUser && !!onAskUserResponse && status === 'running' && !responded
-  const options = pendingAskUser?.options
+  const options = normalizeAskUserOptions(
+    pendingAskUser?.options,
+    pendingAskUser?.disabled_options,
+  )
   const multiSelect = pendingAskUser?.multi_select
-  const isQr = !!qrImage && !!(options && options.length) && /scan|qr|二维码|扫码/i.test(`${question} ${(options || []).join(' ')}`)
+  const hasOptions = options.length > 0
+  const hasDisabledOptions = options.some(option => option.disabled)
+  const isQr = !!qrImage && hasOptions && /scan|qr|二维码|扫码/i.test(`${question} ${options.map(option => option.label).join(' ')}`)
 
-  const handleOptionClick = (option: string) => {
-    if (!isPending) return
+  const handleOptionClick = (option: AskUserOption) => {
+    if (!isPending || option.disabled) return
     if (multiSelect) {
       setSelected(prev =>
-        prev.includes(option)
-          ? prev.filter(o => o !== option)
-          : [...prev, option]
+        prev.includes(option.value)
+          ? prev.filter(o => o !== option.value)
+          : [...prev, option.value]
       )
     } else {
       setResponded(true)
-      onAskUserResponse!(option)
+      onAskUserResponse!(option.value)
     }
   }
 
@@ -187,13 +193,14 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                       <p className="text-[11px] text-neutral-400">Click to enlarge</p>
                       {question && <p className="text-xs text-neutral-500 leading-relaxed">{question}</p>}
                       <div className="space-y-2">
-                        {(options || []).map((option, idx) => (
+                        {options.map((option, idx) => (
                           <button
                             key={idx}
                             onClick={() => handleOptionClick(option)}
-                            className="w-full bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-bold py-2.5 rounded-xl transition-all active:scale-[0.99]"
+                            disabled={option.disabled}
+                            className="w-full bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-bold py-2.5 rounded-xl transition-all active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-neutral-200 disabled:text-neutral-400"
                           >
-                            {option}
+                            {option.label}
                           </button>
                         ))}
                         <SkipButton onSkip={handleSkip} />
@@ -214,17 +221,20 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                   Show QR code
                 </button>
               )}
-              {options && (
+              {hasOptions && (
                 <div className="grid grid-cols-1 gap-1.5">
                   {options.map((option, idx) => {
-                    const isSelected = selected.includes(option)
+                    const isSelected = selected.includes(option.value)
                     return (
                       <button
                         key={idx}
                         onClick={() => handleOptionClick(option)}
+                        disabled={option.disabled}
                         className={cn(
                           "w-full flex items-center gap-3 px-4 py-3 text-left rounded-xl transition-all duration-200 border group/item",
-                          isSelected
+                          option.disabled
+                            ? "cursor-not-allowed border-neutral-200 bg-neutral-100 text-neutral-400 opacity-75"
+                            : isSelected
                             ? "bg-neutral-100 text-neutral-900 border-neutral-400 shadow-sm"
                             : "bg-white text-neutral-700 border-neutral-200 hover:border-neutral-400 hover:bg-neutral-50"
                         )}
@@ -244,7 +254,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                           "text-sm",
                           isSelected ? "font-semibold" : "font-medium text-neutral-600"
                         )}>
-                          {option}
+                          {option.label}
                         </span>
                       </button>
                     )
@@ -265,8 +275,8 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
               )}
 
               {/* Input Fallback (always show or show if no options) */}
-              <div className="space-y-2">
-                {options && (
+              {!hasDisabledOptions && <div className="space-y-2">
+                {hasOptions && (
                   <div className="flex items-center gap-2 px-1">
                     <div className="h-px flex-1 bg-neutral-100" />
                     <span className="text-[11px] font-bold text-neutral-400 uppercase tracking-wide">Or provide custom answer</span>
@@ -280,7 +290,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                     value={textInput}
                     onChange={(e) => setTextInput(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    placeholder={options ? "Something else..." : "Type your answer..."}
+                    placeholder={hasOptions ? "Something else..." : "Type your answer..."}
                     className="flex-1 bg-transparent px-3 py-2 text-sm focus:outline-none placeholder:text-neutral-400 font-medium"
                     autoFocus={!options}
                   />
@@ -294,7 +304,7 @@ export function AskUserCard({ toolCall, pendingAskUser, onAskUserResponse, qrIma
                   </button>
                 </div>
                 <SkipButton onSkip={handleSkip} />
-              </div>
+              </div>}
               </>
               )}
             </div>

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -56,6 +56,7 @@ export interface Message {
 export interface PendingAskUser {
   question: string
   options: string[]
+  disabled_options?: string[]
   multi_select: boolean
   input_type?: string
   fields?: AskUserField[]

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -94,9 +94,15 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
       }
       const toolStatus = toolStatuses.get('ask_user')
       if (toolStatus === 'running' || toolStatus === undefined) {
+        const disabledOptions = (
+          item as unknown as { disabled_options?: unknown }
+        ).disabled_options
         pendingAskUser = {
           question: typeof item.text === 'string' ? item.text : '',
           options: Array.isArray(item.options) ? item.options : [],
+          disabled_options: Array.isArray(disabledOptions)
+            ? disabledOptions.filter((option): option is string => typeof option === 'string')
+            : undefined,
           multi_select: item.multi_select === true,
           input_type: (item as { input_type?: string }).input_type,
           fields: (item as { fields?: PendingAskUser['fields'] }).fields,


### PR DESCRIPTION
Adds chat rendering for allowlisted LinkedIn posts, RedNote image and video cards, and verification screenshots. Disabled choices now stay visible without accepting clicks or showing the custom input.

Checks completed:
- npm test (93 passed)
- npm run lint
- npm exec tsc -- --noEmit