### PR TITLE
test(e2e): cover acp_agent browser contract

### DIFF
--- a/components/chat/messages/tools/generic-card.tsx
+++ b/components/chat/messages/tools/generic-card.tsx
@@ -48,6 +48,7 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
   const argsStr = formatArgs(args)
   const hasArgs = args && Object.keys(args).length > 0
   const hasOutput = result && result.length > 0
+  const expandable = Boolean(hasOutput || (needsApproval && hasArgs))
   const outputLines = result?.split('\n').length || 0
 
   const isError = status === 'error'
@@ -59,8 +60,9 @@ export function GenericCard({ toolCall, pendingApproval, onApprovalResponse }: G
       {/* Header — single-height ledger row: verb, one-line detail, right-pinned meta */}
       <button
         type="button"
+        aria-expanded={expandable ? isExpanded : undefined}
         className={`flex h-7 w-full items-center gap-1.5 cursor-pointer select-none text-left rounded-md px-1.5 -mx-1.5 py-1 -my-1 ${isError ? 'bg-red-50/60 hover:bg-red-50' : 'hover:bg-neutral-100/70'}`}
-        onClick={() => (hasOutput || (needsApproval && hasArgs)) && setIsExpanded(!isExpanded)}
+        onClick={() => expandable && setIsExpanded(!isExpanded)}
       >
         {/* Same 60px rail as the other tool rows. This card is the fallback for
             any tool without its own renderer, so if it drifts every unrecognised

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -235,6 +235,16 @@ access turn limit. `SESSION_STATUS` checks whether a session
 is still alive on the relay. `DASHBOARD_SNAPSHOT { html }` carries the agent's Home page
 — sent right after `CONNECTED`, and again after a run that changed the file.
 
+Generic downward coding-agent activity follows the same boundary. ConnectOnion's
+`acp_agent` adapter exposes only bounded child tool titles/lifecycle and its final
+result through canonical Host events. The Host may carry versioned ACP notifications
+beside legacy aliases during rollout; `@connectonion/react` parses and de-duplicates
+them by stable ID, while O Chat renders the resulting ordinary tool and agent cards.
+O Chat does not parse ACP, add provider-specific transcript state, or depend on the
+retired standalone TypeScript SDK. The deterministic browser contract lives in
+`e2e/acp-agent.spec.ts`; real Claude Code, Codex, and Gemini process coverage remains
+in the ConnectOnion core repository.
+
 Stopping a turn is deliberately not a wire concern in O Chat. The app calls
 `interrupt()` and updates its optimistic presentation; `@connectonion/react` selects
 negotiated ACP `session/cancel` or the one-shot legacy fallback. Application code must

--- a/e2e/acp-agent.spec.ts
+++ b/e2e/acp-agent.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Browser contract for ConnectOnion's generic downward acp_agent adapter.
+ *
+ * Real provider/process coverage lives in the core repository. This spec owns
+ * the other half of the release claim: the versioned Host carrier goes through
+ * @connectonion/react and renders in O Chat without a second parser, duplicate
+ * cards, or an ACP-specific component.
+ */
+
+import { type Page } from '@playwright/test'
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+const CHILD_TOOL_TITLE = 'Claude Code › Read file'
+const FINAL_RESULT = 'The ACP child finished after one bounded read.'
+
+async function runACPAgent(page: Page) {
+  await mockAgent(page, 'acp-agent')
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect(pane(page).getByText(FINAL_RESULT, { exact: true })).toBeVisible({
+    timeout: 15_000,
+  })
+}
+
+test('ACP child activity and the final result each render once', async ({ page, shot }) => {
+  await runACPAgent(page)
+  const transcript = pane(page).getByRole('log', { name: 'Conversation' })
+  const toolCard = transcript.getByRole('button').filter({ hasText: CHILD_TOOL_TITLE })
+
+  // ACP and legacy aliases share a stable tool ID, so the rollout produces one
+  // completed card rather than two nearly identical child activities.
+  await expect(toolCard).toHaveCount(1)
+  await expect(transcript.getByText(FINAL_RESULT, { exact: true })).toHaveCount(1)
+  await expect(transcript.getByText(/running…/)).toHaveCount(0)
+  await expect(toolCard).toHaveAttribute('aria-expanded', 'false')
+
+  await toolCard.click()
+  await expect(toolCard).toHaveAttribute('aria-expanded', 'true')
+  await shot('expanded-child-tool')
+})
+
+test.describe('phone', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('the completed ACP child exchange stays inside 375px', async ({ page, shot }) => {
+    await runACPAgent(page)
+
+    const layout = await page.evaluate(() => ({
+      width: document.documentElement.clientWidth,
+      overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    }))
+    expect(layout.width).toBe(375)
+    expect(layout.overflow, 'ACP child exchange scrolls sideways on a phone').toBeLessThanOrEqual(0)
+
+    await shot('completed')
+  })
+})

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel-acp' | 'cancel-legacy'
+export type Scenario = 'reply' | 'tools' | 'acp-agent' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel-acp' | 'cancel-legacy'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -49,6 +49,20 @@ export const DASHBOARD_HTML =
 
 const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
   ws.send(JSON.stringify(frame))
+
+const sendAcpUpdate = (
+  ws: WebSocketRoute,
+  sessionId: string,
+  update: Record<string, unknown>,
+) => send(ws, {
+  type: 'ACP_NOTIFICATION',
+  acpSchema: 'schema-v1.19.0',
+  message: {
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: { sessionId, update },
+  },
+})
 
 const approvalEvent = {
   id: 'approval-event-1',
@@ -409,6 +423,62 @@ export async function mockAgent(
           type: 'OUTPUT',
           result: 'Read the page, rebuilt the site, and updated the layout.\n\n```ts\nexport default function Layout({ children }: { children: React.ReactNode }) {\n  return <html><body>{children}</body></html>\n}\n```\n\nThe build finished in 4.2 seconds.',
           session: { session_id: connectedSessionId },
+        })
+        return
+      }
+
+      // The generic downward acp_agent adapter deliberately reuses the outer
+      // Host's normal tool lifecycle. React owns the ACP carrier parser and O
+      // Chat owns only this presentation, so exercise both sides of the rolling
+      // dual-write instead of inventing an acp_agent-specific UI event here.
+      if (scenario === 'acp-agent') {
+        const toolId = 'acp-child-tool-1'
+        const title = 'Claude Code › Read file'
+        const messageId = '6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e'
+        const result = 'The ACP child finished after one bounded read.'
+
+        sendAcpUpdate(ws, connectedSessionId, {
+          toolCallId: toolId,
+          title,
+          status: 'in_progress',
+          sessionUpdate: 'tool_call',
+        })
+        send(ws, {
+          type: 'tool_call',
+          tool_id: toolId,
+          name: title,
+          args: {},
+          status: 'in_progress',
+        })
+        sendAcpUpdate(ws, connectedSessionId, {
+          toolCallId: toolId,
+          status: 'completed',
+          content: [{ type: 'content', content: { type: 'text', text: title } }],
+          sessionUpdate: 'tool_call_update',
+        })
+        send(ws, {
+          type: 'tool_result',
+          tool_id: toolId,
+          name: title,
+          status: 'completed',
+          result: title,
+        })
+        sendAcpUpdate(ws, connectedSessionId, {
+          content: { type: 'text', text: result },
+          messageId,
+          sessionUpdate: 'agent_message_chunk',
+        })
+        send(ws, { type: 'thinking', id: 't1', status: 'done' })
+        send(ws, {
+          type: 'OUTPUT',
+          result,
+          session: {
+            session_id: connectedSessionId,
+            messages: [
+              { role: 'user', content: msg.prompt },
+              { role: 'assistant', content: result, id: messageId },
+            ],
+          },
         })
         return
       }


