### PR TITLE
Upgrade React SDK for first-send cache continuity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.7",
+        "@connectonion/react": "0.4.2-alpha.8",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.7",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.7.tgz",
-      "integrity": "sha512-RR1Kj2DW3cSql0moDY0Y1YlFF9OTUiJLnrTj6S4GEBvMmfk/9Gf2VEubb8c/GjxADiU1dbxIh7Mvutrri1/hng==",
+      "version": "0.4.2-alpha.8",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.8.tgz",
+      "integrity": "sha512-mXUmGPcf9cbnuX7WMDKvdeTbcTXheK5L2iJKnrU9ljW2cmRvqphRyii1uqoIsaHMiYs7zEPFnYm1Ht7mxKS9Jg==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.7",
+    "@connectonion/react": "0.4.2-alpha.8",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Fixes the O Chat production path for openonion/connectonion-react#64.

- pins public @connectonion/react 0.4.2-alpha.8 exactly
- removes the realm-bound v1 RemoteAgent cache behavior from the deployed bundle
- no ACP or retired SDK dependency is introduced

Validation:
- 95 Vitest tests pass
- Next webpack production build passes (default local Turbopack worker cannot bind inside this sandbox; CI/Vercel run it normally)
- 20 focused Playwright tests pass: native Codex cards, Work Room desktop/mobile, phone chat, reconnect/manual/online/visibility recovery, and overflow/touch targets
- npm audit: 0 vulnerabilities