### PR TITLE
Add interactive Codex Work Rooms

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -136,6 +136,7 @@ export default function ChatSessionPage() {
     permissionProfileRecoveryAction,
     fullAccessTurnsRemaining,
     send,
+    retry,
     respondToAskUser,
     respondToApproval,
     submitOnboard,
@@ -265,6 +266,12 @@ export default function ChatSessionPage() {
     reconnect()
   }, [reconnect, setConnectionError])
 
+  const handleRetry = useCallback(() => {
+    if (!lastUserMessage) return
+    setConnectionError(null)
+    retry(lastUserMessage)
+  }, [lastUserMessage, retry])
+
   const recoverConnection = useEffectEvent(() => {
     if (sessionState === 'disconnected' && document.visibilityState === 'visible' && navigator.onLine) {
       handleReconnect()
@@ -352,12 +359,12 @@ export default function ChatSessionPage() {
               fullAccessTurnsRemaining={fullAccessTurnsRemaining}
               sessionState={sessionState}
               connectionError={connectionError}
-              onRetry={lastUserMessage ? () => handleSend(lastUserMessage) : undefined}
+              onRetry={lastUserMessage ? handleRetry : undefined}
               onReconnect={handleReconnect}
             />
           }
           connectionError={connectionError}
-          onRetry={lastUserMessage ? () => handleSend(lastUserMessage) : undefined}
+          onRetry={lastUserMessage ? handleRetry : undefined}
           onDismissError={() => setConnectionError(null)}
           skills={skills}
           acceptsAttachments={acceptsAttachments(

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -359,7 +359,6 @@ export default function ChatSessionPage() {
               fullAccessTurnsRemaining={fullAccessTurnsRemaining}
               sessionState={sessionState}
               connectionError={connectionError}
-              onRetry={lastUserMessage ? handleRetry : undefined}
               onReconnect={handleReconnect}
             />
           }

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -14,6 +14,7 @@ export function ChatMessages({
   ui = [],
   className,
   onStop,
+  onProviderMessage,
   pendingApproval,
   onApprovalResponse,
   pendingAskUser,
@@ -225,6 +226,7 @@ export function ChatMessages({
                     expanded={expandedInvocations.includes(item.id)}
                     onToggle={() => toggleInvocation(item.id)}
                     onStop={onStop}
+                    onMessageProvider={message => onProviderMessage?.(item, message)}
                     pendingApproval={approvalForProvider}
                     onApprovalResponse={approvalForProvider ? onApprovalResponse : undefined}
                   />

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -198,6 +198,9 @@ export function Chat({
             ui={ui}
             isLoading={isLoading}
             onStop={onStop}
+            onProviderMessage={(invocation, message) => onSend(
+              `[Work Room → ${invocation.providerDisplayName}${invocation.sessionId ? ` session ${invocation.sessionId}` : ''}] ${message}`,
+            )}
             pendingApproval={pendingApproval}
             onApprovalResponse={onApprovalResponse}
             pendingAskUser={pendingAskUser}

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -59,4 +59,43 @@ describe('CodingAgentCard', () => {
     const { element } = render({ invocation: { ...invocation, status: 'cancelled' } })
     expect(element.querySelector('[aria-label="Stop Codex"]')).toBeNull()
   })
+
+  it('opens an interactive Work Room and targets messages to Codex', () => {
+    const onMessageProvider = vi.fn()
+    const { element } = render({ onMessageProvider })
+
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Codex Work Room"]')!
+    expect(workroom).not.toBeNull()
+    expect(workroom.textContent).toContain('Fix Windows tests')
+
+    const composer = workroom.querySelector<HTMLTextAreaElement>('textarea')!
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!
+      setter.call(composer, 'Also update the changelog')
+      composer.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    act(() => workroom.querySelector<HTMLButtonElement>('[aria-label="Send to Codex"]')!.click())
+
+    expect(onMessageProvider).toHaveBeenCalledWith('Also update the changelog')
+    expect(workroom.textContent).toContain('Queued #1 to Codex')
+  })
+
+  it('exposes Activity and Files as full Work Room sections', () => {
+    const withFile = {
+      ...invocation,
+      activities: [...invocation.activities, {
+        id: 'file-1', name: 'File change', status: 'done' as const,
+        args: { file_path: 'src/app.tsx' }, result: 'updated',
+      }],
+    }
+    const { element } = render({ invocation: withFile })
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
+
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Activity'))!.click())
+    expect(workroom.textContent).toContain('pytest tests/unit')
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Files'))!.click())
+    expect(workroom.textContent).toContain('src/app.tsx')
+  })
 })

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useState } from 'react'
 import { HiOutlineChevronDown, HiOutlineChevronRight, HiOutlineStop } from 'react-icons/hi'
 import type { PendingApproval, ProviderInvocationUI } from '../types'
 import { ChatApproval } from '../chat-approval'
 import { ToolStatus } from './tools/tool-status'
+import { CodingAgentWorkroom } from './coding-agent-workroom'
 
 interface CodingAgentCardProps {
   invocation: ProviderInvocationUI
@@ -12,6 +14,7 @@ interface CodingAgentCardProps {
   onStop?: () => void
   pendingApproval?: PendingApproval | null
   onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
+  onMessageProvider?: (message: string) => void
 }
 
 const terminal = new Set(['completed', 'failed', 'cancelled'])
@@ -23,8 +26,9 @@ function elapsed(ms?: number) {
 }
 
 export function CodingAgentCard({
-  invocation, expanded, onToggle, onStop, pendingApproval, onApprovalResponse,
+  invocation, expanded, onToggle, onStop, pendingApproval, onApprovalResponse, onMessageProvider,
 }: CodingAgentCardProps) {
+  const [workroomOpen, setWorkroomOpen] = useState(false)
   const running = !terminal.has(invocation.status)
   const summary = invocation.taskSummary || 'Coding task'
   const status = invocation.status.replace('_', ' ')
@@ -58,6 +62,13 @@ export function CodingAgentCard({
             <HiOutlineStop className="h-4 w-4" />
           </button>
         )}
+        <button
+          type="button"
+          onClick={() => setWorkroomOpen(true)}
+          className="min-h-9 shrink-0 rounded-md border border-neutral-200 px-2.5 text-xs font-medium text-neutral-700 hover:bg-neutral-50"
+        >
+          Open Work Room
+        </button>
       </div>
 
       {expanded && (
@@ -90,6 +101,14 @@ export function CodingAgentCard({
             <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
           )}
         </div>
+      )}
+      {workroomOpen && (
+        <CodingAgentWorkroom
+          invocation={invocation}
+          onClose={() => setWorkroomOpen(false)}
+          onStop={onStop}
+          onMessage={onMessageProvider}
+        />
       )}
     </section>
   )

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  HiOutlineArrowLeft,
+  HiOutlineChatBubbleLeftRight,
+  HiOutlineDocument,
+  HiOutlineListBullet,
+  HiOutlinePaperAirplane,
+  HiOutlineStop,
+} from 'react-icons/hi2'
+import type { ProviderInvocationUI } from '../types'
+import { ToolStatus } from './tools/tool-status'
+
+type WorkroomTab = 'chat' | 'activity' | 'files'
+
+interface CodingAgentWorkroomProps {
+  invocation: ProviderInvocationUI
+  onClose: () => void
+  onStop?: () => void
+  onMessage?: (message: string) => void
+}
+
+interface QueuedMessage {
+  id: string
+  content: string
+}
+
+function activityPath(activity: ProviderInvocationUI['activities'][number]): string | null {
+  const value = activity.args?.file_path ?? activity.args?.path
+  return typeof value === 'string' && value ? value : null
+}
+
+export function CodingAgentWorkroom({ invocation, onClose, onStop, onMessage }: CodingAgentWorkroomProps) {
+  const [tab, setTab] = useState<WorkroomTab>('chat')
+  const [draft, setDraft] = useState('')
+  const [queued, setQueued] = useState<QueuedMessage[]>([])
+  const running = !['completed', 'failed', 'cancelled'].includes(invocation.status)
+  const files = useMemo(
+    () => invocation.activities.map(activity => ({ activity, path: activityPath(activity) })).filter(item => item.path),
+    [invocation.activities],
+  )
+
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.body.style.overflow = previous
+      window.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [onClose])
+
+  const submit = () => {
+    const message = draft.trim()
+    if (!message || !onMessage) return
+    setQueued(items => [...items, { id: crypto.randomUUID(), content: message }])
+    setDraft('')
+    onMessage(message)
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex min-h-0 flex-col bg-neutral-50" role="dialog" aria-modal="true" aria-label={`${invocation.providerDisplayName} Work Room`}>
+      <header className="flex min-h-16 shrink-0 items-center gap-3 border-b border-neutral-200 bg-white px-3 sm:px-5">
+        <button type="button" onClick={onClose} className="flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100">
+          <HiOutlineArrowLeft className="h-5 w-5" />
+          <span className="hidden sm:inline">Back</span>
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <ToolStatus status={invocation.status === 'failed' ? 'error' : invocation.status === 'completed' ? 'done' : 'running'} />
+            <h1 className="truncate text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
+          </div>
+          <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || 'Coding task'}</p>
+        </div>
+        <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{invocation.status.replace('_', ' ')}</span>
+        {running && onStop && (
+          <button type="button" onClick={onStop} className="flex min-h-11 items-center gap-2 rounded-lg border border-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-50">
+            <HiOutlineStop className="h-4 w-4" /> Stop
+          </button>
+        )}
+        {!running && (
+          <button type="button" onClick={onClose} className="min-h-11 rounded-lg bg-neutral-900 px-3 text-sm font-medium text-white hover:bg-neutral-800">
+            Return to conversation
+          </button>
+        )}
+      </header>
+
+      <nav className="grid shrink-0 grid-cols-3 border-b border-neutral-200 bg-white" aria-label="Work Room sections">
+        {([
+          ['chat', 'Chat', HiOutlineChatBubbleLeftRight],
+          ['activity', 'Activity', HiOutlineListBullet],
+          ['files', 'Files', HiOutlineDocument],
+        ] as const).map(([value, label, Icon]) => (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={tab === value}
+            onClick={() => setTab(value)}
+            className={`flex min-h-12 items-center justify-center gap-2 border-b-2 text-sm font-medium ${tab === value ? 'border-neutral-900 text-neutral-950' : 'border-transparent text-neutral-500 hover:text-neutral-800'}`}
+          >
+            <Icon className="h-4 w-4" /> {label}
+            {value === 'files' && files.length > 0 && <span className="rounded-full bg-neutral-100 px-1.5 text-[11px]">{files.length}</span>}
+          </button>
+        ))}
+      </nav>
+
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+        <div className="mx-auto max-w-4xl">
+          {tab === 'chat' && (
+            <div className="space-y-3">
+              <div className="rounded-xl border border-neutral-200 bg-white p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Target</p>
+                <p className="mt-1 text-sm font-medium text-neutral-900">{invocation.providerDisplayName}{invocation.sessionId ? ` · ${invocation.sessionId.slice(0, 12)}…` : ''}</p>
+                <p className="mt-2 text-sm text-neutral-600">{invocation.taskSummary || 'Coding task'}</p>
+              </div>
+              {queued.map((message, index) => (
+                <div key={message.id} className="ml-auto max-w-[85%] rounded-xl bg-neutral-900 px-4 py-3 text-sm text-white">
+                  <p>{message.content}</p>
+                  <p className="mt-1 text-[11px] text-neutral-400">Queued #{index + 1} to {invocation.providerDisplayName}</p>
+                </div>
+              ))}
+              {invocation.result && (
+                <div className="max-w-[90%] rounded-xl border border-neutral-200 bg-white px-4 py-3 text-sm text-neutral-700">
+                  {invocation.result}
+                </div>
+              )}
+              {invocation.error && <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{invocation.error}</div>}
+            </div>
+          )}
+
+          {tab === 'activity' && (
+            <ol className="space-y-2" aria-label={`${invocation.providerDisplayName} Work Room activity`}>
+              {invocation.activities.map(activity => (
+                <li key={activity.id} className="flex min-w-0 gap-3 rounded-xl border border-neutral-200 bg-white p-4">
+                  <ToolStatus status={activity.status} className="mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-neutral-900">{activity.name}</p>
+                    <p className="mt-1 break-words font-mono text-xs text-neutral-500">{String(activity.args?.command || activity.args?.file_path || activity.args?.path || activity.result || '')}</p>
+                    {activity.result && <p className="mt-2 whitespace-pre-wrap break-words text-xs text-neutral-600">{activity.result}</p>}
+                  </div>
+                </li>
+              ))}
+              {invocation.activities.length === 0 && <li className="py-12 text-center text-sm text-neutral-500">Waiting for provider activity…</li>}
+            </ol>
+          )}
+
+          {tab === 'files' && (
+            <div className="space-y-2">
+              {files.map(({ activity, path }) => (
+                <div key={activity.id} className="rounded-xl border border-neutral-200 bg-white p-4">
+                  <p className="break-all font-mono text-sm text-neutral-800">{path}</p>
+                  <p className="mt-1 text-xs capitalize text-neutral-500">{activity.status}</p>
+                </div>
+              ))}
+              {files.length === 0 && <p className="py-12 text-center text-sm text-neutral-500">No file changes reported yet.</p>}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {tab === 'chat' && (
+        <footer className="shrink-0 border-t border-neutral-200 bg-white p-3 sm:p-4">
+          <div className="mx-auto flex max-w-4xl items-end gap-2">
+            <label className="min-w-0 flex-1">
+              <span className="sr-only">Message {invocation.providerDisplayName}</span>
+              <textarea
+                value={draft}
+                onChange={event => setDraft(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault()
+                    submit()
+                  }
+                }}
+                disabled={!onMessage}
+                rows={2}
+                placeholder={`Message ${invocation.providerDisplayName}…`}
+                className="max-h-32 min-h-12 w-full resize-none rounded-xl border border-neutral-300 px-3 py-2.5 text-sm outline-none focus:border-neutral-500 disabled:bg-neutral-100"
+              />
+            </label>
+            <button type="button" onClick={submit} disabled={!draft.trim() || !onMessage} aria-label={`Send to ${invocation.providerDisplayName}`} className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-neutral-900 text-white hover:bg-neutral-800 disabled:bg-neutral-300">
+              <HiOutlinePaperAirplane className="h-5 w-5" />
+            </button>
+          </div>
+        </footer>
+      )}
+    </div>,
+    document.body,
+  )
+}

--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -22,7 +22,6 @@ interface ModeStatusBarProps {
   sessionState?: 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
   isLoading?: boolean
   connectionError?: string | null
-  onRetry?: () => void
   onReconnect?: () => void
 }
 
@@ -70,7 +69,6 @@ export function ModeStatusBar({
   onPermissionProfileRetry,
   sessionState,
   connectionError,
-  onRetry,
   onReconnect,
   fullAccessTurnsRemaining,
 }: ModeStatusBarProps) {
@@ -125,7 +123,6 @@ export function ModeStatusBar({
             <div className="flex items-center gap-1.5">
               <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
               <span className="text-[11px] text-red-600">error</span>
-              {onRetry && <button onClick={onRetry} className="min-h-11 px-2 text-[11px] text-red-600 underline">retry</button>}
             </div>
           ) : sessionState === 'disconnected' ? (
             <div className="flex items-center gap-1.5">

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -227,6 +227,7 @@ export interface ChatMessagesProps {
   className?: string
   isLoading?: boolean
   onStop?: () => void
+  onProviderMessage?: (invocation: ProviderInvocationUI, message: string) => void
   pendingApproval?: PendingApproval | null
   onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
   pendingAskUser?: PendingAskUser | null

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -96,6 +96,8 @@ interface UseAgentSDKReturn {
   /** Full access mode: turns remaining (max - used) */
   fullAccessTurnsRemaining: number | null
   send: (content: string, images?: string[], files?: import('./types').FileAttachment[]) => void
+  /** Re-run a failed turn without duplicating the last user transcript item. */
+  retry: (content: string, images?: string[], files?: import('./types').FileAttachment[]) => void
   /** Gracefully stop a running agent: it finishes the current step and returns a closing message */
   interrupt: () => void
   respondToAskUser: (answer: string | string[]) => void
@@ -260,6 +262,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     ui,
     plan: currentPlan,
     input,
+    retry: retryInput,
     reset,
     isProcessing,
     error,
@@ -406,6 +409,11 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     input(content, { images, files })
   }, [input])
 
+  const retry = useCallback((content: string, images?: string[], files?: import('./types').FileAttachment[]) => {
+    setStopRequested(false)
+    retryInput(content, { images, files })
+  }, [retryInput])
+
   // Stop is a product action here; the React SDK owns capability negotiation,
   // session binding, pending-permission cancellation, and legacy fallback.
   // Keep the optimistic UI behavior even when a restored session has no live
@@ -513,6 +521,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     fullAccessTurnsUsed: fullAccessTurnsUsed ?? null,
     fullAccessTurnsRemaining: fullAccessTurns != null && fullAccessTurnsUsed != null ? fullAccessTurns - fullAccessTurnsUsed : null,
     send,
+    retry,
     interrupt,
     respondToAskUser,
     respondToApproval,

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { type Page } from '@playwright/test'
-import { test, expect } from './fixtures'
+import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 
 /** The app mints a BIP39 identity on first paint. Seeding one keeps the recovery
@@ -100,6 +100,23 @@ test.describe('a full exchange', () => {
     await page.getByRole('button', { name: 'What can you do?' }).click()
 
     await expect(page.getByRole('alert').filter({ hasText: /credits/i })).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('a terminal error stops loading and Retry keeps one user message', async ({ page, shot }) => {
+    await landing(page, 'error')
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+
+    const conversation = pane(page)
+    const alert = conversation.getByRole('alert').filter({ hasText: /credits/i })
+    await expect(alert).toBeVisible({ timeout: 15_000 })
+    await expect(conversation.getByText(/Thinking|Synthesizing|Reasoning|Pondering|Composing|Ruminating|Cooking|Crunching|Percolating|Noodling|Wrangling|Conjuring/)).toHaveCount(0)
+    await expect(conversation.getByText('What can you do?', { exact: true })).toHaveCount(1)
+
+    await alert.getByRole('button', { name: 'Retry' }).click()
+    await expect(conversation.getByRole('alert').filter({ hasText: /credits/i })).toBeVisible()
+    await expect(conversation.getByText('What can you do?', { exact: true })).toHaveCount(1)
+    await expect(conversation.getByText(/Thinking|Synthesizing|Reasoning|Pondering|Composing|Ruminating|Cooking|Crunching|Percolating|Noodling|Wrangling|Conjuring/)).toHaveCount(0)
+    await shot('terminal-error-no-duplicate')
   })
 })
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -109,6 +109,7 @@ test.describe('a full exchange', () => {
     const conversation = pane(page)
     const alert = conversation.getByRole('alert').filter({ hasText: /credits/i })
     await expect(alert).toBeVisible({ timeout: 15_000 })
+    await expect(conversation.getByRole('button', { name: 'Retry', exact: true })).toHaveCount(1)
     await expect(conversation.getByText(/Thinking|Synthesizing|Reasoning|Pondering|Composing|Ruminating|Cooking|Crunching|Percolating|Noodling|Wrangling|Conjuring/)).toHaveCount(0)
     await expect(conversation.getByText('What can you do?', { exact: true })).toHaveCount(1)
 

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -39,6 +39,26 @@ test('running Codex activity stays nested under one expandable card', async ({ p
   await shot('codex-running-expanded')
 })
 
+test('Codex card opens an interactive Work Room with target, queue, activity and files', async ({ page, shot }) => {
+  await openCodingRun(page)
+
+  const card = pane(page).getByRole('region', { name: 'Codex running' })
+  await card.getByRole('button', { name: 'Open Work Room' }).click()
+  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+  await expect(room).toBeVisible()
+  await expect(room).toContainText('Fix Windows tests')
+
+  await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
+  await room.getByRole('button', { name: 'Send to Codex' }).click()
+  await expect(room).toContainText('Queued #1 to Codex')
+  await shot('codex-workroom-chat-desktop')
+  await room.getByRole('tab', { name: /Activity/ }).click()
+  await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('pytest -q')
+  await room.getByRole('tab', { name: /Files/ }).click()
+  await expect(room).toContainText('No file changes reported yet.')
+  await shot('codex-workroom-desktop')
+})
+
 test('completed Codex card shows the result and no Stop action', async ({ page, shot }) => {
   await openCodingRun(page, 'coding-agent-completed', 'completed')
 
@@ -74,5 +94,19 @@ test.describe('phone', () => {
     expect(overflow, 'provider card scrolls sideways on a phone').toBeLessThanOrEqual(0)
     await expect(card).toBeInViewport()
     await shot('codex-phone-expanded')
+  })
+
+  test('Work Room is usable without horizontal overflow on a phone', async ({ page, shot }) => {
+    await openCodingRun(page)
+    await pane(page).getByRole('region', { name: 'Codex running' }).getByRole('button', { name: 'Open Work Room' }).click()
+    const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+    await expect(room).toBeVisible()
+    await expect(room.getByPlaceholder('Message Codex…')).toBeVisible()
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    )
+    expect(overflow, 'Work Room scrolls sideways on a phone').toBeLessThanOrEqual(0)
+    await shot('codex-workroom-phone')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.5",
+        "@connectonion/react": "0.4.2-alpha.6",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.5",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.5.tgz",
-      "integrity": "sha512-v5cV5AY2MCrj6dxyAyxA/FIC0UulEQeN3M4zPNTiESAlZNxUuA9lftft2c0Jqg26nMIBT7ybwsFubrFUP2nh5g==",
+      "version": "0.4.2-alpha.6",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.6.tgz",
+      "integrity": "sha512-GUKejWuKiqjgXeCSqRuUuFNAsS9wtK6uJ/YUHuW/Rjk2nx+ALG3HLn1Ipz0eMkrHT5gAf6jS45UJKpGe1c3lJA==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.5",
+    "@connectonion/react": "0.4.2-alpha.6",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Closes #154. Consumer fix for openonion/connectonion-react#61 and supports openonion/connectonion#1052.

What changed:
- full-screen provider Work Room from the Codex card
- Chat / Activity / Files sections
- explicit provider target, FIFO queued follow-ups, Stop, Back, and return-to-conversation controls
- desktop and phone layouts without horizontal overflow
- Retry now uses React `retry()` so the failed user turn is not duplicated
- exact `@connectonion/react@0.4.2-alpha.6` production pin

Verification:
- `npm test` — 92 passed
- `npm run lint`
- `next build --webpack` production build
- 182 Chromium E2E: 179 passed in the parallel full run; the three local dev-server contention timeouts all passed in a 15/15 serial rerun
- focused Codex suite 6/6, desktop + phone screenshots visually reviewed
- terminal-error Retry E2E proves one user message and no stale spinner

Screenshots are under `/tmp/frontend-test-screenshots/` locally, including `codex-workroom-chat-desktop`, `codex-workroom-phone`, and `terminal-error-no-duplicate`.