### PR TITLE
Deploy React alpha9 document registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.8",
+        "@connectonion/react": "0.4.2-alpha.9",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.8",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.8.tgz",
-      "integrity": "sha512-mXUmGPcf9cbnuX7WMDKvdeTbcTXheK5L2iJKnrU9ljW2cmRvqphRyii1uqoIsaHMiYs7zEPFnYm1Ht7mxKS9Jg==",
+      "version": "0.4.2-alpha.9",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.9.tgz",
+      "integrity": "sha512-z23Ht/BTb+Fpc7AaVb0xt+qTFvl41YoGdgoIxP3oEe1Gmmj0A4+eWQQcOzqgs74rVlYtg6UUlYGLrleSZwQPNQ==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.8",
+    "@connectonion/react": "0.4.2-alpha.9",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Pins the verified @connectonion/react 0.4.2-alpha.9 tarball and integrity to fix production issue openonion/connectonion-react#67.

Validation:
- 95 Vitest tests pass
- TypeScript typecheck passes
- webpack production build passes
- 36 focused Chromium tests pass: Codex cards, Work Room desktop/phone, dashboard, mobile send/approval, dropped connection, manual/online/visibility reconnect, and healthy-session no-op

After merge, production browser acceptance uses the public ConnectOnion 1.7.0a10 wheel and verifies first INPUT, native Codex card, Work Room follow-up, reload, and mobile screenshots.