### PR TITLE
Fix duplicate onboarding verifier and add co ai journey

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -199,6 +199,17 @@ export default function ChatSessionPage() {
   // the persisted conversation on reload.
   const displayUI = useMemo((): UI[] => dedupeUI(hookUI), [hookUI])
 
+  // One pending challenge, one control. Before the reader has spoken, the
+  // full-screen gate owns onboarding and the same item must not also render as
+  // an interactive transcript card underneath it. Once a conversation exists,
+  // the gate stays away and the inline card remains the right place to answer.
+  const initialOnboard = pendingOnboard && !displayUI.some(item => item.type === 'user')
+    ? pendingOnboard
+    : null
+  const transcriptUI = initialOnboard
+    ? displayUI.filter(item => item.type !== 'onboard_required')
+    : displayUI
+
   // Keep the sidebar title in sync with the first user message
   useEffect(() => {
     if (!sessionId) return
@@ -308,7 +319,7 @@ export default function ChatSessionPage() {
 
         {/* Chat with mode status bar (Full access toggle integrated) */}
         <Chat
-          ui={displayUI}
+          ui={transcriptUI}
           onSend={handleSend}
           onStop={interrupt}
           isLoading={isLoading}
@@ -401,9 +412,9 @@ export default function ChatSessionPage() {
           the onboard prompt is itself an item, so the length was never zero and
           the wall never rendered. What decides this is whether the reader has a
           conversation to lose, and that is what a user message means. */}
-      {pendingOnboard && !displayUI.some(item => item.type === 'user') && (
+      {initialOnboard && (
         <OnboardGate
-          onboard={pendingOnboard}
+          onboard={initialOnboard}
           agentName={agentInfoMap[address]?.name || shortAddress(address)}
           onSubmit={(options: { inviteCode?: string; payment?: number }) => submitOnboard(options)}
         />

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -105,6 +105,11 @@ Before merging, require both independent gates:
 
 - **E2E** installs the exact lockfile, audits dependencies, type-checks, lints,
   runs unit and browser tests, and keeps the screenshot/report artifacts.
+  Its representative `co ai` journey types and sends a release question through
+  the real discovery/WebSocket/UI stack, verifies the tool call and final answer,
+  and saves both desktop and 390px-phone conversation screenshots. Onboarding
+  coverage separately proves an initial invite challenge has exactly one verifier
+  while a challenge raised mid-conversation stays inline with the readable thread.
 - **CodeQL** analyzes all repository JavaScript and TypeScript on pull requests,
   pushes to `main`, and a weekly schedule. Review every initial alert; do not
   exclude the test tree wholesale. A test-only alert needs a precise disposition.

--- a/e2e/co-ai-conversation.spec.ts
+++ b/e2e/co-ai-conversation.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * A representative co ai conversation, kept as visual release evidence.
+ *
+ * The scripted Host keeps CI deterministic while the browser still exercises
+ * the production HTTP discovery, WebSocket parser, signed input, route change,
+ * tool card, final answer, persistence, and responsive transcript UI.
+ */
+
+import { test, expect, pane } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+const prompt = 'Check this machine and tell me whether it is ready for the 1.6.8 release.'
+
+test('co ai receives a real input and leaves reviewable desktop and phone screenshots', async ({ page, shot }) => {
+  // Do not race first-paint identity hydration: a late store hydrate can replace
+  // text typed into the landing composer before React owns the field.
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'oo-chat-storage',
+      JSON.stringify({ state: { conversations: [], agents: [] }, version: 0 }),
+    )
+  })
+  await mockAgent(page, 'tools', {
+    name: 'co ai',
+    skills: [{ name: 'release', description: 'Review and ship a stable release' }],
+  })
+  await page.goto(`/${AGENT_ADDRESS}`)
+
+  await expect(page.getByRole('heading', { name: 'co ai', exact: true })).toBeVisible({ timeout: 20_000 })
+  const composer = page.getByPlaceholder('Message this agent...')
+  await expect(composer).toBeEditable()
+  await composer.fill(prompt)
+  await expect(composer).toHaveValue(prompt)
+  const send = page.getByRole('button', { name: 'Send message' })
+  await expect(send).toBeEnabled()
+  await send.click()
+
+  await expect(page).toHaveURL(new RegExp(`${AGENT_ADDRESS}/.+`))
+  await expect(pane(page).getByText(prompt)).toBeVisible({ timeout: 20_000 })
+  await expect(pane(page).getByText('check the kernel')).toBeVisible()
+  await expect(pane(page).getByText('Darwin 23.1.0 arm64')).toBeVisible()
+  const answer = pane(page).locator('p').filter({ hasText: 'The machine reports' })
+  await expect(answer).toContainText('The machine reports Darwin 23.1.0 arm64.')
+  await expect(answer.locator('code')).toHaveText('Darwin 23.1.0 arm64')
+
+  await shot('desktop-conversation')
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  )
+  expect(overflow, 'the co ai transcript scrolls sideways on a phone').toBeLessThanOrEqual(0)
+  await expect(pane(page).getByText('Darwin 23.1.0 arm64')).toBeVisible()
+  await shot('phone-conversation')
+})

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -146,7 +146,14 @@ test.describe('a shared session link', () => {
 
     await expect(page.getByText(new RegExp(`${PROFILE.name} is invite-only`))).toBeVisible()
 
-    await shot('gate')
+    // ONBOARD_REQUIRED is also a transcript item. The full-screen gate owns it
+    // before the first user message, so rendering both creates duplicate form
+    // controls even though the opaque wall visually hides one of them (#158).
+    await expect(page.getByPlaceholder(/invite code/i), 'two invite fields exist for one challenge').toHaveCount(1)
+    await expect(page.getByRole('button', { name: /continue/i }), 'two Continue buttons exist for one challenge').toHaveCount(1)
+    await expect(page.getByText(/verification required/i)).toHaveCount(0)
+
+    await shot('single-verifier')
   })
 
   test('nothing behind the gate invites a message', async ({ page }) => {
@@ -184,6 +191,8 @@ test.describe('an agent that gates partway through', () => {
     // condition draws, and the branch it would be easy to get wrong.
     await expect(page.getByText(/verification required/i)).toBeVisible({ timeout: 20_000 })
     await expect(page.getByRole('dialog'), 'the wall covered an existing conversation').toHaveCount(0)
+    await expect(page.getByPlaceholder(/invite code/i), 'the inline verifier disappeared').toHaveCount(1)
+    await expect(page.getByRole('button', { name: /continue/i })).toHaveCount(1)
     // Scoped to the pane: unscoped, the first match is the drawer's session title,
     // which is hidden. That has now cost four tests across these passes.
     await expect(page.locator('main').getByText('What can you do?').first()).toBeVisible()


### PR DESCRIPTION
Closes #158

## What changed

- names the initial onboarding state once on the session page
- lets the full-screen gate exclusively own a challenge before the first user message
- keeps the inline transcript verifier when an agent gates after conversation has begun
- asserts exactly one invite field and one Continue button in both paths
- adds a representative `co ai` E2E journey that types a release question, crosses discovery/WebSocket/session routing, renders a tool call and final answer, checks phone overflow, and captures desktop + mobile conversation screenshots
- documents the browser evidence expected before deployment

## Verification

- TypeScript: clean
- ESLint: clean
- Vitest: 90/90
- focused Chromium onboarding suite: all existing cases passed; the corrected initial and mid-conversation verifier cases pass
- co ai Chromium journey: passed with desktop and 390px phone screenshots
- Playwright discovery: 181 tests across 36 files

The screenshots were visually reviewed: the initial gate has one verifier; the co ai transcript is readable on desktop and phone with no horizontal overflow.