### PR TITLE
fix: preserve warmed drafts through Strict Mode replay

### DIFF
--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -162,11 +162,24 @@ export default function AgentLandingPage() {
   const clearRef = useRef(clear)
   useEffect(() => { clearRef.current = clear })
 
-  useEffect(() => () => {
-    // An abandoned draft (viewed, never sent) otherwise leaks its open WebSocket into
-    // the SDK's module-level agent cache and keeps a persisted session key — and those
-    // count against the SDK's 20-session cap, so browsing agents evicts real transcripts.
-    if (!promoted.current) clearRef.current()
+  const draftCleanup = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    // React Strict Mode replays effects in development. Cancel the simulated
+    // unmount's cleanup when this same draft immediately attaches again.
+    if (draftCleanup.current !== null) {
+      clearTimeout(draftCleanup.current)
+      draftCleanup.current = null
+    }
+
+    return () => {
+      // An abandoned draft (viewed, never sent) otherwise leaks its open WebSocket
+      // into the SDK cache and consumes the bounded Host session budget. Deferring
+      // one task distinguishes a real unmount from Strict Mode's immediate replay.
+      draftCleanup.current = setTimeout(() => {
+        draftCleanup.current = null
+        if (!promoted.current) clearRef.current()
+      }, 0)
+    }
   }, [])
 
   // `images` used to be `_images` — accepted and dropped. Sending here does not

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -107,6 +107,7 @@ export async function mockAgent(
    *  down and reopened behind the reader — the screen looks identical either way,
    *  which is what makes a screen-level assertion about it vacuous. */
   let connects = 0
+  let closes = 0
   let activeSessionId = 'e2e-session'
   let planInputs = 0
   /** Authoritative policy changes only after the mock Host answers ACP. */
@@ -123,6 +124,7 @@ export async function mockAgent(
   // the agent's own endpoint for a direct one — and the test should not care.
   await page.routeWebSocket(url => !url.pathname.includes('_next'), ws => {
     let connectedSessionId = activeSessionId
+    ws.onClose(() => { closes += 1 })
     ws.onMessage(raw => {
       const msg = JSON.parse(String(raw)) as {
         type: string
@@ -514,6 +516,8 @@ export async function mockAgent(
   return {
     /** Handshakes seen so far. */
     connects: () => connects,
+    /** Client-initiated socket closes seen so far. */
+    closes: () => closes,
     /** Frames of one type, in order. */
     sent: (type: string) => sent.filter(f => f.type === type),
     /** Release a deliberately parked Host permission acknowledgement. */

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -153,4 +153,16 @@ test.describe('coming back', () => {
     expect(agent.connects(), 'a working socket was torn down and reopened').toBe(before)
     await expect(page.getByText('You said: What can you do?')).toBeVisible()
   })
+
+  test('promoting a warmed draft keeps its one Host connection', async ({ page }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+    await expect.poll(() => agent.connects()).toBe(1)
+
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+    await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
+
+    expect(agent.connects(), 'route promotion replaced the warmed draft connection').toBe(1)
+  })
 })

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -165,4 +165,14 @@ test.describe('coming back', () => {
 
     expect(agent.connects(), 'route promotion replaced the warmed draft connection').toBe(1)
   })
+
+  test('leaving an unused draft closes its Host connection', async ({ page }) => {
+    const agent = await mockAgent(page)
+    await page.goto(`/${AGENT_ADDRESS}`)
+    await expect.poll(() => agent.connects()).toBe(1)
+
+    await page.goto('/')
+
+    await expect.poll(() => agent.closes()).toBe(1)
+  })
 })


### PR DESCRIPTION
## What changed

- defer abandoned-draft cleanup by one task;
- cancel that pending cleanup when React Strict Mode immediately reattaches the effect;
- retain the existing cleanup for a genuinely abandoned draft;
- add a Playwright wire-level regression proving landing-to-session promotion keeps one
  Host connection.

## Root cause

The landing page eagerly warms an SDK agent, then promotes it into a real conversation.
Its unmount-only cleanup called `clear()` during React Strict Mode's development effect
replay. That removed the still-referenced agent from the SDK cache. The landing agent
could then own a native ACP session while the session route opened a second connection
and attempted `session/resume`; the Host correctly rejected the duplicate lease.

This stays at O Chat's lifecycle boundary. O Chat does not construct ACP frames, parse a
Host protocol error, or add a retry. `@connectonion/react` remains the browser protocol
owner.

Fixes #149.

## Validation

- red/green local `next dev` regression: Host handshakes reduced from 2 to 1
- `npm test`: 11 files, 85 tests passed
- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`: 0 vulnerabilities
- real native ACP browser E2E on `next dev`: one pre-reload `session/new`, no pre-reload
  `session/resume`; response, permission, mode, cancel, continued prompt, reload/resume,
  desktop/mobile passed with no browser errors
- the same native ACP E2E passed against `next build && next start`

This pairs with openonion/connectonion-react#48 (tracking issue
openonion/connectonion-react#47), which shares the live-agent cache across Turbopack
route module evaluations.
