### PR TITLE
fix: render one invite verification form

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -291,6 +291,16 @@ export default function ChatSessionPage() {
   }
 
   const isFullAccessActive = permissionProfile === ':danger-full-access'
+  const showsInitialOnboardGate = Boolean(
+    pendingOnboard && !displayUI.some(item => item.type === 'user')
+  )
+  // ONBOARD_REQUIRED is the source for both onboarding surfaces. During an
+  // initial visit the dialog owns that challenge, so do not also mount the
+  // transcript form behind it. The inline card remains the right surface when
+  // an existing conversation is gated partway through.
+  const transcriptUI = showsInitialOnboardGate
+    ? displayUI.filter(item => item.type !== 'onboard_required')
+    : displayUI
 
   const chatPane = (
       <div className="flex flex-col flex-1 min-h-0 relative">
@@ -308,7 +318,7 @@ export default function ChatSessionPage() {
 
         {/* Chat with mode status bar (Full access toggle integrated) */}
         <Chat
-          ui={displayUI}
+          ui={transcriptUI}
           onSend={handleSend}
           onStop={interrupt}
           isLoading={isLoading}
@@ -401,9 +411,9 @@ export default function ChatSessionPage() {
           the onboard prompt is itself an item, so the length was never zero and
           the wall never rendered. What decides this is whether the reader has a
           conversation to lose, and that is what a user message means. */}
-      {pendingOnboard && !displayUI.some(item => item.type === 'user') && (
+      {showsInitialOnboardGate && (
         <OnboardGate
-          onboard={pendingOnboard}
+          onboard={pendingOnboard!}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
           onSubmit={(options: { inviteCode?: string; payment?: number }) => submitOnboard(options)}
         />

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -145,6 +145,13 @@ test.describe('a shared session link', () => {
     ).toBeVisible({ timeout: 20_000 })
 
     await expect(page.getByText(new RegExp(`${PROFILE.name} is invite-only`))).toBeVisible()
+    // One ONBOARD_REQUIRED frame used to mount both the wall and the transcript
+    // card behind it. That produced two code fields and two Continue buttons in
+    // the same document for one challenge.
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByRole('textbox')).toHaveCount(1)
+    await expect(dialog.getByRole('button', { name: /continue/i })).toHaveCount(1)
+    await expect(page.getByPlaceholder('Enter your invite code')).toHaveCount(0)
 
     await shot('gate')
   })


### PR DESCRIPTION
## Summary

- render the modal as the only onboarding surface for an initial gated visit
- keep the inline transcript challenge for gates that occur after conversation starts
- add a browser regression test proving one invite textbox and one Continue button exist

## Root cause

One `ONBOARD_REQUIRED` item fed both `OnboardGate` and the transcript `OnboardRequired` card. Both forms remained mounted in the document, so the page asked for the same verification code twice.

## Verification

- focused Chromium onboarding E2E passes
- unit tests, lint, and production build pass

Closes #158
