### PR TITLE
fix: render approval without a matching tool card

### DIFF
--- a/components/chat/chat-approval.tsx
+++ b/components/chat/chat-approval.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import type { PendingApproval } from './types'
+import { ApprovalButtons, type ApprovalState } from './messages/tools/approval-buttons'
+import { KVRows } from './messages/tools/kv-rows'
+
+interface ChatApprovalProps {
+  approval: PendingApproval
+  onResponse: (
+    approved: boolean,
+    scope: 'once' | 'session',
+    mode?: 'reject_soft' | 'reject_hard' | 'reject_explain',
+    feedback?: string,
+  ) => void
+}
+
+/** Decision surface for a permission request that has no separate tool update. */
+export function ChatApproval({ approval, onResponse }: ChatApprovalProps) {
+  const [approvalSent, setApprovalSent] = useState<ApprovalState>(null)
+  const toolName = approval.tool.split(':')[0]
+  const hasArguments = Object.keys(approval.arguments).length > 0
+
+  const handleApproval = (
+    approved: boolean,
+    scope: 'once' | 'session',
+    mode?: 'reject_soft' | 'reject_hard' | 'reject_explain',
+  ) => {
+    if (approvalSent) return
+    if (approved) setApprovalSent(scope === 'session' ? 'approved_session' : 'approved')
+    else setApprovalSent(mode === 'reject_soft' ? 'skipped' : 'stopped')
+    onResponse(approved, scope, mode)
+  }
+
+  return (
+    <section
+      aria-label={`Approval required for ${toolName}`}
+      className="my-2 overflow-hidden rounded-lg border border-neutral-200 bg-white px-3 py-2 shadow-sm"
+    >
+      <div className="flex items-baseline gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-neutral-500">Approval required</span>
+        <span className="font-mono text-sm font-semibold text-neutral-800">{toolName}</span>
+      </div>
+
+      {hasArguments && (
+        <div className="mt-2 rounded-md bg-neutral-50 px-3 py-2">
+          <KVRows data={approval.arguments} />
+        </div>
+      )}
+
+      <ApprovalButtons
+        approvalSent={approvalSent}
+        onApproval={handleApproval}
+        toolName={toolName}
+        description={approval.description}
+        batchRemaining={approval.batch_remaining}
+      />
+    </section>
+  )
+}

