### PR TITLE
Fix stale error after successful retry

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -64,8 +64,19 @@ export default function ChatSessionPage() {
   const initialPlanMode = searchParams.get('workflow') === 'plan'
     || searchParams.get('mode') === 'plan'
 
-  // Defined before the hook callback receives it.
-  const [connectionError, setConnectionError] = useState<string | null>(null)
+  // Next can preserve this client component while moving between dynamic
+  // session routes. Bind an error to the session that produced it so an older
+  // failure can never flash in or disable a new conversation during transition.
+  const [connectionErrorState, setConnectionErrorState] = useState<{
+    sessionId: string
+    message: string
+  } | null>(null)
+  const connectionError = connectionErrorState?.sessionId === sessionId
+    ? connectionErrorState.message
+    : null
+  const setConnectionError = useCallback((message: string | null) => {
+    setConnectionErrorState(message ? { sessionId, message } : null)
+  }, [sessionId])
 
   const {
     agents,
@@ -153,8 +164,8 @@ export default function ChatSessionPage() {
     agentAddress: address,
     sessionId,
     initialPlanMode,
-    // The stable setter prevents the error effect from replaying a stale SDK
-    // error merely because clearing this local state caused another render.
+    // The SDK reports null when a retry/new run clears its error, so the page's
+    // banner and status recover together with the underlying connection.
     onError: setConnectionError,
   })
 
@@ -229,7 +240,7 @@ export default function ChatSessionPage() {
     }
     setConnectionError(null)
     send(content, images, files)
-  }, [permissionProfileChangePending, conversation, sessionId, address, createConversation, send])
+  }, [permissionProfileChangePending, conversation, sessionId, address, createConversation, setConnectionError, send])
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -270,7 +281,7 @@ export default function ChatSessionPage() {
     if (!lastUserMessage) return
     setConnectionError(null)
     retry(lastUserMessage)
-  }, [lastUserMessage, retry])
+  }, [lastUserMessage, retry, setConnectionError])
 
   const recoverConnection = useEffectEvent(() => {
     if (sessionState === 'disconnected' && document.visibilityState === 'visible' && navigator.onLine) {

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -80,8 +80,10 @@ export default function AgentLandingPage() {
   const [gateError, setGateError] = useState<string | null>(null)
   const submittingRef = useRef(false)
 
-  const onGateError = useCallback((message: string) => {
-    if (!submittingRef.current) return
+  const onGateError = useCallback((message: string | null) => {
+    // A cleared SDK error is useful to active chat pages but is not an invite
+    // rejection. The gate owns its own success/reset lifecycle.
+    if (!message || !submittingRef.current) return
     submittingRef.current = false
     setSubmitting(false)
     // The host's reason ("Invalid invite code") is already the right thing to say; the

--- a/components/chat/use-agent-sdk.test.ts
+++ b/components/chat/use-agent-sdk.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ChatItem } from '@connectonion/react'
 
-import { deriveSessionState, extractPendingStates, submitSignedOnboard } from './use-agent-sdk'
+import {
+  connectionErrorUpdate,
+  deriveSessionState,
+  extractPendingStates,
+  submitSignedOnboard,
+} from './use-agent-sdk'
 
 const runningTool: ChatItem = {
   id: 'tool-1',
@@ -41,6 +46,21 @@ describe('deriveSessionState', () => {
 
   it('does not call a cold agent disconnected before a conversation exists', () => {
     expect(deriveSessionState('disconnected', false, false, false)).toBe('idle')
+  })
+})
+
+describe('connectionErrorUpdate', () => {
+  it('clears a previous banner when the SDK error is cleared after retry', () => {
+    expect(connectionErrorUpdate(null, false)).toBeNull()
+  })
+
+  it('reports ordinary agent failures', () => {
+    expect(connectionErrorUpdate(new Error('Agent error: misconfigured'), false))
+      .toBe('Agent error: misconfigured')
+  })
+
+  it('leaves the general banner alone for permission-profile errors', () => {
+    expect(connectionErrorUpdate(new Error('profile rejected'), true)).toBeUndefined()
   })
 })
 

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -58,7 +58,26 @@ interface UseAgentSDKOptions {
   sessionId: string
   initialPlanMode?: boolean
   onComplete?: (result: string) => void
-  onError?: (error: string) => void
+  /** Current SDK error. `null` clears a previously reported failure. */
+  onError?: (error: string | null) => void
+}
+
+/**
+ * Translate the SDK error channel into the page-owned connection banner.
+ *
+ * `undefined` means "leave the current banner alone" for permission-profile
+ * errors that already have their own recovery UI. `null` is deliberately
+ * different: a retry/new run cleared the SDK error, so consumers must clear
+ * the old banner too instead of leaving the conversation permanently marked
+ * as failed.
+ */
+export function connectionErrorUpdate(
+  error: Error | null,
+  permissionProfileError: boolean,
+): string | null | undefined {
+  if (!error) return null
+  if (permissionProfileError) return undefined
+  return error.message
 }
 
 /** Session state for compatibility with page.tsx */
@@ -383,14 +402,21 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
 
   // Handle errors
   useEffect(() => {
-    if (!error) {
+    const permissionProfileError = Boolean(
+      error && (
+        permissionProfileRequestInFlight.current
+        || ownedPermissionProfileErrors.current.has(error.message)
+      )
+    )
+    const update = connectionErrorUpdate(error, permissionProfileError)
+    if (update === null) {
       ownedPermissionProfileErrors.current.clear()
+      onError?.(null)
       return
     }
     // React exposes setPermissionProfile failures on its general error channel too.
     // They already have a targeted recovery UI and are not connection errors.
-    if (permissionProfileRequestInFlight.current || ownedPermissionProfileErrors.current.has(error.message)) return
-    onError?.(error.message)
+    if (update !== undefined) onError?.(update)
   }, [error, onError])
 
   // Extract pending states from UI

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -119,6 +119,21 @@ test.describe('a full exchange', () => {
     await expect(conversation.getByText(/Thinking|Synthesizing|Reasoning|Pondering|Composing|Ruminating|Cooking|Crunching|Percolating|Noodling|Wrangling|Conjuring/)).toHaveCount(0)
     await shot('terminal-error-no-duplicate')
   })
+
+  test('a successful Retry clears the terminal error banner and status', async ({ page }) => {
+    await landing(page, 'error-once')
+    await page.getByRole('button', { name: 'What can you do?' }).click()
+
+    const conversation = pane(page)
+    const alert = conversation.getByRole('alert').filter({ hasText: /temporary agent failure/i })
+    await expect(alert).toBeVisible({ timeout: 15_000 })
+
+    await alert.getByRole('button', { name: 'Retry' }).click()
+    await expect(conversation.getByText('You said: What can you do?')).toBeVisible({ timeout: 15_000 })
+    await expect(alert).toHaveCount(0)
+    await expect(conversation.getByText('error', { exact: true })).toHaveCount(0)
+    await expect(conversation.getByText('live', { exact: true })).toBeVisible()
+  })
 })
 
 test.describe('phone', () => {

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'error' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
+export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -81,6 +81,7 @@ export async function mockAgent(
   let connects = 0
   let activeSessionId = 'e2e-session'
   let planInputs = 0
+  let terminalErrorInputs = 0
   /** Authoritative policy changes only after the mock Host acknowledges OIP. */
   let currentMode = ':read-only'
   let pendingModeAcknowledgement: (() => void) | null = null
@@ -259,6 +260,14 @@ export async function mockAgent(
         send(ws, { type: 'thinking', id: 't1', status: 'done' })
         setTimeout(() => ws.close({ code: 1006, reason: 'connection lost' }), 800)
         return
+      }
+
+      if (scenario === 'error-once') {
+        terminalErrorInputs += 1
+        if (terminalErrorInputs === 1) {
+          send(ws, { type: 'ERROR', message: 'temporary agent failure' })
+          return
+        }
       }
 
       if (scenario === 'error' || scenario === 'dashboard-error') {


### PR DESCRIPTION
Fixes #166.

The public alpha8 E2E showed Codex and its same-session Work Room completing successfully while oo-chat continued to display an earlier `[Errno 2]` failure. This change makes the SDK wrapper forward error clearance and binds page-owned errors to the session that produced them.

Checks:
- `npm test` — 95 passed
- `npm run lint` — passed
- `npm run build` — passed
- Playwright regression: terminal error → Retry → successful output → banner/status cleared — passed