### PR TITLE
fix: pin React ACP alpha.2 and recover sessions

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -36,7 +36,7 @@
  */
 'use client'
 
-import { useEffect, useCallback, useMemo, useRef, useState } from 'react'
+import { useEffect, useEffectEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Chat, useAgentSDK, ModeStatusBar, PlanModeBanner, FullAccessModeBanner } from '@/components/chat'
 import { CurrentPlanPanel } from '@/components/current-plan-panel'
@@ -152,7 +152,9 @@ export default function ChatSessionPage() {
     agentAddress: address,
     sessionId,
     initialPlanMode,
-    onError: (error) => setConnectionError(error),
+    // The stable setter prevents the error effect from replaying a stale SDK
+    // error merely because clearing this local state caused another render.
+    onError: setConnectionError,
   })
 
   // Skills come from the authenticated socket once it is up, and from the public relay
@@ -252,28 +254,28 @@ export default function ChatSessionPage() {
     reconnect()
   }, [reconnect, setConnectionError])
 
+  const recoverConnection = useEffectEvent(() => {
+    if (sessionState === 'disconnected' && document.visibilityState === 'visible' && navigator.onLine) {
+      handleReconnect()
+    }
+  })
+
   // Coming out of a tunnel, or unlocking a phone after the socket was reaped,
   // should not require noticing a status line at the bottom of the screen and
   // tapping a word in it. The reader's agent stopped working through no action of
   // theirs; it should start working again the same way.
   //
-  // Bound to the transitions the browser reports rather than a timer, and armed
-  // only while actually disconnected — so a working socket is never torn down
-  // mid-run just because the tab was switched to, and an agent that is genuinely
-  // gone is not hammered on an interval.
+  // Bind once so a browser event cannot land between the disconnected render and
+  // an effect re-subscription. The Effect Event reads the latest state without
+  // re-subscribing, so a working socket is never torn down on a tab switch.
   useEffect(() => {
-    if (sessionState !== 'disconnected') return
-
-    const recover = () => {
-      if (document.visibilityState === 'visible' && navigator.onLine) handleReconnect()
-    }
-    window.addEventListener('online', recover)
-    document.addEventListener('visibilitychange', recover)
+    window.addEventListener('online', recoverConnection)
+    document.addEventListener('visibilitychange', recoverConnection)
     return () => {
-      window.removeEventListener('online', recover)
-      document.removeEventListener('visibilitychange', recover)
+      window.removeEventListener('online', recoverConnection)
+      document.removeEventListener('visibilitychange', recoverConnection)
     }
-  }, [sessionState, handleReconnect])
+  }, [])
 
   // Redirect to agent landing if no conversation and no pending messages
   // Only after store has hydrated from localStorage — avoids redirect on refresh

