### PR TITLE
Pin React OIP authentication recovery alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.6",
+        "@connectonion/react": "0.4.2-alpha.7",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.6",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.6.tgz",
-      "integrity": "sha512-GUKejWuKiqjgXeCSqRuUuFNAsS9wtK6uJ/YUHuW/Rjk2nx+ALG3HLn1Ipz0eMkrHT5gAf6jS45UJKpGe1c3lJA==",
+      "version": "0.4.2-alpha.7",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.7.tgz",
+      "integrity": "sha512-RR1Kj2DW3cSql0moDY0Y1YlFF9OTUiJLnrTj6S4GEBvMmfk/9Gf2VEubb8c/GjxADiU1dbxIh7Mvutrri1/hng==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.6",
+    "@connectonion/react": "0.4.2-alpha.7",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- pin the public `@connectonion/react@0.4.2-alpha.7` artifact exactly
- carry the one-time OIP reauthentication/replay fix found during production Codex acceptance

## Verification
- public npm registry: `alpha = 0.4.2-alpha.7`, stable `latest = 0.4.1`
- `npm test` — 12 files, 92 tests
- `npm run lint`
- `npx next build --webpack`

## Production evidence
The prior production build returned `authenticate first (send CONNECT)` on its first prompt and then succeeded via Retry once Host auth completed. React PR openonion/connectonion-react#63 makes that recovery automatic and exactly-once.