--- a/components/chat/chat-messages.test.tsx
+++ b/components/chat/chat-messages.test.tsx
@@ -1,0 +1,134 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { ChatItem } from '@connectonion/react'
+import { ChatMessages } from './chat-messages'
+import type { PendingApproval } from './types'
+
+// The message barrel pulls in every specialised tool renderer, including modules
+// whose Next.js path alias is not configured in Vitest. This suite is about the
+// decision placement in ChatMessages, so keep unrelated renderers outside it.
+vi.mock('./messages', () => {
+  const EmptyMessage = () => null
+  const ToolCall = ({ pendingApproval }: { pendingApproval?: PendingApproval }) => (
+    pendingApproval ? <button type="button">Allow once</button> : null
+  )
+  return {
+    User: EmptyMessage,
+    Agent: EmptyMessage,
+    Thinking: EmptyMessage,
+    ToolCall,
+    AskUser: EmptyMessage,
+    OnboardRequired: EmptyMessage,
+    OnboardSuccess: EmptyMessage,
+    Intent: EmptyMessage,
+    Eval: EmptyMessage,
+    Compact: EmptyMessage,
+    ToolBlocked: EmptyMessage,
+    FilesReceived: EmptyMessage,
+  }
+})
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function render(ui: ChatItem[], pendingApproval: PendingApproval, onApprovalResponse = vi.fn()) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(
+    <ChatMessages
+      ui={ui}
+      pendingApproval={pendingApproval}
+      onApprovalResponse={onApprovalResponse}
+    />,
+  ))
+  return { element: container, onApprovalResponse }
+}
+
+function buttonNamed(element: HTMLElement, name: string) {
+  return Array.from(element.querySelectorAll('button')).find(button =>
+    button.textContent?.replace(/\s+/g, ' ').trim().startsWith(name),
+  )
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+const approval: PendingApproval = {
+  tool: 'write',
+  arguments: { path: 'release.txt' },
+  description: 'Write the release marker',
+}
+
+const approvalItem: ChatItem = {
+  id: 'approval-1',
+  type: 'approval_needed',
+  ...approval,
+}
+
+describe('ChatMessages permission decisions', () => {
+  it('renders every decision for a normalized permission without a tool update', () => {
+    const { element } = render([approvalItem], approval)
+
+    expect(element.querySelector('[aria-label="Approval required for write"]')).not.toBeNull()
+    expect(element.querySelector('[data-pending-decision]')).not.toBeNull()
+    expect(element.textContent).toContain('release.txt')
+    expect(buttonNamed(element, 'Allow once')).toBeDefined()
+    expect(buttonNamed(element, 'Trust write')).toBeDefined()
+    expect(buttonNamed(element, 'Reject')).toBeDefined()
+    expect(buttonNamed(element, 'Stop')).toBeDefined()
+    expect(buttonNamed(element, 'Explain')).toBeDefined()
+
+  })
+
+  it.each([
+    ['Allow once', true, 'once', undefined],
+    ['Trust write', true, 'session', undefined],
+    ['Reject', false, 'once', 'reject_soft'],
+    ['Stop', false, 'once', 'reject_hard'],
+    ['Explain', false, 'once', 'reject_explain'],
+  ] as const)('routes %s through the typed approval callback', (label, approved, scope, mode) => {
+    const { element, onApprovalResponse } = render([approvalItem], approval)
+
+    act(() => buttonNamed(element, label)!.click())
+
+    expect(onApprovalResponse).toHaveBeenCalledOnce()
+    expect(onApprovalResponse).toHaveBeenCalledWith(approved, scope, mode)
+  })
+
+  it('keeps approval inline when a matching running tool card exists', () => {
+    const toolItem: ChatItem = {
+      id: 'tool-1',
+      type: 'tool_call',
+      name: 'write',
+      args: { path: 'release.txt' },
+      status: 'running',
+    }
+    const { element } = render([toolItem, approvalItem], approval)
+
+    expect(element.querySelector('[aria-label="Approval required for write"]')).toBeNull()
+    const allowOnceButtons = Array.from(element.querySelectorAll('button')).filter(button =>
+      button.textContent?.includes('Allow once'),
+    )
+    expect(allowOnceButtons).toHaveLength(1)
+    expect(element.querySelectorAll('[data-pending-decision]')).toHaveLength(1)
+  })
+})

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -6,6 +6,7 @@ import { HiOutlineArrowDown } from 'react-icons/hi'
 import { cn } from './utils'
 import { User, Agent, Thinking, ToolCall, AskUser, OnboardRequired, OnboardSuccess, Intent, Eval, Compact, ToolBlocked, FilesReceived } from './messages'
 import { ChatAskUser } from './chat-ask-user'
+import { ChatApproval } from './chat-approval'
 import { ChatFullAccessCheckpoint } from './chat-full-access-checkpoint'
 import type { ChatMessagesProps, OnboardRequiredUI, OnboardSuccessUI, IntentUI, EvalUI, CompactUI, ToolBlockedUI, FullAccessCheckpointUI, FilesReceivedUI } from './types'
 
@@ -111,6 +112,13 @@ export function ChatMessages({
         .pop()?.id
     : null
 
+  // Native ACP permits a permission request without a preceding tool update.
+  // Keep the existing inline tool-card treatment when that context exists;
+  // otherwise the latest normalized approval item needs its own decision surface.
+  const pendingStandaloneApprovalId = pendingApproval && !pendingToolId
+    ? ui.filter(item => item.type === 'approval_needed').pop()?.id
+    : null
+
   // Find the last ask_user tool call that's still running
   const pendingAskUserToolId = pendingAskUser
     ? ui.filter(item => item.type === 'tool_call' && item.name.toLowerCase() === 'ask_user' && item.status === 'running')
@@ -210,7 +218,21 @@ export function ChatMessages({
               }
               return <AskUser key={item.id} question={item} />
             case 'approval_needed':
-              // Don't render separate approval message - it's shown inline in tool card
+              if (
+                item.id === pendingStandaloneApprovalId
+                && pendingApproval
+                && onApprovalResponse
+              ) {
+                return (
+                  <div key={item.id} data-pending-decision="">
+                    <ChatApproval
+                      approval={pendingApproval}
+                      onResponse={onApprovalResponse}
+                    />
+                  </div>
+                )
+              }
+              // A matching running tool card owns the inline decision controls.
               return null
             case 'plan_review':
               // Rendered inline via tool card (exit_plan_and_implement)


### PR DESCRIPTION
## Summary

- render one standalone approval card when React reports a pending approval without a matching running tool card
- keep the existing inline tool-card decision UI when matching context exists
- route Allow once, Trust session, Reject, Stop, and Explain through the existing typed React callback
- mark the standalone card as the pending-decision target used by “Jump to it”

O Chat consumes only React-normalized state and actions. It does not parse ACP, inspect request IDs, construct JSON-RPC, or synthesize a tool event.

## Why

A real Host → React → O Chat WSS run showed a valid permission request could leave the UI saying “Waiting on your answer” with no actionable controls when no tool card was available. The tool card is useful presentation context, but it must not be a prerequisite for a human to answer a pending permission.

React PR openonion/connectonion-react#37 now also normalizes native permission-first ordering into a stable tool card. This O Chat fallback keeps the product actionable for any React-normalized approval lacking that optional presentation context, while matching and fallback remain mutually exclusive.

## Validation

- 11 Vitest files / 83 tests
- component coverage for standalone rendering, pending-decision anchor, all five typed callback paths, and no duplicate when a running tool card exists
- TypeScript `--noEmit`
- ESLint
- clean Next.js production build using the exact final `@connectonion/react@0.4.2-alpha.0` tarball
- npm audit: 0 vulnerabilities
- real admitted WSS Chromium flow: prompt, permission/Allow once, mode, Stop/cancel, reload/resume
- 375 × 667 mobile viewport with no horizontal overflow
- no legacy `/ws`, page errors, or console errors
- visual inspection of final desktop and mobile screenshots

## Security boundary

- admission, TLS, session correlation, permission encoding, de-duplication, and fallback remain React-owned
- arguments are displayed so the user can see what they are authorizing
- approval success is not inferred by O Chat
- the retired standalone TypeScript SDK is unchanged

Closes #140.
Parent: #136.
