### PR TITLE
feat: delegate Stop to @connectonion/react

### DIFF
--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -206,6 +206,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     ulwTurns,
     ulwTurnsUsed,
     sendMessage,
+    interrupt: sdkInterrupt,
     signOnboard,
     setMode: sdkSetMode,
     reconnect: sdkReconnect,
@@ -313,19 +314,16 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     input(content, { images, files })
   }, [input])
 
-  // Stop: the UI stops immediately (optimistic — spinners freeze, the input
-  // returns to send mode), while the agent-side poll_interrupt handler drains
-  // the INTERRUPT at the next iteration boundary, finishes the current step,
-  // and returns a closing message that reconciles the transcript.
-  // The INTERRUPT frame is only sent on a live socket (RemoteAgent.send throws
-  // on a null socket), but the optimistic UI stop applies regardless, so a
-  // restored session stuck showing "running" can also be dismissed.
+  // Stop is a product action here; the React SDK owns capability negotiation,
+  // session binding, pending-permission cancellation, and legacy fallback.
+  // Keep the optimistic UI behavior even when a restored session has no live
+  // socket, so a stale "running" state can still be dismissed.
   const interrupt = useCallback(() => {
     setStopRequested(true)
     if (connectionState === 'connected') {
-      sendMessage({ type: 'INTERRUPT' })
+      sdkInterrupt()
     }
-  }, [sendMessage, connectionState])
+  }, [sdkInterrupt, connectionState])
 
   const respondToAskUser = useCallback((answer: string | string[]) => {
     sendMessage({ type: 'ASK_USER_RESPONSE', answer: Array.isArray(answer) ? answer.join(', ') : answer })

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,9 @@ exists as of `connectonion@0.3.0`.
    turns each into a `ChatItem`; oo-chat renders each as a row.
 5. If the agent needs you (approve a command, answer a question, review a plan), the
    run pauses and a card appears; your reply goes back over the same socket.
-6. When the turn ends, the SDK has already saved the transcript to localStorage.
+6. If you press Stop, oo-chat updates the UI immediately and calls the SDK's
+   `interrupt()` operation. The SDK owns session binding and protocol selection.
+7. When the turn ends, the SDK has already saved the transcript to localStorage.
    Reload restores it instantly; the socket reconnects only when you send again.
 
 ## Two ideas that explain the rest
@@ -220,6 +222,11 @@ events until `OUTPUT` settles the turn. `PING`/`PONG` keep the socket alive.
 Switching mode mid-run sends `mode_change`. `SESSION_STATUS` checks whether a session
 is still alive on the relay. `DASHBOARD_SNAPSHOT { html }` carries the agent's Home page
 — sent right after `CONNECTED`, and again after a run that changed the file.
+
+Stopping a turn is deliberately not a wire concern in oo-chat. The app calls
+`interrupt()` and updates its optimistic presentation; `@connectonion/react` selects
+negotiated ACP `session/cancel` or the one-shot legacy fallback. Application code must
+not construct either cancellation frame.
 
 **SDK persistence details:** before writing, the SDK strips base64 data URLs (images)
 so a conversation can't blow the ~5MB quota; it keeps the 20 most-recent sessions and

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -12,8 +12,8 @@ out in `connectonion@0.3.0` and that subpath no longer exists. If you are about 
 `from 'connectonion/react'`, that is the old shape — use `@connectonion/react`.
 
 A React SDK change only reaches production once it is published to npm and oo-chat is
-bumped to that version. The standalone TypeScript client has its own non-React consumers
-and is not part of this deployment chain.
+bumped to that version. The standalone TypeScript client is retired and is not part of
+this deployment chain; do not add it back as a fallback or parallel protocol owner.
 
 ## The dependency, two ways
 

--- a/e2e/cancellation.spec.ts
+++ b/e2e/cancellation.spec.ts
@@ -1,0 +1,46 @@
+/** Stop is an application action whose wire behavior belongs to @connectonion/react. */
+
+import { type Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+async function atARunningTurn(
+  page: Page,
+  scenario: 'cancel-acp' | 'cancel-legacy',
+) {
+  const agent = await mockAgent(page, scenario)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(page.getByRole('button', { name: 'Stop agent' })).toBeVisible({
+    timeout: 20_000,
+  })
+  return agent
+}
+
+test('Stop delegates negotiated ACP cancellation to the React package', async ({ page }) => {
+  const agent = await atARunningTurn(page, 'cancel-acp')
+
+  await page.getByRole('button', { name: 'Stop agent' }).click()
+
+  await expect.poll(() => agent.sent('ACP_NOTIFICATION')).toEqual([{
+    type: 'ACP_NOTIFICATION',
+    acpSchema: 'schema-v1.19.0',
+    message: {
+      jsonrpc: '2.0',
+      method: 'session/cancel',
+      params: { sessionId: 'e2e-session' },
+    },
+  }])
+  expect(agent.sent('INTERRUPT')).toEqual([])
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeVisible()
+})
+
+test('Stop keeps the React package legacy fallback for an old Host', async ({ page }) => {
+  const agent = await atARunningTurn(page, 'cancel-legacy')
+
+  await page.getByRole('button', { name: 'Stop agent' }).click()
+
+  await expect.poll(() => agent.sent('INTERRUPT')).toEqual([{ type: 'INTERRUPT' }])
+  expect(agent.sent('ACP_NOTIFICATION')).toEqual([])
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeVisible()
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns' | 'cancel-acp' | 'cancel-legacy'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -104,7 +104,19 @@ export async function mockAgent(
           return
         }
         connects += 1
-        send(ws, { type: 'CONNECTED', session_id: 'e2e-session', status: 'idle' })
+        send(ws, {
+          type: 'CONNECTED',
+          session_id: 'e2e-session',
+          status: 'idle',
+          ...(scenario === 'cancel-acp' && {
+            carrier_capabilities: {
+              acp: {
+                schema: 'schema-v1.19.0',
+                client_notifications: ['session/cancel'],
+              },
+            },
+          }),
+        })
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         // Pushed on connect for agents that ship one. Its arrival is what flips
         // hasDashboard, which is what splits the workspace in two.
@@ -119,6 +131,13 @@ export async function mockAgent(
       }
 
       if (msg.type !== 'INPUT') return
+
+      // Keep a turn running until the test presses Stop. The mock records the
+      // resulting client frame above; React, not oo-chat, decides its protocol.
+      if (scenario === 'cancel-acp' || scenario === 'cancel-legacy') {
+        send(ws, { type: 'thinking', id: 't1', status: 'running' })
+        return
+      }
 
       // Credit is spent while the run goes on. The agent republishes its profile
       // with the new balance, which is the only way the reader learns before it


### PR DESCRIPTION
Closes #131.

## Summary

- delegate the O Chat Stop action to `useAgentForHuman().interrupt()`
- preserve O Chats immediate optimistic stop presentation and disconnected restored-session dismissal
- keep ACP capability negotiation, session identity, pending-permission cancellation, one-shot behavior, and legacy fallback inside `@connectonion/react`
- add browser-level assertions for an ACP-capable Host and an old Host
- correct the remaining deploy-doc statement: the standalone TypeScript client is retired and must not return as a parallel protocol owner

## Architecture

The frontend path is Host → `@connectonion/react` → O Chat. Production O Chat constructs no ACP cancellation or legacy interrupt frame. Host support landed in openonion/connectonion#880; the React operation landed in openonion/connectonion-react#19.

## Verification against the packed React package

- O Chat unit suite: 7 files / 65 tests passed
- ESLint passed
- Next production build with webpack passed, including TypeScript and static generation
- targeted Playwright: 2/2 passed against the packed React artifact
  - exact ACP `session/cancel`, with no legacy dual-send
  - one legacy `INTERRUPT` for an old Host, with no ACP dual-send
  - both preserve immediate Send-button recovery
- npm audit: 0 vulnerabilities
- `git diff --check` passed

The default local Turbopack build cannot bind its CSS worker port in this sandbox (`Operation not permitted`); the webpack production build completed.

## Draft blocker — do not merge yet

`@connectonion/react` has not been published with #19. Before this PR can leave Draft:

1. publish the agreed React prerelease (recommended `0.4.0-alpha.1`; no release is performed by this PR)
2. pin that exact registry version in `package.json` and `package-lock.json`
3. confirm the lockfile resolves a registry tarball, not a local path
4. require the Vercel preview/build and Playwright checks to pass
5. repeat final code/security review

Until then, CI against the currently locked published package may report the expected missing `interrupt` API.