### PR TITLE
Render React-normalized ACP plan state

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -40,6 +40,7 @@
 import { useEffect, useCallback, useMemo, useRef, useState } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Chat, useAgentSDK, ModeStatusBar, PlanModeBanner, UlwModeBanner } from '@/components/chat'
+import { CurrentPlanPanel } from '@/components/current-plan-panel'
 import { WorkspaceShell } from '@/components/dashboard/workspace-shell'
 import { DashboardPane } from '@/components/dashboard/dashboard-pane'
 import type { UI, ApprovalMode } from '@/components/chat/types'
@@ -116,6 +117,7 @@ export default function ChatSessionPage() {
 
   const {
     ui: hookUI,
+    currentPlan,
     isLoading,
     pendingAskUser,
     pendingApproval,
@@ -296,6 +298,8 @@ export default function ChatSessionPage() {
         {isUlwActive && (
           <UlwModeBanner turnsRemaining={ulwTurnsRemaining} onExit={() => setMode('safe')} />
         )}
+
+        <CurrentPlanPanel entries={currentPlan} />
 
         {/* Chat with mode status bar (ULW toggle integrated) */}
         <Chat

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -1,7 +1,13 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-import { useAgentForHuman, type AgentInfo, type ChatItem, type ApprovalMode } from '@connectonion/react'
+import {
+  useAgentForHuman,
+  type AgentInfo,
+  type ApprovalMode,
+  type ChatItem,
+  type PlanEntry,
+} from '@connectonion/react'
 import type { PendingAskUser, PendingApproval, PendingOnboard, PendingUlwTurnsReached, PendingPlanReview } from './types'
 import { dedupeUI } from './dedupe-ui'
 
@@ -28,6 +34,8 @@ interface CurrentSession {
 
 interface UseAgentSDKReturn {
   ui: ChatItem[]
+  /** Current session's complete, observational plan snapshot. */
+  currentPlan: ReadonlyArray<PlanEntry>
   isConnected: boolean
   isLoading: boolean
   pendingAskUser: PendingAskUser | null
@@ -197,6 +205,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     status,
     connectionState,
     ui,
+    plan: currentPlan,
     input,
     reset,
     isProcessing,
@@ -375,6 +384,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
 
   return {
     ui: cleanUI,
+    currentPlan,
     isConnected,
     isLoading,
     pendingAskUser,

--- a/components/current-plan-panel.test.tsx
+++ b/components/current-plan-panel.test.tsx
@@ -1,0 +1,59 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PlanEntry } from '@connectonion/react'
+import { CurrentPlanPanel } from './current-plan-panel'
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function render(entries: ReadonlyArray<PlanEntry>) {
+  if (!container) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  }
+  act(() => root!.render(<CurrentPlanPanel entries={entries} />))
+  return container
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+describe('CurrentPlanPanel', () => {
+  it('shows every ACP status and priority as accessible text', () => {
+    const element = render([
+      { content: 'Inspect history', status: 'pending', priority: 'high' },
+      { content: 'Implement change', status: 'in_progress', priority: 'medium' },
+      { content: 'Review code', status: 'completed', priority: 'low' },
+    ])
+
+    expect(element.querySelector('[aria-label="Current plan"]')).not.toBeNull()
+    expect(element.textContent).toContain('Pending')
+    expect(element.textContent).toContain('In progress')
+    expect(element.textContent).toContain('Completed')
+    expect(element.textContent).toContain('High priority')
+    expect(element.textContent).toContain('Medium priority')
+    expect(element.textContent).toContain('Low priority')
+    expect(element.querySelectorAll('button')).toHaveLength(0)
+  })
+
+  it('replaces the whole list and removes the panel when the plan clears', () => {
+    const element = render([
+      { content: 'Old step', status: 'pending', priority: 'medium' },
+    ])
+
+    render([{ content: 'Replacement step', status: 'in_progress', priority: 'high' }])
+    expect(element.textContent).not.toContain('Old step')
+    expect(element.textContent).toContain('Replacement step')
+
+    render([])
+    expect(element.querySelector('[aria-label="Current plan"]')).toBeNull()
+  })
+})

--- a/components/current-plan-panel.tsx
+++ b/components/current-plan-panel.tsx
@@ -1,0 +1,71 @@
+import type { PlanEntry } from '@connectonion/react'
+
+const STATUS = {
+  pending: {
+    label: 'Pending',
+    dot: 'bg-neutral-300',
+    content: 'text-neutral-700',
+  },
+  in_progress: {
+    label: 'In progress',
+    dot: 'bg-brand-500',
+    content: 'font-medium text-neutral-950',
+  },
+  completed: {
+    label: 'Completed',
+    dot: 'bg-emerald-500',
+    content: 'text-neutral-500 line-through decoration-neutral-300',
+  },
+} as const
+
+const PRIORITY = {
+  high: 'High priority',
+  medium: 'Medium priority',
+  low: 'Low priority',
+} as const
+
+interface CurrentPlanPanelProps {
+  entries: ReadonlyArray<PlanEntry>
+}
+
+/** Read-only progress state. Plan approval remains in the plan-review tool card. */
+export function CurrentPlanPanel({ entries }: CurrentPlanPanelProps) {
+  if (entries.length === 0) return null
+
+  const completed = entries.filter((entry) => entry.status === 'completed').length
+
+  return (
+    <aside
+      aria-label="Current plan"
+      aria-live="polite"
+      className="shrink-0 border-b border-neutral-200 bg-neutral-50/90 px-4 py-3"
+    >
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-2 flex items-baseline justify-between gap-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-700">
+            Current plan
+          </h2>
+          <p className="text-xs tabular-nums text-neutral-500">
+            {completed} / {entries.length} completed
+          </p>
+        </div>
+        <ol className="max-h-52 space-y-1.5 overflow-y-auto md:max-h-36" aria-label="Plan steps">
+          {entries.map((entry, index) => {
+            const status = STATUS[entry.status]
+            return (
+              <li
+                key={`${index}:${entry.content}`}
+                className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md bg-white px-2.5 py-2 text-sm ring-1 ring-neutral-200"
+              >
+                <span className={`h-2 w-2 shrink-0 rounded-full ${status.dot}`} aria-hidden="true" />
+                <span className={`min-w-0 flex-1 break-words ${status.content}`}>{entry.content}</span>
+                <span className="text-xs font-medium text-neutral-600">{status.label}</span>
+                <span className="text-xs text-neutral-500">{PRIORITY[entry.priority]}</span>
+              </li>
+            )
+          })}
+        </ol>
+      </div>
+    </aside>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -17,10 +17,12 @@ import { useAgentInfo } from '@/hooks/use-agent-info'
 import { AgentHeader } from '@/components/agent-header'
 import { SessionList } from '@/components/session-list'
 import { ConfirmDialog } from '@/components/confirm-dialog'
-// The SDK this app actually runs on. It used to read `connectonion/package.json`,
-// which npm installed as a peer of @connectonion/react and which no longer exists:
-// the protocol moved into the React package, so that is the version to show.
-import { version as connectonionVersion } from '@connectonion/react/package.json'
+// O Chat directly consumes the React integration package. The retired standalone
+// ConnectOnion TypeScript SDK is intentionally not a dependency, so this is the
+// package version the UI should expose.
+import connectonionPackage from '@connectonion/react/package.json'
+
+const connectonionVersion = connectonionPackage.version
 
 interface SidebarProps {
   isOpen: boolean

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,8 +5,8 @@ the WebSocket protocol, and saving the transcript. oo-chat just routes, lays out
 renders the SDK's stream of events.
 
 oo-chat has one SDK boundary: `@connectonion/react` (`../connectonion-react`). It owns
-the React hooks, connection, protocol normalization, browser identity, and transcript
-persistence. The standalone `connectonion` TypeScript package is not installed by
+the React hooks, connection, protocol normalization, browser identity, transcript
+persistence, and current session plan. The standalone `connectonion` TypeScript package is not installed by
 React applications. `connectonion/react` was the old package subpath and no longer
 exists as of `connectonion@0.3.0`.
 
@@ -37,7 +37,8 @@ exists as of `connectonion@0.3.0`.
 3. That page calls the SDK's `useAgentForHuman(address, sessionId)`, which opens a
    WebSocket to the relay (`wss://oo.openonion.ai`) and sends your message.
 4. The agent streams back events — thinking, tool calls, results, questions. The SDK
-   turns each into a `ChatItem`; oo-chat renders each as a row.
+   turns conversational events into `ChatItem` rows and exposes the latest complete
+   plan separately; oo-chat renders that plan in a read-only panel outside the transcript.
 5. If the agent needs you (approve a command, answer a question, review a plan), the
    run pauses and a card appears; your reply goes back over the same socket.
 6. When the turn ends, the SDK has already saved the transcript to localStorage.
@@ -68,6 +69,7 @@ owner (the SDK); the sidebar store just lists conversations:
 | `app/[address]/[sessionId]/page.tsx` | the live chat |
 | `components/chat/use-agent-sdk.ts` | wraps the SDK hook; derives the "waiting" cards |
 | `components/chat/chat-messages.tsx` | `ChatItem.type` → message component |
+| `components/current-plan-panel.tsx` | renders the SDK's current plan; no protocol parsing or actions |
 | `components/dashboard/workspace-shell.tsx` | the Chat + Home split, and the mobile switch |
 | `components/dashboard/dashboard-pane.tsx` | the Home iframe + the button→skill bridge |
 | `components/dashboard/build-srcdoc.ts` | wraps agent HTML with the CSP and bridge |
@@ -206,6 +208,10 @@ events until `OUTPUT` settles the turn. `PING`/`PONG` keep the socket alive.
 **Streamed events → `ChatItem`** (rendered by `chat-messages.tsx`):
 `thinking` (llm_call/result), `agent` (assistant/image), `tool_call` (+`tool_result`),
 `tool_blocked`, `intent`, `eval`, `compact`, `files_received`.
+
+**Current plan → `PlanEntry[]`** (rendered by `current-plan-panel.tsx`): the SDK
+normalizes full replacements and empty clears per session. It is observational state,
+not a `ChatItem` and not the interactive `plan_review` gate.
 
 **Interactive gates** pause the run (`status = 'waiting'`) until you respond:
 

--- a/e2e/current-plan.spec.ts
+++ b/e2e/current-plan.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * The ACP plan is current session state, not transcript history and not approval.
+ * Drive the real React reader through its WebSocket boundary so O Chat never gets
+ * a chance to pass by parsing the protocol itself.
+ */
+
+import { test, expect } from './fixtures'
+import { AGENT_ADDRESS, mockAgent } from './mock-agent'
+
+async function openPlan(page: import('@playwright/test').Page) {
+  const sessionId = 'e2e-session'
+  await page.addInitScript(([address, session]) => {
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations: [{
+          sessionId: session,
+          title: 'Plan session',
+          agentAddress: address,
+          createdAt: new Date(0).toISOString(),
+        }],
+        activeSessionId: session,
+        agents: [address],
+      },
+      version: 0,
+    }))
+  }, [AGENT_ADDRESS, sessionId])
+  await mockAgent(page, 'plan')
+  await page.goto(`/${AGENT_ADDRESS}/${sessionId}`)
+  await page.getByPlaceholder(/message/i).fill('Start the plan')
+  await page.keyboard.press('Enter')
+  return page.getByRole('complementary', { name: 'Current plan' })
+}
+
+test('full replacements never become transcript rows and an empty plan clears', async ({ page, shot }) => {
+  const panel = await openPlan(page)
+  await expect(panel).toBeVisible({ timeout: 20_000 })
+  await expect(panel).toContainText('Inspect history')
+  await expect(panel).toContainText('Completed')
+  await expect(panel).toContainText('High priority')
+  await expect(panel).toContainText('In progress')
+  await expect(panel).toContainText('Medium priority')
+  await expect(panel).toContainText('Pending')
+  await expect(panel).toContainText('Low priority')
+  await expect(panel.getByRole('button')).toHaveCount(0)
+
+  const transcript = page.getByRole('log', { name: 'Conversation' })
+  await expect(transcript.getByText('Inspect history')).toHaveCount(0)
+  await shot('initial')
+
+  await page.getByPlaceholder(/message/i).fill('Replace the plan')
+  await page.keyboard.press('Enter')
+  await expect(panel).toContainText('Replacement step')
+  await expect(panel).not.toContainText('Inspect history')
+
+  await page.getByPlaceholder(/message/i).fill('Clear the plan')
+  await page.keyboard.press('Enter')
+  await expect(panel).toHaveCount(0)
+  await expect(transcript.getByText('Plan update 3')).toBeVisible()
+})
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('long plan content stays inside the viewport', async ({ page, shot }) => {
+    const panel = await openPlan(page)
+    await expect(panel).toBeVisible({ timeout: 20_000 })
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow, 'the plan panel scrolls the page sideways').toBeLessThanOrEqual(0)
+
+    await shot('mobile')
+  })
+})

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -5,7 +5,7 @@ import { dirname } from 'node:path'
 /** Where a UI review looks. One flat, stably-named folder beats digging through
  *  `test-results/<mangled-test-name>/`, and it survives a green run — which is the
  *  point: a passing suite cannot tell you a control turned white on white. */
-export const SHOTS_DIR = 'e2e-screenshots'
+export const SHOTS_DIR = process.env.E2E_SHOTS_DIR || 'e2e-screenshots'
 
 /** `some test — does a thing` → `some-test-does-a-thing` */
 export const slug = (title: string) =>

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns'
+export type Scenario = 'reply' | 'tools' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'ulw-turns' | 'plan'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -71,6 +71,7 @@ export async function mockAgent(
    *  down and reopened behind the reader — the screen looks identical either way,
    *  which is what makes a screen-level assertion about it vacuous. */
   let connects = 0
+  let planInputs = 0
   /** Every frame the client sent. The approval buttons differ only in the frame
    *  they produce — the UI is identical whichever one is wired to which — so the
    *  wire is the only place that difference is observable. */
@@ -119,6 +120,40 @@ export async function mockAgent(
       }
 
       if (msg.type !== 'INPUT') return
+
+      if (scenario === 'plan') {
+        planInputs += 1
+        const entries = planInputs === 1
+          ? [
+              { content: 'Inspect history', priority: 'high', status: 'completed' },
+              { content: 'Implement the React boundary', priority: 'medium', status: 'in_progress' },
+              {
+                content: 'Verify current-plan-panel-does-not-overflow-at-375px-with-a-long-unbroken-identifier',
+                priority: 'low',
+                status: 'pending',
+              },
+            ]
+          : planInputs === 2
+            ? [{ content: 'Replacement step', priority: 'high', status: 'in_progress' }]
+            : []
+        send(ws, {
+          type: 'ACP_NOTIFICATION',
+          acpSchema: 'schema-v1.19.0',
+          message: {
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId: 'e2e-session',
+              update: { sessionUpdate: 'plan', entries },
+            },
+          },
+        })
+        // The Host emits ACP first and then the legacy compatibility frame.
+        // Receiving both must still produce one current snapshot, never rows.
+        send(ws, { type: 'plan', session_id: 'e2e-session', entries })
+        send(ws, { type: 'OUTPUT', result: `Plan update ${planInputs}`, session: { session_id: 'e2e-session' } })
+        return
+      }
 
       // Credit is spent while the run goes on. The agent republishes its profile
       // with the new balance, which is the only way the reader learns before it

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "^0.3.2",
+        "@connectonion/react": "^0.4.0",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
@@ -39,6 +39,15 @@
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -368,11 +377,12 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.3.2.tgz",
-      "integrity": "sha512-G/BXXjR3MefG/+Szr0g6SzAoU9gnLnWzaxFPo+pLqxJF5U4p4MRB2eu29GOZ+WjR0BUWxxmHK1ETo2Hrix8Fog==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.0.tgz",
+      "integrity": "sha512-pGQKINJ0WHM+mvxl/eduV/rjyzqoBISwvsvuSz0vGqCJ1TUPVa9tPchquEGJLRejTEjERGWqtmSLG18O/y+F4w==",
       "license": "MIT",
       "dependencies": {
+        "@agentclientprotocol/sdk": "1.2.1",
         "tweetnacl": "^1.0.3",
         "ws": "^8.18.0",
         "zustand": "^5.0.0"
@@ -10314,7 +10324,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "^0.3.2",
+    "@connectonion/react": "^0.4.0",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",


### PR DESCRIPTION
## Summary

- consume the typed `useAgentForHuman().plan` state through O Chat's React integration wrapper, named `currentPlan` at the presentation boundary
- render one read-only current-plan panel outside the append-only transcript, with visible status and priority text and an empty-plan clear
- keep the existing interactive `plan_review` card and response handlers unchanged
- add real WebSocket E2E coverage for ACP + legacy dual delivery, complete replacement, empty clearing, transcript isolation, and 375px overflow
- make `@connectonion/react` the only direct frontend protocol boundary; the retired standalone ConnectOnion TypeScript SDK is not a dependency

## Dependency gate — cleared

O Chat now consumes the published, provenance-attested `@connectonion/react@0.4.0` registry artifact. The lockfile resolves that exact release and no standalone ConnectOnion TypeScript package. The official `@agentclientprotocol/sdk@1.2.1` is an internal transitive dependency of the React package; O Chat does not import it or parse ACP wire events itself.

Host counterpart openonion/connectonion#888 is merged. React reader openonion/connectonion-react#29 is merged, and release openonion/connectonion-react#30 published `0.4.0` through the exact-tag workflow.

## Validation on `be67498`

- clean `npm ci`: passed, 0 vulnerabilities
- production dependency audit: 0 vulnerabilities
- ESLint: passed
- TypeScript (`tsc --noEmit`): passed
- Vitest: 8 files, 67 tests passed
- webpack production build: passed, all routes generated
- complete Playwright browser suite: **170/170 passed**
- Current Plan E2E: desktop replacement/clear/transcript isolation and 375px no-overflow passed
- visual review: desktop and 375px mobile screenshots reviewed; status and priority remain readable
- dependency tree: `oo-chat → @connectonion/react@0.4.0 → @agentclientprotocol/sdk@1.2.1`

The sandboxed workstation cannot run Next 16's default Turbopack build because its internal worker is denied a local port bind; the equivalent webpack production build passes. Vercel's remote build remains the authoritative default-build gate.

Closes #134
