### PR TITLE
test(e2e): make WebSocket mock readiness deterministic

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -101,6 +101,15 @@ git push                               # push the branch; merge the PR to main
 Vercel auto-deploys: a branch push builds a **preview**; a merge to `main` builds
 **production**. Confirm the preview is green before merging.
 
+The Playwright suite stays parallel and keeps a full-page PNG for every test. When
+running locally against an already-built target (`E2E_BASE_URL=...`), it uses four
+workers by default. Eight simultaneous Chromium pages plus PNG encoding can starve
+a page-local HTTP/WebSocket mock long enough to turn a transient connecting screen
+into a false offline failure. CI keeps Playwright's capacity-aware default. Use
+`E2E_WORKERS=N` only for an explicit stress/debug run. The `mock-readiness` spec
+separately proves four isolated browser contexts receive their local Host handshake
+and never fall through to the live relay.
+
 ### 4. If you symlinked for local dev, undo it before committing
 
 `package.json` must keep the semver. Only `node_modules` may point at a local checkout, and

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -101,6 +101,15 @@ export async function mockAgent(
   overrides: Partial<typeof PROFILE> = {},
 ) {
   const profile = { ...PROFILE, ...overrides }
+  const socketUrls: string[] = []
+  let readyKind: 'connected' | 'onboard-required' | null = null
+  let resolveReady!: () => void
+  const ready = new Promise<void>(resolve => { resolveReady = resolve })
+  const markReady = (kind: Exclude<typeof readyKind, null>) => {
+    if (readyKind) return
+    readyKind = kind
+    resolveReady()
+  }
   /** Per-call, so the drop scenario interrupts one connection rather than all of them. */
   let dropped = false
   /** How many times a client has handshaked. The only way to see a socket torn
@@ -122,6 +131,10 @@ export async function mockAgent(
   // depends on what the relay record advertises — relay socket for a hosted agent,
   // the agent's own endpoint for a direct one — and the test should not care.
   await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
+    // Route every non-Next socket and never call connectToServer(): a protocol
+    // URL regression must stay hermetic instead of silently reaching the live
+    // relay. waitUntilReady() reports the exact routed URLs when CONNECT is absent.
+    socketUrls.push(ws.url())
     let connectedSessionId = activeSessionId
     ws.onMessage(raw => {
       const msg = JSON.parse(String(raw)) as {
@@ -153,6 +166,7 @@ export async function mockAgent(
             payment_amount: 12,
             payment_address: PAYEE_ADDRESS,
           })
+          markReady('onboard-required')
           return
         }
         connects += 1
@@ -185,6 +199,7 @@ export async function mockAgent(
             },
           })
           send(ws, { type: 'AGENT_PROFILE', ...profile })
+          markReady('connected')
           // Pushed on connect for agents that ship one. Its arrival is what flips
           // hasDashboard, which is what splits the workspace in two.
           if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains' || scenario === 'dashboard-error' || scenario === 'dashboard-drop') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
@@ -524,6 +539,35 @@ export async function mockAgent(
     },
     /** Session identity the Host echoed from CONNECT. */
     sessionId: () => activeSessionId,
+    /** Every non-Next socket is intercepted locally; no live fallback is allowed. */
+    socketUrls: () => [...socketUrls],
+    /**
+     * Prove the mock boundary completed its first Host response.
+     *
+     * UI locators answer product questions. This answers the earlier question:
+     * did the page reach the page-local WebSocket mock and receive its handshake?
+     */
+    waitUntilReady: async (timeoutMs = 20_000) => {
+      if (scenario === 'offline') {
+        throw new Error('mock readiness is intentionally unavailable for the offline scenario')
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined
+      try {
+        await Promise.race([
+          ready,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(
+              'mock Host did not complete its first response '
+              + `(scenario=${scenario}, connects=${connects}, ready=${readyKind ?? 'no'}, `
+              + `sockets=${socketUrls.join(', ') || 'none'}, `
+              + `frames=${sent.map(frame => String(frame.type)).join(', ') || 'none'})`
+            )), timeoutMs)
+          }),
+        ])
+      } finally {
+        if (timer) clearTimeout(timer)
+      }
+    },
   }
 }
 