### PR DESCRIPTION
## Outcome

Prove the browser half of the generic downward `acp_agent` contract without adding a second protocol parser or an ACP-specific component.

The new Playwright scenario sends the versioned ACP `session/update` notifications and their rolling-upgrade legacy aliases through the real `@connectonion/react` reader. O Chat must render exactly one completed child tool card and exactly one final agent answer on desktop and at 375px.

## What changed

- add a deterministic `acp-agent` WebSocket scenario with tool start/completion, stable IDs, final message, and authoritative `OUTPUT`
- assert ACP/legacy twins do not duplicate the tool card or final answer
- assert the completed exchange has no lingering running state and no phone overflow
- document that React owns ACP parsing/de-duplication and that the retired standalone TypeScript SDK is not involved
- expose `aria-expanded` on expandable generic tool cards; the first browser run found that the chevron changed visually but assistive technology could not observe its state

## Design boundary

This follows ConnectOnion DD-035, DD-036, DD-043, and DD-052: the core adapter bounds child activity and emits canonical events, React owns browser protocol state, and O Chat remains a thin renderer. Child raw input/output, thoughts, and plans are not introduced as O Chat state.

The deterministic mock complements the real core-provider evidence on openonion/connectonion#901; it does not expose a local coding agent or workspace through a public relay.

## Validation

- `npm test` — 85 passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npx playwright test e2e/acp-agent.spec.ts --project=chromium` — 2 passed
- `npm run e2e` — 180 passed in 10.6m
- desktop and 375px screenshots inspected; one tool card, one answer, no horizontal overflow
- `git diff --check` — passed

Closes #152
Related: openonion/connectonion#900
Related: openonion/connectonion#901
