### PR TITLE
Fix answered native approval state

### DIFF
--- a/components/chat/use-agent-sdk.test.ts
+++ b/components/chat/use-agent-sdk.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatItem } from '@connectonion/react'
+
+import { extractPendingStates } from './use-agent-sdk'
+
+const runningTool: ChatItem = {
+  id: 'tool-1',
+  type: 'tool_call',
+  name: 'write',
+  args: { path: 'release.txt' },
+  status: 'running',
+}
+
+function approval(answered?: boolean): ChatItem {
+  return {
+    id: 'permission-1',
+    type: 'approval_needed',
+    tool: 'write',
+    arguments: { path: 'release.txt' },
+    ...(answered === undefined ? {} : { answered }),
+  }
+}
+
+describe('extractPendingStates', () => {
+  it('keeps an unanswered approval attached to its running tool', () => {
+    expect(extractPendingStates([runningTool, approval()]).pendingApproval).toEqual({
+      tool: 'write',
+      arguments: { path: 'release.txt' },
+    })
+  })
+
+  it('clears an answered approval even before the tool receives a terminal update', () => {
+    expect(extractPendingStates([runningTool, approval(true)]).pendingApproval).toBeNull()
+  })
+})

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -95,7 +95,7 @@ interface UseAgentSDKReturn {
 /**
  * Extract pending states from SDK UI.
  */
-function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser | null, pendingApproval: PendingApproval | null, pendingOnboard: PendingOnboard | null, pendingFullAccessCheckpoint: PendingFullAccessCheckpoint | null, pendingPlanReview: PendingPlanReview | null } {
+export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser | null, pendingApproval: PendingApproval | null, pendingOnboard: PendingOnboard | null, pendingFullAccessCheckpoint: PendingFullAccessCheckpoint | null, pendingPlanReview: PendingPlanReview | null } {
   let pendingAskUser: PendingAskUser | null = null
   let pendingApproval: PendingApproval | null = null
   let pendingOnboard: PendingOnboard | null = null
@@ -125,6 +125,10 @@ function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingAskUser 
         pendingAskUser = null
       }
     } else if (item.type === 'approval_needed') {
+      if (item.answered) {
+        pendingApproval = null
+        continue
+      }
       // Only set pendingApproval if the tool is still running
       const toolStatus = toolStatuses.get(item.tool.split(':')[0].toLowerCase())
       if (toolStatus === 'running' || toolStatus === undefined) {


### PR DESCRIPTION
## Summary

- stop treating an answered React `approval_needed` item as a pending user decision
- re-enable collaboration/permission controls and the composer after native approval completes
- keep O Chat as a thin `@connectonion/react` consumer with no ACP parser or JSON-RPC construction
- add focused pending-state regression coverage

## Root cause

The real native ACP browser flow marked `approval_needed.answered = true` after Allow once, but O Chat's pending-state reducer did not inspect that field. The page kept “Jump to it” active and disabled Auto even after the Host completed the prompt.

## Validation

- 10 Vitest files / 76 tests
- TypeScript `--noEmit`
- ESLint
- clean Next.js production build with the exact local React `0.4.2-alpha.0` candidate
- desktop Chromium: prompt → permission → Auto → Stop → reload/resume
- iPhone 13 emulation: 390 px viewport, no horizontal overflow
- only native `/acp`; no legacy `/ws`
- no console/page errors or transcript duplication

Tracks #136. The registry pin remains a separate step after the React Alpha is published.