--- a/e2e/mock-readiness.spec.ts
+++ b/e2e/mock-readiness.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * The WebSocket mock is a test boundary, so prove it independently of the UI.
+ *
+ * A many-core local production run once let eight simultaneous full-page PNG
+ * captures starve the next wave of pages. Two product tests timed out on the
+ * offline transition state even though their mocked CONNECT eventually arrived.
+ * This test exercises the configured four-way concurrency directly and makes a
+ * missing interception fail as a Host-handshake error with routed URLs/frames.
+ */
+
+import { expect, test } from './fixtures'
+import { AGENT_ADDRESS, mockAgent, PROFILE } from './mock-agent'
+
+test('a missing mock connection reports the protocol boundary, not a UI timeout', async ({ page }) => {
+  const agent = await mockAgent(page)
+
+  await expect(agent.waitUntilReady(25)).rejects.toThrow(
+    /mock Host did not complete.*connects=0.*sockets=none.*frames=none/
+  )
+})
+
+test('four isolated browser contexts complete their page-local mock handshake', async ({ browser, page }) => {
+  const extraContexts = await Promise.all(
+    Array.from({ length: 3 }, () => browser.newContext({ viewport: { width: 390, height: 844 } }))
+  )
+  const pages = [page, ...await Promise.all(extraContexts.map(context => context.newPage()))]
+
+  try {
+    const agents = await Promise.all(pages.map(current => mockAgent(current)))
+    await Promise.all(pages.map(current => current.goto(`/${AGENT_ADDRESS}`)))
+    await Promise.all(agents.map(agent => agent.waitUntilReady()))
+
+    for (const [index, current] of pages.entries()) {
+      await expect(
+        current.getByRole('heading', { name: PROFILE.name, exact: true }),
+        `context ${index + 1} received the mock handshake but did not render its profile`,
+      ).toBeVisible({ timeout: 20_000 })
+      expect(agents[index].connects()).toBeGreaterThan(0)
+      expect(agents[index].socketUrls()).toHaveLength(1)
+      expect(agents[index].socketUrls()[0]).toMatch(/^wss?:\/\//)
+    }
+
+    // Keep the same evidence pressure as the real suite: four full-page PNGs at
+    // once, after all four independent protocol paths have rendered.
+    await Promise.all(pages.map(current => current.screenshot({ fullPage: true })))
+  } finally {
+    await Promise.all(extraContexts.map(context => context.close()))
+  }
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,14 +10,24 @@ import { defineConfig, devices } from '@playwright/test'
  * more than once in this repo.
  */
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000'
+const requestedWorkersText = process.env.E2E_WORKERS
+const requestedWorkers = requestedWorkersText ? Number(requestedWorkersText) : null
+
+if (requestedWorkers !== null && (!Number.isSafeInteger(requestedWorkers) || requestedWorkers < 1)) {
+  throw new Error('E2E_WORKERS must be a positive integer')
+}
 
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
-  // Against the local dev server, one worker. Next compiles each route on first
-  // request, and several workers hitting cold routes at once times out tests that
-  // pass individually. CI runs against a built preview, where that does not apply.
-  workers: process.env.E2E_BASE_URL || process.env.CI ? undefined : 1,
+  // Against the local dev server, one worker: several workers hitting cold Next
+  // routes at once time out tests that pass individually. A built target stays
+  // parallel, but four is deliberate. Every test keeps a full-page PNG, and on a
+  // many-core laptop Playwright's default (half the cores) let eight simultaneous
+  // captures starve the next page's mocked HTTP/WebSocket handshake beyond its UI
+  // timeout. Four keeps product pressure without turning screenshot evidence into
+  // transport flakiness. E2E_WORKERS is an explicit stress/debug override.
+  workers: requestedWorkers ?? (process.env.CI ? undefined : process.env.E2E_BASE_URL ? 4 : 1),
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI


### PR DESCRIPTION
## Outcome

Make O Chat's parallel Playwright evidence deterministic without retrying failures, serializing the suite, or allowing mocked browser tests to reach the live relay.

## Root cause

A focused 80-case run with eight real Chromium workers passed 80/80, but individual cases took 12–33 seconds while full-page PNGs were encoded concurrently. The prior 5-second UI assertions could therefore observe the offline transition before the next page's local HTTP/WebSocket mock processed `CONNECT`. The route was not lost and product behavior was not regressed; local many-core screenshot pressure starved the harness.

## Changes

- cap local production-target runs at four workers while keeping the Chromium project fully parallel;
- keep CI on Playwright's capacity-aware worker default;
- add strict `E2E_WORKERS=N` validation for deliberate stress/debug runs;
- expose page-local mock handshake readiness and routed socket diagnostics;
- add success and failure-path readiness coverage, including four isolated browser contexts under concurrent full-page screenshots;
- document the maintainer workflow in `docs/DEPLOY.md`.

Every non-Next WebSocket is still intercepted locally and `connectToServer()` is never used, so there is no live-relay fallback.

## Validation

On merged base `b949c70cc03d86cf61ff2e584e1f602d1f066fc5` with exact `@connectonion/react@0.4.2-alpha.2`:

- `npm run build -- --webpack`: passed, 7/7 pages;
- `npx tsc --noEmit`: passed;
- full `npm run lint`: passed;
- `npm test`: 85/85 passed;
- readiness spec: 2/2 passed;
- production-build E2E without retries: 180/180 × 3 consecutive runs = 540/540;
- screenshot evidence: 246 PNGs in every run, no missing markers;
- invalid `E2E_WORKERS=4x`: rejected with the harness-specific configuration error.

The separate docs site has no public O Chat test-runner surface, so no docs-site change applies; the repository's maintainer deployment guide is updated.

Closes #145