### PR TITLE
chore: pin React OIP compatibility alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.4",
+        "@connectonion/react": "0.4.2-alpha.5",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.4",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.4.tgz",
-      "integrity": "sha512-zZvP2VQ/NPr6GHqIzOJJV/zJVUf+EoGtUaL3r4w2Y/6wLOBMxmZ3tEKsRZaVYbGCYQP1igh7mGJeE8mqzPNooQ==",
+      "version": "0.4.2-alpha.5",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.5.tgz",
+      "integrity": "sha512-v5cV5AY2MCrj6dxyAyxA/FIC0UulEQeN3M4zPNTiESAlZNxUuA9lftft2c0Jqg26nMIBT7ybwsFubrFUP2nh5g==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.4",
+    "@connectonion/react": "0.4.2-alpha.5",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Outcome\n\nPins O Chat to the exact public @connectonion/react 0.4.2-alpha.5 artifact for the OIP 0.1 rolling-compatibility release gate in openonion/connectonion#1053.\n\nThe UI remains the previously reviewed provider-card design. Native Codex app-server and Claude Code stream-json adapters translate into OIP provider_invocation/tool events; O Chat does not parse provider transcripts and no ACP transport is reintroduced.\n\n## Verification\n\n- exact public npm tarball and integrity recorded in package-lock.json\n- npm audit: 0 vulnerabilities\n- 90/90 Vitest tests\n- ESLint passed\n- Next production Webpack build passed\n- browser Codex cards: running, completed, failed, expanded, desktop, and mobile all passed 4/4\n- screenshots retained in the test artifact path\n\nRefs openonion/connectonion#1053.\n