--- a/components/chat/chat-error.tsx
+++ b/components/chat/chat-error.tsx
@@ -28,7 +28,7 @@ export function ChatError({ error, onRetry, onDismiss }: ChatErrorProps) {
         {onRetry && (
           <button
             onClick={onRetry}
-            className="text-sm font-medium text-red-600 hover:text-red-700"
+            className="min-h-11 px-2 text-sm font-medium text-red-600 hover:text-red-700"
           >
             Retry
           </button>

--- a/components/chat/use-agent-sdk.test.ts
+++ b/components/chat/use-agent-sdk.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ChatItem } from '@connectonion/react'
 
-import { extractPendingStates } from './use-agent-sdk'
+import { deriveSessionState, extractPendingStates } from './use-agent-sdk'
 
 const runningTool: ChatItem = {
   id: 'tool-1',
@@ -31,5 +31,15 @@ describe('extractPendingStates', () => {
 
   it('clears an answered approval even before the tool receives a terminal update', () => {
     expect(extractPendingStates([runningTool, approval(true)]).pendingApproval).toBeNull()
+  })
+})
+
+describe('deriveSessionState', () => {
+  it('keeps an authoritative transport loss visible over stale running UI', () => {
+    expect(deriveSessionState('disconnected', true, false, true)).toBe('disconnected')
+  })
+
+  it('does not call a cold agent disconnected before a conversation exists', () => {
+    expect(deriveSessionState('disconnected', false, false, false)).toBe('idle')
   })
 })

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -6,6 +6,7 @@ import {
   type AgentInfo,
   type ChatItem,
   type CollaborationMode,
+  type ConnectionState,
   type HostSessionModeState,
   type PermissionProfile,
   type PlanEntry,
@@ -19,6 +20,23 @@ import {
 
 /** Session lifecycle state */
 export type SessionActiveState = 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
+
+/** Reduce React-owned transport state and product activity into one display state. */
+export function deriveSessionState(
+  connectionState: ConnectionState,
+  isLoading: boolean,
+  serverSessionAlive: boolean,
+  hasConversation: boolean,
+): SessionActiveState {
+  if (connectionState === 'reconnecting') return 'reconnecting'
+  // A transport loss is authoritative. Stale running transcript items must not
+  // hide it, but a cold agent has no connection to call lost yet.
+  if (connectionState === 'disconnected' && hasConversation) return 'disconnected'
+  if (connectionState === 'connected' || isLoading) return 'active'
+  if (serverSessionAlive) return 'disconnected'
+  if (hasConversation) return 'connected'
+  return 'idle'
+}
 
 // Re-export ChatItem as UI for compatibility
 export type UI = ChatItem
@@ -469,18 +487,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     pendingOnboard,
     pendingFullAccessCheckpoint,
     pendingPlanReview,
-    sessionState: connectionState === 'reconnecting' ? 'reconnecting' as const
-      : connectionState === 'connected' || isLoading ? 'active' as const
-      // The transport's own word counts, not only the server poll. That poll
-      // reports true while the *server* still has a run in flight, so a socket
-      // dropped while the agent was idle fell through to 'connected' below — the
-      // reader was told everything was fine and typed into a dead socket. Gated on
-      // there being a conversation, because before the first send the transport is
-      // legitimately not connected yet and saying so would put an error state on
-      // every first impression.
-      : serverSessionAlive || (connectionState === 'disconnected' && cleanUI.length > 0) ? 'disconnected' as const
-      : cleanUI.length > 0 ? 'connected' as const
-      : 'idle' as const,
+    sessionState: deriveSessionState(connectionState, isLoading, serverSessionAlive, cleanUI.length > 0),
     currentSession,
     collaborationMode,
     permissionProfile,

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -232,7 +232,7 @@ test.describe('a connection that drops while the reader is on Home', () => {
     await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
-    await expect(page.getByText(/disconnected/i).first()).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('Connection lost', { exact: true })).toBeVisible({ timeout: 20_000 })
     await page.getByRole('tab', { name: 'Home' }).click()
     await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
   }
@@ -270,7 +270,7 @@ test.describe('a connection that drops while the reader is on Home', () => {
     // reader who can read it there is noise, and noise is what teaches people to
     // stop reading notices.
     await expect(page.getByText(/connection to this agent dropped/i)).toHaveCount(0)
-    await expect(page.getByText(/disconnected/i).first()).toBeVisible()
+    await expect(page.getByText('Connection lost', { exact: true })).toBeVisible()
   })
 
   test('a healthy connection says nothing on Home', async ({ page }) => {

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -592,7 +592,7 @@ export async function mockTwoAgents(page: Page) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        endpoints: ['https://scriptbot.example'],
+        endpoints: [],
         relay: 'wss://oo.openonion.ai/ws',
         last_seen: new Date(0).toISOString(),
         profile: byAddress(address),

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -496,6 +496,7 @@ export async function mockAgent(
     route.fulfill({
       status: scenario === 'offline' ? 503 : 200,
       contentType: 'application/json',
+      headers: { 'cache-control': 'no-store' },
       body: JSON.stringify(profile),
     })
   )

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -5,7 +5,7 @@
  * cellular, the screen locking long enough for the socket to be reaped. The
  * agent stops being reachable and the reader is left looking at a status line.
  *
- * `ModeStatusBar` has a `disconnected` branch with a `reconnect` link, and it was
+ * The recovery surface reports `Connection lost` with a `Retry` action, and it was
  * effectively never shown: the state was derived from an HTTP poll that only
  * reports true while the *server* still has a run in flight, so a socket that
  * dropped while the agent was idle fell through to "connected". The reader is
@@ -26,7 +26,7 @@
  *     the reliable witness that the close actually ran.
  */
 
-import { test, expect } from './fixtures'
+import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 
 /** Send a message, then let the mock close the session's socket underneath it. */
@@ -34,7 +34,7 @@ async function dropMidRun(page: import('@playwright/test').Page) {
   await mockAgent(page, 'drop')
   await page.goto(`/${AGENT_ADDRESS}`)
   await page.getByRole('button', { name: 'What can you do?' }).click()
-  await expect(page.getByText('What can you do?').first()).toBeVisible({ timeout: 20_000 })
+  await expect(pane(page).getByText('What can you do?').first()).toBeVisible({ timeout: 20_000 })
 }
 
 test.describe('phone', () => {
@@ -45,7 +45,7 @@ test.describe('phone', () => {
 
     // "connected" beside a socket that is gone is the worst of the options: it is
     // the one state that tells the reader to keep waiting.
-    await expect(page.getByText('disconnected', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Connection lost', { exact: true })).toBeVisible({ timeout: 15_000 })
     await expect(page.getByText('connected', { exact: true })).toHaveCount(0)
 
     await shot('dropped')
@@ -54,13 +54,13 @@ test.describe('phone', () => {
   test('and offers a way back, at a size a thumb can hit', async ({ page }) => {
     await dropMidRun(page)
 
-    const reconnect = page.getByRole('button', { name: /reconnect/i })
-    await expect(reconnect, 'no way back from a dead connection').toBeVisible({ timeout: 15_000 })
+    const retry = page.getByRole('button', { name: /^retry$/i }).first()
+    await expect(retry, 'no way back from a dead connection').toBeVisible({ timeout: 15_000 })
 
     // It was an 11px underlined word. This is the control someone reaches for
     // one-handed, on a train, having just come out of a tunnel.
-    const box = await reconnect.boundingBox()
-    expect(box!.height, `reconnect is ${Math.round(box!.width)}x${Math.round(box!.height)}`).toBeGreaterThanOrEqual(44)
+    const box = await retry.boundingBox()
+    expect(box!.height, `retry is ${Math.round(box!.width)}x${Math.round(box!.height)}`).toBeGreaterThanOrEqual(44)
   })
 
   test('a fresh landing page is not accused of being disconnected', async ({ page }) => {
@@ -70,8 +70,8 @@ test.describe('phone', () => {
 
     // Before anything is sent the transport is legitimately not connected yet.
     // Saying so would put an error state on every first impression.
-    await expect(page.getByText('disconnected', { exact: true })).toHaveCount(0)
-    await expect(page.getByRole('button', { name: /reconnect/i })).toHaveCount(0)
+    await expect(page.getByText('Connection lost', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^retry$/i })).toHaveCount(0)
   })
 
   test('a healthy conversation still reads as live', async ({ page }) => {
@@ -82,7 +82,7 @@ test.describe('phone', () => {
 
     // The other direction: the fix must not start calling working sockets dead.
     await expect(page.getByText('live', { exact: true })).toBeVisible()
-    await expect(page.getByText('disconnected', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('Connection lost', { exact: true })).toHaveCount(0)
   })
 })
 
@@ -92,14 +92,14 @@ test.describe('coming back', () => {
   test('the reconnect link actually restores the session', async ({ page, shot }) => {
     await dropMidRun(page)
 
-    const link = page.getByRole('button', { name: /reconnect/i })
-    await expect(link).toBeVisible({ timeout: 15_000 })
-    await link.click()
+    const retry = page.getByRole('button', { name: /^retry$/i }).first()
+    await expect(retry).toBeVisible({ timeout: 15_000 })
+    await retry.click()
 
     // Not just a status flipping back — the session has to carry a message again,
     // which is the only thing the reader actually wanted.
     await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
-    await expect(link).toHaveCount(0)
+    await expect(retry).toHaveCount(0)
 
     await page.getByPlaceholder(/message/i).fill('are you back?')
     await page.keyboard.press('Enter')
@@ -110,7 +110,7 @@ test.describe('coming back', () => {
 
   test('regaining connectivity reconnects without being asked', async ({ page }) => {
     await dropMidRun(page)
-    await expect(page.getByRole('button', { name: /reconnect/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Connection lost', { exact: true })).toBeVisible({ timeout: 15_000 })
 
     // The browser's own event, the one that fires when a phone comes out of a
     // tunnel. Nobody should have to notice a status line at the bottom of the
@@ -118,12 +118,12 @@ test.describe('coming back', () => {
     await page.evaluate(() => window.dispatchEvent(new Event('online')))
 
     await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByRole('button', { name: /reconnect/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^retry$/i })).toHaveCount(0)
   })
 
   test('returning to the tab reconnects without being asked', async ({ page }) => {
     await dropMidRun(page)
-    await expect(page.getByRole('button', { name: /reconnect/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Connection lost', { exact: true })).toBeVisible({ timeout: 15_000 })
 
     // Locking a phone long enough for the socket to be reaped, then unlocking it.
     await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "^0.4.1",
+        "@connectonion/react": "0.4.2-alpha.0",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.1.tgz",
-      "integrity": "sha512-JcEkX2qsou/eaAnun014v3McJyHeO2HDHXgItTkjj23+SGyCeLrd+p1I9l1UogcY2HMBhq0FLTogmiNEcp/t2A==",
+      "version": "0.4.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.0.tgz",
+      "integrity": "sha512-NYcizlNodKOc+jQPgBJYBnJySqs7VfCU/WDq8npmjKzupJTSlslx+nG0sjWPe8mPjzKggbkoYZPRz+kdK2J3Uw==",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.0",
+        "@connectonion/react": "0.4.2-alpha.2",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.0.tgz",
-      "integrity": "sha512-NYcizlNodKOc+jQPgBJYBnJySqs7VfCU/WDq8npmjKzupJTSlslx+nG0sjWPe8mPjzKggbkoYZPRz+kdK2J3Uw==",
+      "version": "0.4.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.2.tgz",
+      "integrity": "sha512-/SAQEagSthgvY6IDewgEIA1+l+85luOQBkT/I0GFpPZnf1ELD1IESPzkPJp04oWv7+nivQsSnCTd/viZsxVVPQ==",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.0",
+    "@connectonion/react": "0.4.2-alpha.2",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "^0.4.1",
+    "@connectonion/react": "0.4.2-alpha.0",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",


### PR DESCRIPTION
Closes #136

## Why

O Chat consumes browser ACP through @connectonion/react. The published Alpha consumer gate exposed route-handoff, status-poll, and browser recovery races; the SDK fixes now ship in exact version 0.4.2-alpha.2.

## Change

- pin @connectonion/react exactly to 0.4.2-alpha.2 and its reviewed registry integrity
- give the React-owned disconnected state priority over stale running transcript items
- keep online and visibility recovery listeners stable with React 19 useEffectEvent
- keep the O Chat error callback stable so clearing a recovered error cannot replay it
- make the mobile Retry target at least 44px high
- align deterministic mocks with non-cacheable discovery and their actual relay topology

No ACP parser, JSON-RPC method construction, or duplicate protocol state machine is added to O Chat. The retired standalone TypeScript SDK remains outside the browser path.

## Validation

- registry gitHead matches React main release commit 98f762f
- registry integrity and SLSA provenance verified; npm alpha points to 0.4.2-alpha.2 while latest remains 0.4.1
- production npm audit: 0 vulnerabilities
- Vitest: 10 files / 78 tests
- TypeScript: pass
- ESLint: pass
- Next.js production build: pass
- published-package Playwright: 28/28 recovery, Dashboard, and multi-agent cases using the repository-required single local worker
- desktop and mobile screenshots visually inspected
- React package: 19 suites / 270 tests, Node 20/22/24 CI, CodeQL, clean packed install, and published-runtime ACP probe

## Rollback

Revert this PR to restore exact 0.4.2-alpha.0, or pin exact stable 0.4.1. The npm latest dist-tag remains 0.4.1.