### PR TITLE
test: verify React-owned ACP approvals

### DIFF
--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -206,6 +206,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     ulwTurns,
     ulwTurnsUsed,
     sendMessage,
+    respondToApproval: sdkRespondToApproval,
     signOnboard,
     setMode: sdkSetMode,
     reconnect: sdkReconnect,
@@ -332,8 +333,8 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   }, [sendMessage])
 
   const respondToApproval = useCallback((approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => {
-    sendMessage({ type: 'APPROVAL_RESPONSE', approved, scope, ...(mode && { mode }), ...(feedback && { feedback }) })
-  }, [sendMessage])
+    sdkRespondToApproval(approved, scope, mode, feedback)
+  }, [sdkRespondToApproval])
 
   const respondToPlanReview = useCallback((message: string) => {
     sendMessage({ type: 'PLAN_REVIEW_RESPONSE', message })

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -21,35 +21,49 @@ import { test, expect } from './fixtures'
 import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
 /** Get to a parked approval prompt with a scary command behind it. */
-async function atAnApproval(page: import('@playwright/test').Page) {
-  const agent = await mockAgent(page, 'approval')
+async function atAnApproval(
+  page: import('@playwright/test').Page,
+  scenario: 'approval' | 'legacy-approval' = 'approval',
+) {
+  const agent = await mockAgent(page, scenario)
   await page.goto(`/${AGENT_ADDRESS}`)
   await page.getByRole('button', { name: 'What can you do?' }).click()
   await expect(page.getByRole('button', { name: /allow once/i })).toBeVisible({ timeout: 20_000 })
   return agent
 }
 
-/** label → the frame the agent must receive. */
-const DECISIONS: [RegExp, Record<string, unknown>][] = [
-  [/allow once/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }],
-  [/trust/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'session' }],
-  [/reject/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_soft' }],
-  [/stop/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_hard' }],
-  [/explain/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_explain' }],
+/** label → the ACP option the agent must receive. */
+const DECISIONS: [RegExp, string][] = [
+  [/allow once/i, 'allow_once'],
+  [/trust/i, 'allow_session'],
+  [/reject/i, 'reject_soft'],
+  [/stop/i, 'reject_hard'],
+  [/explain/i, 'reject_explain'],
 ]
+
+const acpResponse = (optionId: string, sessionId: string) => ({
+  type: 'ACP_RESPONSE',
+  acpSchema: 'schema-v1.19.0',
+  sessionId,
+  message: {
+    jsonrpc: '2.0',
+    id: 'approval-event-1',
+    result: { outcome: { outcome: 'selected', optionId } },
+  },
+})
 
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  for (const [label, frame] of DECISIONS) {
+  for (const [label, optionId] of DECISIONS) {
     test(`"${label.source}" sends exactly what it promises`, async ({ page }) => {
       const agent = await atAnApproval(page)
 
       await page.getByRole('button', { name: label }).first().click()
 
       await expect
-        .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
-        .toEqual([frame])
+        .poll(() => agent.sent('ACP_RESPONSE'), { timeout: 10_000 })
+        .toEqual([acpResponse(optionId, agent.sessionId())])
     })
   }
 
@@ -60,7 +74,7 @@ test.describe('phone', () => {
     // client on its own — a retry, an effect firing twice — would be the agent
     // being told "yes" by nobody.
     await page.waitForTimeout(3000)
-    expect(agent.sent('APPROVAL_RESPONSE'), 'an answer was sent without anyone pressing anything').toEqual([])
+    expect(agent.sent('ACP_RESPONSE'), 'an answer was sent without anyone pressing anything').toEqual([])
 
     await shot('parked')
   })
@@ -75,7 +89,17 @@ test.describe('phone', () => {
     await allow.click({ force: true, timeout: 2000 }).catch(() => {})
 
     await page.waitForTimeout(2000)
-    expect(agent.sent('APPROVAL_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
+    expect(agent.sent('ACP_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
+  })
+
+  test('a legacy-only Host still receives one legacy response', async ({ page }) => {
+    const agent = await atAnApproval(page, 'legacy-approval')
+
+    await page.getByRole('button', { name: /allow once/i }).first().click()
+
+    await expect
+      .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
+      .toEqual([{ type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }])
   })
 })
 

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -50,6 +50,42 @@ export const DASHBOARD_HTML =
 const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
   ws.send(JSON.stringify(frame))
 
+const approvalEvent = {
+  id: 'approval-event-1',
+  tool_call_id: 'call-1',
+  tool: 'bash:uname',
+  arguments: { command: 'uname -a' },
+  description: 'Run `uname -a`',
+}
+
+function sendAcpApproval(ws: WebSocketRoute, sessionId: string) {
+  send(ws, {
+    type: 'ACP_REQUEST',
+    acpSchema: 'schema-v1.19.0',
+    message: {
+      jsonrpc: '2.0',
+      id: approvalEvent.id,
+      method: 'session/request_permission',
+      params: {
+        sessionId,
+        toolCall: {
+          toolCallId: approvalEvent.tool_call_id,
+          title: approvalEvent.tool,
+          status: 'pending',
+          rawInput: approvalEvent.arguments,
+        },
+        options: [
+          { optionId: 'allow_once', name: 'Allow this call', kind: 'allow_once' },
+          { optionId: 'allow_session', name: 'Allow for this session', kind: 'allow_always' },
+          { optionId: 'reject_soft', name: 'Reject this call and continue', kind: 'reject_once' },
+          { optionId: 'reject_hard', name: 'Reject and stop this turn', kind: 'reject_once' },
+          { optionId: 'reject_explain', name: 'Reject and explain first', kind: 'reject_once' },
+        ],
+      },
+    },
+  })
+}
+
 /**
  * Intercept every relay socket and play `scenario`.
  *
@@ -71,6 +107,7 @@ export async function mockAgent(
    *  down and reopened behind the reader — the screen looks identical either way,
    *  which is what makes a screen-level assertion about it vacuous. */
   let connects = 0
+  let sessionId = 'e2e-session'
   /** Every frame the client sent. The approval buttons differ only in the frame
    *  they produce — the UI is identical whichever one is wired to which — so the
    *  wire is the only place that difference is observable. */
@@ -81,7 +118,11 @@ export async function mockAgent(
   // the agent's own endpoint for a direct one — and the test should not care.
   await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
     ws.onMessage(raw => {
-      const msg = JSON.parse(String(raw)) as { type: string; prompt?: string }
+      const msg = JSON.parse(String(raw)) as {
+        type: string
+        prompt?: string
+        session_id?: string
+      }
       sent.push(msg)
 
       // An offline agent answers nothing. Replying to CONNECT with a profile is
@@ -104,7 +145,8 @@ export async function mockAgent(
           return
         }
         connects += 1
-        send(ws, { type: 'CONNECTED', session_id: 'e2e-session', status: 'idle' })
+        sessionId = msg.session_id || sessionId
+        send(ws, { type: 'CONNECTED', session_id: sessionId, status: 'idle' })
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
@@ -184,7 +226,7 @@ export async function mockAgent(
 
       send(ws, { type: 'thinking', id: 't1', status: 'running' })
 
-      if (scenario === 'tools' || scenario === 'approval' || scenario === 'dashboard-approval') {
+      if (scenario === 'tools' || scenario === 'approval' || scenario === 'legacy-approval' || scenario === 'dashboard-approval') {
         send(ws, {
           type: 'tool_call',
           id: 'call-1',
@@ -199,22 +241,23 @@ export async function mockAgent(
         // while the reader is looking at Home, which means the test needs time to
         // switch panes before it lands. An approval that is already on screen when
         // you get there proves nothing about being told.
-        setTimeout(() => send(ws, {
-          type: 'approval_needed',
-          tool: 'bash:uname',
-          description: 'Run `uname -a`',
-        }), 5000)
+        setTimeout(() => {
+          sendAcpApproval(ws, sessionId)
+          send(ws, { type: 'approval_needed', ...approvalEvent })
+        }, 5000)
         return
       }
 
       if (scenario === 'approval') {
         // The run parks here: no OUTPUT until the reader answers. That is the state
         // the approval card exists for, and the one worth a screenshot.
-        send(ws, {
-          type: 'approval_needed',
-          tool: 'bash:uname',
-          description: 'Run `uname -a`',
-        })
+        sendAcpApproval(ws, sessionId)
+        send(ws, { type: 'approval_needed', ...approvalEvent })
+        return
+      }
+
+      if (scenario === 'legacy-approval') {
+        send(ws, { type: 'approval_needed', ...approvalEvent })
         return
       }
 
@@ -341,6 +384,8 @@ export async function mockAgent(
     connects: () => connects,
     /** Frames of one type, in order. */
     sent: (type: string) => sent.filter(f => f.type === type),
+    /** Session identity the Host echoed from CONNECT. */
+    sessionId: () => sessionId,
   }
 }
 


### PR DESCRIPTION
## Summary\n\n- delegate O Chat approval decisions to the React SDK instead of constructing protocol frames\n- verify every ACP permission option on the browser wire\n- verify no automatic answer, one-shot double-tap behavior, Host session identity, and legacy-only fallback\n- keep O Chat protocol-free: ACP decoding and response encoding remain in @connectonion/react\n\nCloses #129.\n\n## Design\n\nThis follows the ownership decision recorded in #129 and the merged carrier work:\n\n- Host: openonion/connectonion#873\n- React protocol layer: openonion/connectonion-react#16\n- React identity and replay fix: openonion/connectonion-react#17\n\nThe standalone TypeScript SDK is not part of this path.\n\n## Verification\n\n- npm test: 65 passed\n- npm run lint: passed\n- npm run build: passed\n- production Playwright approval target against the packed React changes: 14 passed\n- packed dependency used for E2E: @connectonion/react 0.3.3 built from the merged React branch\n\n## Merge blocker\n\nDraft until the React ACP API is published under a new package version and this PR pins or ranges to that released version. The current registry 0.3.3 does not expose respondToApproval, so merging before publication would make a clean install fail.