### PR TITLE
ci: add O Chat CodeQL security gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+# Static analysis for the JavaScript and TypeScript O Chat ships.
+#
+# CodeQL extracts these interpreted languages directly, so installing npm
+# dependencies or building the app would add time without improving coverage.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Tuesday 04:43 UTC: re-run updated queries even when the code is unchanged.
+    - cron: '43 4 * * 2'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Required to upload the analysis to GitHub code scanning.
+      security-events: write
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24'
           cache: npm
@@ -36,6 +36,9 @@ jobs:
       # consumer does is the property whose absence made "green locally, red on
       # Vercel" possible twice in this repo.
       - run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
 
       # Static checks first: they take seconds and they are the ones that were
       # slipping through. main shipped a lint error because a local run was
@@ -63,7 +66,7 @@ jobs:
       # white on white — that is what these are for.
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: screenshots
           path: e2e-screenshots/
@@ -72,7 +75,7 @@ jobs:
 
       - name: Upload the full report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/
@@ -83,7 +86,7 @@ jobs:
       # thread. A link nobody clicks is not a review.
       - name: Comment on the pull request
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           OUTCOME: ${{ job.status }}
         with:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -101,6 +101,18 @@ git push                               # push the branch; merge the PR to main
 Vercel auto-deploys: a branch push builds a **preview**; a merge to `main` builds
 **production**. Confirm the preview is green before merging.
 
+Before merging, require both independent gates:
+
+- **E2E** installs the exact lockfile, audits dependencies, type-checks, lints,
+  runs unit and browser tests, and keeps the screenshot/report artifacts.
+- **CodeQL** analyzes all repository JavaScript and TypeScript on pull requests,
+  pushes to `main`, and a weekly schedule. Review every initial alert; do not
+  exclude the test tree wholesale. A test-only alert needs a precise disposition.
+
+Both workflows complement GitHub Dependabot and `npm audit`; none replaces the
+others. After the first clean CodeQL baseline, make its check required in branch
+protection so a missing, running, or failed analysis cannot be merged unnoticed.
+
 ### 4. If you symlinked for local dev, undo it before committing
 
 `package.json` must keep the semver. Only `node_modules` may point at a local checkout, and


### PR DESCRIPTION
## Outcome

Establish O Chat's first JavaScript/TypeScript CodeQL baseline without weakening or duplicating the existing product gates.

This changes CI and maintainer documentation only; it does not change runtime or UI behavior.

## Design

- analyze exactly `javascript-typescript` with `build-mode: none`;
- run on pull requests to `main`, pushes to `main`, and a weekly off-peak schedule;
- keep the default high-precision query suite and include tests in the analysis;
- grant only `contents: read` globally and `security-events: write` to the analysis job;
- pin all CodeQL and E2E GitHub-owned actions to verified immutable release commits;
- keep CodeQL independent from Dependabot, lockfile audit, lint, tests, build, and browser evidence.

The workflow follows GitHub's current [advanced setup](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configuring-advanced-setup-for-code-scanning) and [workflow configuration](https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options) guidance.

## Changes

- add a minimal two-step CodeQL analysis after checkout;
- add `npm audit --audit-level=high` to the existing E2E gate;
- pin checkout, setup-node, upload-artifact, and github-script in E2E;
- document how CodeQL, E2E, audit, and Dependabot complement one another and how to handle test-only alerts.

## Local validation

- both workflow files parse as YAML mappings with jobs;
- all eight action references use verified 40-character commit SHAs;
- `npm audit --audit-level=high`: 0 vulnerabilities;
- `npx tsc --noEmit`: passed;
- full `npm run lint`: passed;
- `npm test`: 85/85 passed;
- `npm run build -- --webpack`: passed, 7/7 pages;
- `git diff --check`: passed.

The public docs site has O Chat product/protocol pages but no maintainer CI configuration surface, so this repository-private security workflow is documented in `docs/DEPLOY.md` only.

## Post-merge owner step

Do not close #143 solely from this PR. After merge, confirm CodeQL succeeds on `main`, review the initial alert set, then require the clean CodeQL check in branch protection.

Advances #143