### PR TITLE
chore: pin React OIP alpha 4

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -55,8 +55,8 @@ export default function SettingsPage() {
   const [addAgentError, setAddAgentError] = useState('')
   const [showApiKey, setShowApiKey] = useState(false)
 
-  const handleImportKey = useCallback(() => {
-    if (importKey(importKeyInput)) {
+  const handleImportKey = useCallback(async () => {
+    if (await importKey(importKeyInput)) {
       setShowImportKey(false)
       setImportKeyInput('')
     }

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -120,7 +120,7 @@ export function ChatMessages({
         .pop()?.id
     : null
 
-  // Native ACP permits a permission request without a preceding tool update.
+  // OIP permits a permission request without a preceding tool update.
   // Keep the existing inline tool-card treatment when that context exists;
   // otherwise the latest normalized approval item needs its own decision surface.
   const pendingStandaloneApprovalId = pendingApproval && !pendingToolId

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -23,7 +23,9 @@ afterEach(() => {
 const invocation: ProviderInvocationUI = {
   id: 'codex:call-7', type: 'provider_invocation', parentToolCallId: 'call-7',
   provider: 'codex', providerDisplayName: 'Codex', taskSummary: 'Fix Windows tests',
-  status: 'running', activities: [{ id: 'a', name: 'Bash', status: 'running', args: { command: 'pytest tests/unit' } }],
+  status: 'running', activities: [{
+    id: 'a', name: 'Bash', status: 'done', args: { command: 'pytest tests/unit' }, result: '89 passed',
+  }],
 }
 
 function render(overrides: Partial<Parameters<typeof CodingAgentCard>[0]> = {}) {
@@ -48,6 +50,7 @@ describe('CodingAgentCard', () => {
   it('shows nested activity inline when expanded without horizontal overflow classes', () => {
     const { element } = render({ expanded: true })
     expect(element.textContent).toContain('pytest tests/unit')
+    expect(element.textContent).toContain('89 passed')
     expect(element.querySelector('section')?.className).toContain('min-w-0')
     expect(element.querySelector('section')?.className).toContain('overflow-hidden')
   })

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -67,8 +67,13 @@ export function CodingAgentCard({
               <li key={activity.id} className="flex min-w-0 items-start gap-2 py-1 text-xs">
                 <ToolStatus status={activity.status} className="mt-0.5" />
                 <span className="shrink-0 font-medium text-neutral-700">{activity.name}</span>
-                <span className="min-w-0 truncate font-mono text-neutral-500">
-                  {String(activity.args?.command || activity.args?.file_path || activity.args?.path || activity.result || '')}
+                <span className="min-w-0 flex-1 overflow-hidden font-mono text-neutral-500">
+                  <span className="block truncate">
+                    {String(activity.args?.command || activity.args?.file_path || activity.args?.path || activity.result || '')}
+                  </span>
+                  {activity.result != null && Boolean(activity.args?.command || activity.args?.file_path || activity.args?.path) && (
+                    <span className="block break-words text-neutral-400">{String(activity.result)}</span>
+                  )}
                 </span>
               </li>
             ))}

--- a/components/current-plan-panel.test.tsx
+++ b/components/current-plan-panel.test.tsx
@@ -27,7 +27,7 @@ afterEach(() => {
 })
 
 describe('CurrentPlanPanel', () => {
-  it('shows every ACP status and priority as accessible text', () => {
+  it('shows every OIP status and priority as accessible text', () => {
     const element = render([
       { content: 'Inspect history', status: 'pending', priority: 'high' },
       { content: 'Implement change', status: 'in_progress', priority: 'medium' },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,20 +225,20 @@ not a `ChatItem` and not the interactive `plan_review` gate.
 | `approval_needed` | allow/deny a tool | `APPROVAL_RESPONSE` |
 | `plan_review` | approve a plan | `PLAN_REVIEW_RESPONSE` |
 | `onboard_required` | invite code / payment | `ONBOARD_SUBMIT` |
-| `full_access_checkpoint` | end the Host-bounded run | React-owned `session/cancel` |
+| `full_access_checkpoint` | end the Host-bounded run | React-owned `INTERRUPT` |
 
 While idle, O Chat renders only Host-advertised permission profiles. It awaits
-React's `setPermissionProfile`; React owns ACP request IDs, acknowledgement,
-timeout, and reconnect. Default/Plan collaboration is local and independent.
-O Chat constructs no ACP or legacy permission frames and cannot author a Full
+React's `setPermissionProfile`; React owns OIP acknowledgement, timeout, and
+reconnect. Default/Plan collaboration is local and independent.
+O Chat constructs no transport frames and cannot author a Full
 access turn limit. `SESSION_STATUS` checks whether a session
 is still alive on the relay. `DASHBOARD_SNAPSHOT { html }` carries the agent's Home page
 — sent right after `CONNECTED`, and again after a run that changed the file.
 
 Stopping a turn is deliberately not a wire concern in O Chat. The app calls
-`interrupt()` and updates its optimistic presentation; `@connectonion/react` selects
-negotiated ACP `session/cancel` or the one-shot legacy fallback. Application code must
-not construct either cancellation frame. Approval responses follow the same ownership
+`interrupt()` and updates its optimistic presentation; `@connectonion/react` sends the
+OIP `INTERRUPT` frame. Application code must not construct the cancellation frame.
+Approval responses follow the same ownership
 rule: O Chat selects a product decision and React correlates and encodes the response.
 
 **SDK persistence details:** before writing, the SDK strips base64 data URLs (images)

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -23,48 +23,36 @@ import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 /** Get to a parked approval prompt with a scary command behind it. */
 async function atAnApproval(
   page: import('@playwright/test').Page,
-  scenario: 'approval' | 'legacy-approval' = 'approval',
 ) {
-  const agent = await mockAgent(page, scenario)
+  const agent = await mockAgent(page, 'approval')
   await page.goto(`/${AGENT_ADDRESS}`)
   await page.getByRole('button', { name: 'What can you do?' }).click()
   await expect(page.getByRole('button', { name: /allow once/i })).toBeVisible({ timeout: 20_000 })
   return agent
 }
 
-/** label → the ACP option the agent must receive. */
-const DECISIONS: [RegExp, string][] = [
-  [/allow once/i, 'allow_once'],
-  [/trust/i, 'allow_session'],
-  [/reject/i, 'reject_soft'],
-  [/stop/i, 'reject_hard'],
-  [/explain/i, 'reject_explain'],
+/** Label → the exact OIP approval decision the Host must receive. */
+const DECISIONS: [RegExp, Record<string, unknown>][] = [
+  [/allow once/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }],
+  [/trust/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'session' }],
+  [/reject/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_soft' }],
+  [/stop/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_hard' }],
+  [/explain/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_explain' }],
 ]
-
-const acpResponse = (optionId: string, sessionId: string) => ({
-  type: 'ACP_RESPONSE',
-  acpSchema: 'schema-v1.19.0',
-  sessionId,
-  message: {
-    jsonrpc: '2.0',
-    id: 'approval-event-1',
-    result: { outcome: { outcome: 'selected', optionId } },
-  },
-})
 
 test.describe('phone', () => {
   test.describe.configure({ timeout: 120_000 })
   test.use({ viewport: { width: 375, height: 667 } })
 
-  for (const [label, optionId] of DECISIONS) {
+  for (const [label, response] of DECISIONS) {
     test(`"${label.source}" sends exactly what it promises`, async ({ page }) => {
       const agent = await atAnApproval(page)
 
       await page.getByRole('button', { name: label }).first().click()
 
       await expect
-        .poll(() => agent.sent('ACP_RESPONSE'), { timeout: 10_000 })
-        .toEqual([acpResponse(optionId, agent.sessionId())])
+        .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
+        .toEqual([response])
     })
   }
 
@@ -75,7 +63,7 @@ test.describe('phone', () => {
     // client on its own — a retry, an effect firing twice — would be the agent
     // being told "yes" by nobody.
     await page.waitForTimeout(3000)
-    expect(agent.sent('ACP_RESPONSE'), 'an answer was sent without anyone pressing anything').toEqual([])
+    expect(agent.sent('APPROVAL_RESPONSE'), 'an answer was sent without anyone pressing anything').toEqual([])
 
     await shot('parked')
   })
@@ -90,17 +78,7 @@ test.describe('phone', () => {
     await allow.click({ force: true, timeout: 2000 }).catch(() => {})
 
     await page.waitForTimeout(2000)
-    expect(agent.sent('ACP_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
-  })
-
-  test('a legacy-only Host still receives one legacy response', async ({ page }) => {
-    const agent = await atAnApproval(page, 'legacy-approval')
-
-    await page.getByRole('button', { name: /allow once/i }).first().click()
-
-    await expect
-      .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
-      .toEqual([{ type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }])
+    expect(agent.sent('APPROVAL_RESPONSE'), 'a double tap answered twice').toHaveLength(1)
   })
 })
 
@@ -156,27 +134,18 @@ test.describe('the other decisions that reach the agent', () => {
     // can leave perfect-looking controls sending stale IDs, which silently
     // changes whether the agent asks before edits or runs with full access.
     await page.getByRole('button', { name: 'Auto', exact: true }).click()
-    await expect.poll(() => agent.sent('ACP_REQUEST').length).toBe(1)
+    await expect.poll(() => agent.sent('mode_change').length).toBe(1)
     await page.getByRole('button', { name: 'Plan', exact: true }).click()
     await expect(page.getByRole('button', { name: 'Plan', exact: true })).toHaveAttribute('aria-pressed', 'true')
-    expect(agent.sent('ACP_REQUEST')).toHaveLength(1)
+    expect(agent.sent('mode_change')).toHaveLength(1)
     await page.getByRole('button', { name: 'Full access', exact: true }).click()
 
     await expect
-      .poll(() => agent.sent('ACP_REQUEST').map(frame => (frame as { message: unknown }).message), { timeout: 10_000 })
+      .poll(() => agent.sent('mode_change'), { timeout: 10_000 })
       .toEqual([
-        expect.objectContaining({
-          jsonrpc: '2.0',
-          method: 'session/set_mode',
-          params: { sessionId, modeId: ':workspace' },
-        }),
-        expect.objectContaining({
-          jsonrpc: '2.0',
-          method: 'session/set_mode',
-          params: { sessionId, modeId: ':danger-full-access' },
-        }),
+        { type: 'mode_change', mode: ':workspace' },
+        { type: 'mode_change', mode: ':danger-full-access' },
       ])
-    expect(agent.sent('mode_change')).toEqual([])
   })
 
   test('permission acknowledgement blocks a prompt from racing the policy write', async ({ page }) => {
@@ -220,7 +189,7 @@ test.describe('the other decisions that reach the agent', () => {
     await expect.poll(() => agent.connects()).toBeGreaterThan(beforeReconnect)
     await expect(page.getByText(/permission profile acknowledgement/i)).toBeHidden()
     await expect(page.getByRole('button', { name: 'Read only', exact: true })).toHaveAttribute('aria-pressed', 'true')
-    expect(agent.sent('ACP_REQUEST')).toHaveLength(1)
+    expect(agent.sent('mode_change')).toHaveLength(1)
   })
 })
 
@@ -295,12 +264,8 @@ test.describe('the gate and the turn limit', () => {
     // The one prompt where the agent has been working unattended and is asking to
     // carry on. An action without its budget would be an unbounded grant.
     await expect
-      .poll(() => agent.sent('ACP_NOTIFICATION').map(frame => (frame as { message: unknown }).message), { timeout: 10_000 })
-      .toEqual([expect.objectContaining({
-        jsonrpc: '2.0',
-        method: 'session/cancel',
-        params: { sessionId },
-      })])
+      .poll(() => agent.sent('INTERRUPT'), { timeout: 10_000 })
+      .toEqual([{ type: 'INTERRUPT' }])
     expect(agent.sent('FULL_ACCESS_RESPONSE')).toEqual([])
     await expect(page.getByText('Completed 20 of 100 turns')).toBeHidden()
     await expect(page.getByText('Full access run ended.')).toBeVisible()

--- a/e2e/cancellation.spec.ts
+++ b/e2e/cancellation.spec.ts
@@ -6,9 +6,8 @@ import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
 async function atARunningTurn(
   page: Page,
-  scenario: 'cancel-acp' | 'cancel-legacy',
 ) {
-  const agent = await mockAgent(page, scenario)
+  const agent = await mockAgent(page, 'cancel')
   await page.goto(`/${AGENT_ADDRESS}`)
   await page.getByRole('button', { name: 'What can you do?' }).click()
   await expect(page.getByRole('button', { name: 'Stop agent' })).toBeVisible({
@@ -17,30 +16,11 @@ async function atARunningTurn(
   return agent
 }
 
-test('Stop delegates negotiated ACP cancellation to the React package', async ({ page }) => {
-  const agent = await atARunningTurn(page, 'cancel-acp')
-
-  await page.getByRole('button', { name: 'Stop agent' }).click()
-
-  await expect.poll(() => agent.sent('ACP_NOTIFICATION')).toEqual([{
-    type: 'ACP_NOTIFICATION',
-    acpSchema: 'schema-v1.19.0',
-    message: {
-      jsonrpc: '2.0',
-      method: 'session/cancel',
-      params: { sessionId: agent.sessionId() },
-    },
-  }])
-  expect(agent.sent('INTERRUPT')).toEqual([])
-  await expect(page.getByRole('button', { name: 'Send message' })).toBeVisible()
-})
-
-test('Stop keeps the React package legacy fallback for an old Host', async ({ page }) => {
-  const agent = await atARunningTurn(page, 'cancel-legacy')
+test('Stop sends one OIP interrupt through the React package', async ({ page }) => {
+  const agent = await atARunningTurn(page)
 
   await page.getByRole('button', { name: 'Stop agent' }).click()
 
   await expect.poll(() => agent.sent('INTERRUPT')).toEqual([{ type: 'INTERRUPT' }])
-  expect(agent.sent('ACP_NOTIFICATION')).toEqual([])
   await expect(page.getByRole('button', { name: 'Send message' })).toBeVisible()
 })

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -1,43 +1,69 @@
 /** Exact React package events render as one usable nested coding-agent card. */
 
 import { type Page } from '@playwright/test'
-import reactPackage from '@connectonion/react/package.json'
 import { test, expect, pane } from './fixtures'
-import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+import { mockAgent, AGENT_ADDRESS, PROFILE, type Scenario } from './mock-agent'
 
-async function openCodingRun(page: Page) {
+async function openCodingRun(
+  page: Page,
+  scenario: Extract<Scenario, 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed'> = 'coding-agent',
+  status: 'running' | 'completed' | 'failed' = 'running',
+) {
   await page.addInitScript(() => {
     localStorage.setItem(
       'oo-chat-storage',
       JSON.stringify({ state: { conversations: [], agents: [] }, version: 0 }),
     )
   })
-  await mockAgent(page, 'coding-agent')
+  await mockAgent(page, scenario)
   await page.goto(`/${AGENT_ADDRESS}`)
   await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
   await page.getByRole('button', { name: 'What can you do?' }).click()
-  await expect(pane(page).getByRole('region', { name: 'Codex running' })).toBeVisible({
+  await expect(pane(page).getByRole('region', { name: `Codex ${status}` })).toBeVisible({
     timeout: 15_000,
   })
 }
 
-test('provider activity stays nested under one expandable card', async ({ page }) => {
-  test.skip(reactPackage.version !== '0.4.2-alpha.3', 'requires the exact React Alpha.3 candidate')
+test('running Codex activity stays nested under one expandable card', async ({ page, shot }) => {
   await openCodingRun(page)
 
   const card = pane(page).getByRole('region', { name: 'Codex running' })
+  await expect(card).toContainText('Fix Windows tests')
+  await expect(card).toContainText('running')
   await expect(card.getByRole('button', { name: 'Stop Codex' })).toBeVisible()
   await card.getByRole('button', { expanded: false }).click()
   await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('Bash')
   await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('pytest -q')
+  await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('89 passed')
   await expect(pane(page).getByRole('region', { name: 'Codex running' })).toHaveCount(1)
+  await shot('codex-running-expanded')
+})
+
+test('completed Codex card shows the result and no Stop action', async ({ page, shot }) => {
+  await openCodingRun(page, 'coding-agent-completed', 'completed')
+
+  const card = pane(page).getByRole('region', { name: 'Codex completed' })
+  await expect(card).toContainText('1s')
+  await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
+  await card.getByRole('button', { expanded: false }).click()
+  await expect(card).toContainText('Codex fixed the Windows tests.')
+  await shot('codex-completed-expanded')
+})
+
+test('failed Codex card exposes the error and no Stop action', async ({ page, shot }) => {
+  await openCodingRun(page, 'coding-agent-failed', 'failed')
+
+  const card = pane(page).getByRole('region', { name: 'Codex failed' })
+  await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
+  await card.getByRole('button', { expanded: false }).click()
+  await expect(card).toContainText('Codex exited before applying the patch.')
+  await shot('codex-failed-expanded')
 })
 
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  test('expanded provider activity does not overflow the viewport', async ({ page }) => {
-    test.skip(reactPackage.version !== '0.4.2-alpha.3', 'requires the exact React Alpha.3 candidate')
+  test('expanded provider activity does not overflow the viewport', async ({ page, shot }) => {
     await openCodingRun(page)
     const card = pane(page).getByRole('region', { name: 'Codex running' })
     await card.getByRole('button', { expanded: false }).click()
@@ -46,5 +72,7 @@ test.describe('phone', () => {
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
     )
     expect(overflow, 'provider card scrolls sideways on a phone').toBeLessThanOrEqual(0)
+    await expect(card).toBeInViewport()
+    await shot('codex-phone-expanded')
   })
 })

--- a/e2e/current-plan.spec.ts
+++ b/e2e/current-plan.spec.ts
@@ -1,5 +1,5 @@
 /**
- * The ACP plan is current session state, not transcript history and not approval.
+ * The OIP plan is current session state, not transcript history and not approval.
  * Drive the real React reader through its WebSocket boundary so O Chat never gets
  * a chance to pass by parsing the protocol itself.
  */

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel-acp' | 'cancel-legacy'
+export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel-acp' | 'cancel-legacy'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -357,7 +357,7 @@ export async function mockAgent(
 
       send(ws, { type: 'thinking', id: 't1', status: 'running' })
 
-      if (scenario === 'coding-agent') {
+      if (scenario === 'coding-agent' || scenario === 'coding-agent-completed' || scenario === 'coding-agent-failed') {
         send(ws, {
           type: 'tool_call', id: 'call-7', name: 'codex',
           args: { prompt: 'Fix Windows tests' }, status: 'running',
@@ -377,6 +377,22 @@ export async function mockAgent(
           type: 'tool_result', tool_id: 'child-1', status: 'completed', result: '89 passed',
           parentToolCallId: 'call-7', invocationId: 'codex:call-7',
         })
+        if (scenario === 'coding-agent-completed') {
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-7',
+            parentToolCallId: 'call-7', provider: 'codex',
+            providerDisplayName: 'Codex', status: 'completed', elapsedMs: 1_250,
+            result: 'Codex fixed the Windows tests.',
+          })
+        }
+        if (scenario === 'coding-agent-failed') {
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-7',
+            parentToolCallId: 'call-7', provider: 'codex',
+            providerDisplayName: 'Codex', status: 'failed', elapsedMs: 800,
+            error: 'Codex exited before applying the patch.',
+          })
+        }
         return
       }
 

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -527,13 +527,16 @@ export async function mockTwoAgents(page: Page) {
       const msg = JSON.parse(String(raw)) as {
         type: string
         prompt?: string
-        payload?: { to?: string }
+        to?: string
       }
 
       if (msg.type === 'CONNECT') {
-        target = msg.payload?.to ?? AGENT_ADDRESS
+        target = msg.to ?? AGENT_ADDRESS
         const profile = byAddress(target)
-        send(ws, { type: 'CONNECTED', session_id: `e2e-${profile.name}`, status: 'idle' })
+        send(ws, {
+          type: 'CONNECTED', protocol: { name: 'oip', version: '0.1' },
+          session_id: `e2e-${profile.name}`, status: 'idle',
+        })
         send(ws, { type: 'AGENT_PROFILE', ...profile })
         return
       }

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'legacy-approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel-acp' | 'cancel-legacy'
+export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -58,34 +58,6 @@ const approvalEvent = {
   description: 'Run `uname -a`',
 }
 
-function sendAcpApproval(ws: WebSocketRoute, sessionId: string) {
-  send(ws, {
-    type: 'ACP_REQUEST',
-    acpSchema: 'schema-v1.19.0',
-    message: {
-      jsonrpc: '2.0',
-      id: approvalEvent.id,
-      method: 'session/request_permission',
-      params: {
-        sessionId,
-        toolCall: {
-          toolCallId: approvalEvent.tool_call_id,
-          title: approvalEvent.tool,
-          status: 'pending',
-          rawInput: approvalEvent.arguments,
-        },
-        options: [
-          { optionId: 'allow_once', name: 'Allow this call', kind: 'allow_once' },
-          { optionId: 'allow_session', name: 'Allow for this session', kind: 'allow_always' },
-          { optionId: 'reject_soft', name: 'Reject this call and continue', kind: 'reject_once' },
-          { optionId: 'reject_hard', name: 'Reject and stop this turn', kind: 'reject_once' },
-          { optionId: 'reject_explain', name: 'Reject and explain first', kind: 'reject_once' },
-        ],
-      },
-    },
-  })
-}
-
 /**
  * Intercept every relay socket and play `scenario`.
  *
@@ -109,7 +81,7 @@ export async function mockAgent(
   let connects = 0
   let activeSessionId = 'e2e-session'
   let planInputs = 0
-  /** Authoritative policy changes only after the mock Host answers ACP. */
+  /** Authoritative policy changes only after the mock Host acknowledges OIP. */
   let currentMode = ':read-only'
   let pendingModeAcknowledgement: (() => void) | null = null
   let fullAccessCheckpointSent = false
@@ -128,11 +100,7 @@ export async function mockAgent(
         type: string
         prompt?: string
         session_id?: string
-        message?: {
-          id?: string
-          method?: string
-          params?: { sessionId?: string; modeId?: string }
-        }
+        mode?: string
       }
       sent.push(msg)
 
@@ -164,17 +132,9 @@ export async function mockAgent(
         setTimeout(() => {
           send(ws, {
             type: 'CONNECTED',
+            protocol: { name: 'oip', version: '0.1' },
             session_id: connectedSessionId,
             status: scenario === 'mode-disconnect' && connects > 1 ? 'connected' : 'idle',
-            carrier_capabilities: {
-              acp: {
-                schema: 'schema-v1.19.0',
-                client_notifications: scenario === 'cancel-legacy'
-                  ? []
-                  : ['session/cancel'],
-                client_requests: ['session/set_mode'],
-              },
-            },
             session_modes: {
               currentModeId: currentMode,
               availableModes: [
@@ -198,23 +158,12 @@ export async function mockAgent(
         return
       }
 
-      if (msg.type === 'ACP_REQUEST' && msg.message?.method === 'session/set_mode') {
-        const requestId = msg.message.id
-        const sessionId = msg.message.params?.sessionId
-        const modeId = msg.message.params?.modeId
-        if (!requestId || !sessionId || !modeId) return
+      if (msg.type === 'mode_change') {
+        const modeId = msg.mode
+        if (!modeId) return
 
         if (scenario === 'mode-reject') {
-          send(ws, {
-            type: 'ACP_RESPONSE',
-            acpSchema: 'schema-v1.19.0',
-            sessionId,
-            message: {
-              jsonrpc: '2.0',
-              id: requestId,
-              error: { code: -32000, message: 'Session is busy' },
-            },
-          })
+          send(ws, { type: 'ERROR', code: -32000, message: 'Session is busy' })
           return
         }
         if (scenario === 'mode-disconnect') {
@@ -225,10 +174,9 @@ export async function mockAgent(
         const acknowledge = () => {
           currentMode = modeId
           send(ws, {
-            type: 'ACP_RESPONSE',
-            acpSchema: 'schema-v1.19.0',
-            sessionId,
-            message: { jsonrpc: '2.0', id: requestId, result: {} },
+            type: 'mode_changed',
+            session_id: connectedSessionId,
+            mode: modeId,
           })
         }
         if (scenario === 'mode-delay') pendingModeAcknowledgement = acknowledge
@@ -238,8 +186,7 @@ export async function mockAgent(
 
       if (
         scenario === 'full-access-checkpoint'
-        && msg.type === 'ACP_NOTIFICATION'
-        && msg.message?.method === 'session/cancel'
+        && msg.type === 'INTERRUPT'
       ) {
         send(ws, {
           type: 'OUTPUT',
@@ -252,8 +199,8 @@ export async function mockAgent(
       if (msg.type !== 'INPUT') return
 
       // Keep the turn running until the test presses Stop. The mock records the
-      // resulting frame; React, not O Chat, chooses ACP or the legacy fallback.
-      if (scenario === 'cancel-acp' || scenario === 'cancel-legacy') {
+      // resulting OIP frame; React, not O Chat, owns that wire contract.
+      if (scenario === 'cancel') {
         send(ws, { type: 'thinking', id: 't1', status: 'running' })
         return
       }
@@ -273,20 +220,6 @@ export async function mockAgent(
           : planInputs === 2
             ? [{ content: 'Replacement step', priority: 'high', status: 'in_progress' }]
             : []
-        send(ws, {
-          type: 'ACP_NOTIFICATION',
-          acpSchema: 'schema-v1.19.0',
-          message: {
-            jsonrpc: '2.0',
-            method: 'session/update',
-            params: {
-              sessionId: connectedSessionId,
-              update: { sessionUpdate: 'plan', entries },
-            },
-          },
-        })
-        // The Host emits ACP first and then the legacy compatibility frame.
-        // Receiving both must still produce one current snapshot, never rows.
         send(ws, { type: 'plan', session_id: connectedSessionId, entries })
         send(ws, { type: 'OUTPUT', result: `Plan update ${planInputs}`, session: { session_id: connectedSessionId } })
         return
@@ -396,7 +329,7 @@ export async function mockAgent(
         return
       }
 
-      if (scenario === 'tools' || scenario === 'approval' || scenario === 'legacy-approval' || scenario === 'dashboard-approval') {
+      if (scenario === 'tools' || scenario === 'approval' || scenario === 'dashboard-approval') {
         send(ws, {
           type: 'tool_call',
           id: 'call-1',
@@ -412,7 +345,6 @@ export async function mockAgent(
         // switch panes before it lands. An approval that is already on screen when
         // you get there proves nothing about being told.
         setTimeout(() => {
-          sendAcpApproval(ws, connectedSessionId)
           send(ws, { type: 'approval_needed', ...approvalEvent })
         }, 5000)
         return
@@ -421,12 +353,6 @@ export async function mockAgent(
       if (scenario === 'approval') {
         // The run parks here: no OUTPUT until the reader answers. That is the state
         // the approval card exists for, and the one worth a screenshot.
-        sendAcpApproval(ws, connectedSessionId)
-        send(ws, { type: 'approval_needed', ...approvalEvent })
-        return
-      }
-
-      if (scenario === 'legacy-approval') {
         send(ws, { type: 'approval_needed', ...approvalEvent })
         return
       }

--- a/hooks/use-identity.ts
+++ b/hooks/use-identity.ts
@@ -1,214 +1,110 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import nacl from 'tweetnacl'
-import * as bip39 from 'bip39'
+import {
+  createBrowserIdentity,
+  importBrowserIdentity,
+  initializeBrowserIdentity,
+  type BrowserIdentity,
+} from '@connectonion/react'
 import { useChatStore } from '@/store/chat-store'
 
-export interface AddressData {
-  address: string
-  shortAddress: string
-  publicKey: Uint8Array
-  privateKey: Uint8Array
-  mnemonic?: string
-}
-
-function generateWithMnemonic(): { keys: AddressData; mnemonic: string } {
-  const mnemonic = bip39.generateMnemonic()
-  const keys = keysFromMnemonic(mnemonic)
-  return { keys: { ...keys, mnemonic }, mnemonic }
-}
-
-function keysFromMnemonic(mnemonic: string): AddressData {
-  const seed = bip39.mnemonicToSeedSync(mnemonic).slice(0, 32)
-  const keyPair = nacl.sign.keyPair.fromSeed(seed)
-  const address = '0x' + Array.from(keyPair.publicKey).map(b => b.toString(16).padStart(2, '0')).join('')
-  const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`
-  return { address, shortAddress, publicKey: keyPair.publicKey, privateKey: keyPair.secretKey }
-}
-
-function saveBrowser(keys: AddressData, mnemonic?: string): void {
-  if (typeof window === 'undefined') return
-  const data = {
-    address: keys.address,
-    shortAddress: keys.shortAddress,
-    publicKey: Array.from(keys.publicKey).map(b => b.toString(16).padStart(2, '0')).join(''),
-    privateKey: Array.from(keys.privateKey).map(b => b.toString(16).padStart(2, '0')).join(''),
-    mnemonic,
-  }
-  window.localStorage.setItem('connectonion_keys', JSON.stringify(data))
-}
-
-function loadBrowser(): AddressData | null {
-  if (typeof window === 'undefined') return null
-  const stored = window.localStorage.getItem('connectonion_keys')
-  if (!stored) return null
-  const data = JSON.parse(stored)
-  return {
-    address: data.address,
-    shortAddress: data.shortAddress,
-    publicKey: new Uint8Array(data.publicKey.match(/.{2}/g)!.map((b: string) => parseInt(b, 16))),
-    privateKey: new Uint8Array(data.privateKey.match(/.{2}/g)!.map((b: string) => parseInt(b, 16))),
-    mnemonic: data.mnemonic,
-  }
-}
-
-function signMessage(keys: AddressData, message: string): string {
-  const msgBytes = new TextEncoder().encode(message)
-  const signature = nacl.sign.detached(msgBytes, keys.privateKey)
-  return Array.from(signature).map(b => b.toString(16).padStart(2, '0')).join('')
-}
-
-async function authenticateWithOpenOnion(keys: AddressData): Promise<string> {
+async function authenticateWithOpenOnion(identity: BrowserIdentity): Promise<string> {
   const timestamp = Math.floor(Date.now() / 1000)
-  const message = `ConnectOnion-Auth-${keys.address}-${timestamp}`
-  const signature = signMessage(keys, message)
-
+  const message = `ConnectOnion-Auth-${identity.address}-${timestamp}`
+  const signature = await identity.sign(message)
   const response = await fetch('/api/auth', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      public_key: keys.address,
-      signature,
-      message,
-    }),
+    body: JSON.stringify({ public_key: identity.address, signature, message }),
   })
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: 'Authentication failed' }))
     throw new Error(error.detail || 'Authentication failed')
   }
-
-  const data = await response.json()
-  return data.token
+  return (await response.json()).token
 }
 
 async function getUserProfile(token: string) {
   const response = await fetch('/api/auth', {
     headers: { 'Authorization': `Bearer ${token}` },
   })
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch profile')
-  }
-
+  if (!response.ok) throw new Error('Failed to fetch profile')
   return response.json()
 }
 
 export function useIdentity() {
   const { setApiKey, setUserProfile } = useChatStore()
-
-  const [identity, setIdentity] = useState<AddressData | null>(null)
+  const [identity, setIdentity] = useState<BrowserIdentity | null>(null)
   const [authLoading, setAuthLoading] = useState(false)
   const [authError, setAuthError] = useState<string | null>(null)
   const [showRecoveryPhrase, setShowRecoveryPhrase] = useState(false)
   const [newMnemonic, setNewMnemonic] = useState<string | null>(null)
 
-  // Load identity on mount
   useEffect(() => {
-    // loadBrowser() reads localStorage, which does not exist during SSR, so this
-    // cannot move into a useState initialiser. Loading browser-only state on
-    // mount is what an effect is for.
-    const keys = loadBrowser()
-    if (keys) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIdentity(keys)
-    } else {
-      const { keys: newKeys, mnemonic } = generateWithMnemonic()
-      saveBrowser(newKeys, mnemonic)
-      setIdentity(newKeys)
-      setNewMnemonic(mnemonic)
-      setShowRecoveryPhrase(true)
-    }
+    let active = true
+    initializeBrowserIdentity().then(initialized => {
+      if (!active) return
+      setIdentity(initialized.identity)
+      if (initialized.recovery) {
+        setNewMnemonic(initialized.recovery.value)
+        setShowRecoveryPhrase(true)
+      }
+    }).catch(error => {
+      if (active) setAuthError(error instanceof Error ? error.message : 'Identity unavailable')
+    })
+    return () => { active = false }
   }, [])
 
-  // Authenticate when identity changes
   useEffect(() => {
     if (!identity) return
-
     const authenticate = async () => {
       setAuthLoading(true)
       setAuthError(null)
       const token = await authenticateWithOpenOnion(identity)
       setApiKey(token)
-      const profile = await getUserProfile(token)
-      setUserProfile(profile)
+      setUserProfile(await getUserProfile(token))
       setAuthLoading(false)
     }
-
-    authenticate().catch(err => {
-      setAuthError(err instanceof Error ? err.message : 'Authentication failed')
+    authenticate().catch(error => {
+      setAuthError(error instanceof Error ? error.message : 'Authentication failed')
       setApiKey('')
       setUserProfile(null)
       setAuthLoading(false)
     })
   }, [identity, setApiKey, setUserProfile])
 
-  // No live profile polling: this browser identity isn't the account that spends
-  // credits (the connected agent is), and its balance is no longer shown. The JWT
-  // above is what's needed for auth / voice transcription; the profile is fetched
-  // once at login. Agent balances are polled per-agent via useAgentInfo.
-
-  const generateNewIdentity = useCallback(() => {
+  const generateNewIdentity = useCallback(async () => {
     if (!window.confirm('This will generate a new identity. Make sure you have backed up your current recovery phrase! Continue?')) return
-    const { keys: newKeys, mnemonic } = generateWithMnemonic()
-    saveBrowser(newKeys, mnemonic)
+    const created = await createBrowserIdentity()
     setApiKey('')
     setUserProfile(null)
-    setIdentity(newKeys)
-    setNewMnemonic(mnemonic)
-    setShowRecoveryPhrase(true)
+    setIdentity(created.identity)
+    setNewMnemonic(created.recovery?.value ?? null)
+    setShowRecoveryPhrase(Boolean(created.recovery))
   }, [setApiKey, setUserProfile])
 
-  const importKey = useCallback((input: string) => {
-    const trimmed = input.trim().toLowerCase()
-    if (!trimmed) return false
-
-    const words = trimmed.split(/\s+/)
-    if (words.length === 12 || words.length === 24) {
-      if (!bip39.validateMnemonic(trimmed)) {
-        alert('Invalid recovery phrase. Please check your words and try again.')
-        return false
-      }
-
-      const keys = keysFromMnemonic(trimmed)
-      saveBrowser(keys, trimmed)
+  const importKey = useCallback(async (input: string) => {
+    if (!input.trim()) return false
+    try {
+      const imported = await importBrowserIdentity(input)
       setApiKey('')
       setUserProfile(null)
-      setIdentity(keys)
+      setIdentity(imported.identity)
+      setNewMnemonic(null)
+      setShowRecoveryPhrase(false)
       return true
-    }
-
-    const keyHex = trimmed.startsWith('0x') ? trimmed.slice(2) : trimmed
-    if (keyHex.length !== 128) {
-      alert('Invalid format. Enter a 12-word recovery phrase.')
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Invalid recovery material')
       return false
     }
-
-    const privateKey = new Uint8Array(keyHex.match(/.{2}/g)!.map((b: string) => parseInt(b, 16)))
-    const publicKey = privateKey.slice(32)
-    const address = '0x' + Array.from(publicKey).map(b => b.toString(16).padStart(2, '0')).join('')
-    const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`
-
-    const keys: AddressData = { address, shortAddress, publicKey, privateKey }
-    saveBrowser(keys)
-    setApiKey('')
-    setUserProfile(null)
-    setIdentity(keys)
-    return true
   }, [setApiKey, setUserProfile])
 
   const exportKey = useCallback(() => {
-    if (!identity) return
-    if (identity.mnemonic) {
-      setNewMnemonic(identity.mnemonic)
-      setShowRecoveryPhrase(true)
-    } else {
-      const privateKeyHex = Array.from(identity.privateKey).map(b => b.toString(16).padStart(2, '0')).join('')
-      navigator.clipboard.writeText(privateKeyHex)
-      alert('Private key copied (legacy format). Consider generating a new identity for mnemonic recovery.')
-    }
-  }, [identity])
+    if (newMnemonic) setShowRecoveryPhrase(true)
+    else alert('For security, the recovery phrase is shown only when an identity is created or migrated.')
+  }, [newMnemonic])
 
   const dismissRecoveryPhrase = useCallback(() => {
     setShowRecoveryPhrase(false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.2",
+        "@connectonion/react": "0.4.2-alpha.4",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "bip39": "^3.1.0",
@@ -39,15 +39,6 @@
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
-      }
-    },
-    "node_modules/@agentclientprotocol/sdk": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
-      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -377,12 +368,12 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.2",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.2.tgz",
-      "integrity": "sha512-/SAQEagSthgvY6IDewgEIA1+l+85luOQBkT/I0GFpPZnf1ELD1IESPzkPJp04oWv7+nivQsSnCTd/viZsxVVPQ==",
+      "version": "0.4.2-alpha.4",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.4.tgz",
+      "integrity": "sha512-zZvP2VQ/NPr6GHqIzOJJV/zJVUf+EoGtUaL3r4w2Y/6wLOBMxmZ3tEKsRZaVYbGCYQP1igh7mGJeE8mqzPNooQ==",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "1.2.1",
+        "@scure/bip39": "1.6.0",
         "tweetnacl": "^1.0.3",
         "ws": "^8.18.0",
         "zustand": "^5.0.0"
@@ -1959,6 +1950,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2197,6 +2210,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -10324,6 +10403,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@connectonion/react": "0.4.2-alpha.4",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "bip39": "^3.1.0",
         "clsx": "^2.1.1",
         "next": "^16.2.12",
         "prism-react-renderer": "^2.4.1",
@@ -24,7 +23,6 @@
         "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
-        "tweetnacl": "^1.0.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -3307,15 +3305,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@connectonion/react": "0.4.2-alpha.4",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "bip39": "^3.1.0",
     "clsx": "^2.1.1",
     "next": "^16.2.12",
     "prism-react-renderer": "^2.4.1",
@@ -30,7 +29,6 @@
     "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
-    "tweetnacl": "^1.0.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.2",
+    "@connectonion/react": "0.4.2-alpha.4",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "bip39": "^3.1.0",


### PR DESCRIPTION
## Summary

- pin O Chat to the public `@connectonion/react@0.4.2-alpha.4` artifact
- remove the abandoned protocol SDK from the installed dependency tree
- use the React package's OIP-only browser client

## Verification

- npm audit: 0 vulnerabilities
- ESLint passes
- Vitest: 12 files / 90 tests pass
- Next.js production build passes
- both manifests resolve the exact npm registry tarball and integrity

Related: openonion/connectonion-react#59
Related: openonion/connectonion#1045
