### PR TITLE
Fix Codex Work Room continuation results

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -178,7 +178,7 @@ export function ChatMessages({
         aria-label="Conversation"
         className="mx-auto max-w-3xl space-y-1"
       >
-        {ui.map((item) => {
+        {ui.map((item, itemIndex) => {
           switch (item.type) {
             case 'user':
               return <User key={item.id} message={item} />
@@ -216,6 +216,12 @@ export function ChatMessages({
               )
             }
             case 'provider_invocation': {
+              const continuations = item.sessionId
+                ? ui.slice(itemIndex + 1).filter((candidate): candidate is typeof item =>
+                    candidate.type === 'provider_invocation'
+                    && candidate.provider === item.provider
+                    && candidate.sessionId === item.sessionId)
+                : []
               const approvalForProvider = pendingApproval
                 && pendingApproval.tool.split(':')[0].toLowerCase() === item.provider
                 ? pendingApproval : undefined
@@ -223,6 +229,7 @@ export function ChatMessages({
                 <div key={item.id} {...(approvalForProvider ? { 'data-pending-decision': '' } : {})}>
                   <CodingAgentCard
                     invocation={item}
+                    continuations={continuations}
                     expanded={expandedInvocations.includes(item.id)}
                     onToggle={() => toggleInvocation(item.id)}
                     onStop={onStop}

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -81,6 +81,28 @@ describe('CodingAgentCard', () => {
     expect(workroom.textContent).toContain('Queued #1 to Codex')
   })
 
+  it('reconciles a queued message with a resumed provider result', () => {
+    const continuation: ProviderInvocationUI = {
+      ...invocation,
+      id: 'codex:call-8',
+      parentToolCallId: 'call-8',
+      sessionId: 'codex-session-1',
+      taskSummary: 'Also update the changelog',
+      status: 'completed',
+      result: 'Changelog updated.',
+    }
+    const { element } = render({
+      invocation: { ...invocation, sessionId: 'codex-session-1' },
+      continuations: [continuation],
+    })
+
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
+    expect(workroom.textContent).toContain('Completed #1 by Codex')
+    expect(workroom.textContent).toContain('Also update the changelog')
+    expect(workroom.textContent).toContain('Changelog updated.')
+  })
+
   it('exposes Activity and Files as full Work Room sections', () => {
     const withFile = {
       ...invocation,

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -9,6 +9,7 @@ import { CodingAgentWorkroom } from './coding-agent-workroom'
 
 interface CodingAgentCardProps {
   invocation: ProviderInvocationUI
+  continuations?: ProviderInvocationUI[]
   expanded: boolean
   onToggle: () => void
   onStop?: () => void
@@ -26,7 +27,7 @@ function elapsed(ms?: number) {
 }
 
 export function CodingAgentCard({
-  invocation, expanded, onToggle, onStop, pendingApproval, onApprovalResponse, onMessageProvider,
+  invocation, continuations = [], expanded, onToggle, onStop, pendingApproval, onApprovalResponse, onMessageProvider,
 }: CodingAgentCardProps) {
   const [workroomOpen, setWorkroomOpen] = useState(false)
   const running = !terminal.has(invocation.status)
@@ -105,6 +106,7 @@ export function CodingAgentCard({
       {workroomOpen && (
         <CodingAgentWorkroom
           invocation={invocation}
+          continuations={continuations}
           onClose={() => setWorkroomOpen(false)}
           onStop={onStop}
           onMessage={onMessageProvider}

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -17,6 +17,7 @@ type WorkroomTab = 'chat' | 'activity' | 'files'
 
 interface CodingAgentWorkroomProps {
   invocation: ProviderInvocationUI
+  continuations?: ProviderInvocationUI[]
   onClose: () => void
   onStop?: () => void
   onMessage?: (message: string) => void
@@ -32,7 +33,7 @@ function activityPath(activity: ProviderInvocationUI['activities'][number]): str
   return typeof value === 'string' && value ? value : null
 }
 
-export function CodingAgentWorkroom({ invocation, onClose, onStop, onMessage }: CodingAgentWorkroomProps) {
+export function CodingAgentWorkroom({ invocation, continuations = [], onClose, onStop, onMessage }: CodingAgentWorkroomProps) {
   const [tab, setTab] = useState<WorkroomTab>('chat')
   const [draft, setDraft] = useState('')
   const [queued, setQueued] = useState<QueuedMessage[]>([])
@@ -119,12 +120,30 @@ export function CodingAgentWorkroom({ invocation, onClose, onStop, onMessage }: 
                 <p className="mt-1 text-sm font-medium text-neutral-900">{invocation.providerDisplayName}{invocation.sessionId ? ` · ${invocation.sessionId.slice(0, 12)}…` : ''}</p>
                 <p className="mt-2 text-sm text-neutral-600">{invocation.taskSummary || 'Coding task'}</p>
               </div>
-              {queued.map((message, index) => (
-                <div key={message.id} className="ml-auto max-w-[85%] rounded-xl bg-neutral-900 px-4 py-3 text-sm text-white">
-                  <p>{message.content}</p>
-                  <p className="mt-1 text-[11px] text-neutral-400">Queued #{index + 1} to {invocation.providerDisplayName}</p>
-                </div>
-              ))}
+              {Array.from({ length: Math.max(queued.length, continuations.length) }, (_, index) => {
+                const message = queued[index]
+                const continuation = continuations[index]
+                const status = continuation?.status === 'completed'
+                  ? 'Completed'
+                  : continuation?.status === 'failed'
+                    ? 'Failed'
+                    : continuation
+                      ? 'Working'
+                      : 'Queued'
+                return (
+                  <div key={message?.id || continuation.id} className="space-y-3">
+                    <div className="ml-auto max-w-[85%] rounded-xl bg-neutral-900 px-4 py-3 text-sm text-white">
+                      <p>{message?.content || continuation.taskSummary || 'Continuation'}</p>
+                      <p className="mt-1 text-[11px] text-neutral-400">{status} #{index + 1} {status === 'Queued' ? 'to' : 'by'} {invocation.providerDisplayName}</p>
+                    </div>
+                    {(continuation?.result || continuation?.error) && (
+                      <div className={`max-w-[90%] rounded-xl px-4 py-3 text-sm ${continuation.error ? 'bg-red-50 text-red-700' : 'border border-neutral-200 bg-white text-neutral-700'}`}>
+                        {continuation.error || continuation.result}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
               {invocation.result && (
                 <div className="max-w-[90%] rounded-xl border border-neutral-200 bg-white px-4 py-3 text-sm text-neutral-700">
                   {invocation.result}

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -50,7 +50,8 @@ test('Codex card opens an interactive Work Room with target, queue, activity and
 
   await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
   await room.getByRole('button', { name: 'Send to Codex' }).click()
-  await expect(room).toContainText('Queued #1 to Codex')
+  await expect(room).toContainText('Completed #1 by Codex')
+  await expect(room).toContainText('Changelog updated.')
   await shot('codex-workroom-chat-desktop')
   await room.getByRole('tab', { name: /Activity/ }).click()
   await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('pytest -q')

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -82,6 +82,7 @@ export async function mockAgent(
   let activeSessionId = 'e2e-session'
   let planInputs = 0
   let terminalErrorInputs = 0
+  let codingAgentInputs = 0
   /** Authoritative policy changes only after the mock Host acknowledges OIP. */
   let currentMode = ':read-only'
   let pendingModeAcknowledgement: (() => void) | null = null
@@ -300,6 +301,21 @@ export async function mockAgent(
       send(ws, { type: 'thinking', id: 't1', status: 'running' })
 
       if (scenario === 'coding-agent' || scenario === 'coding-agent-completed' || scenario === 'coding-agent-failed') {
+        codingAgentInputs += 1
+        if (codingAgentInputs > 1) {
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-8',
+            parentToolCallId: 'call-8', provider: 'codex',
+            providerDisplayName: 'Codex', taskSummary: 'Also update the changelog',
+            sessionId: 'codex-session-1', status: 'completed', elapsedMs: 900,
+            result: 'Changelog updated.',
+          })
+          send(ws, {
+            type: 'OUTPUT', result: 'Changelog updated.',
+            session: { session_id: connectedSessionId },
+          })
+          return
+        }
         send(ws, {
           type: 'tool_call', id: 'call-7', name: 'codex',
           args: { prompt: 'Fix Windows tests' }, status: 'running',
@@ -308,7 +324,7 @@ export async function mockAgent(
           type: 'provider_invocation', invocationId: 'codex:call-7',
           parentToolCallId: 'call-7', provider: 'codex',
           providerDisplayName: 'Codex', taskSummary: 'Fix Windows tests',
-          permissionMode: 'workspace_write', status: 'running',
+          permissionMode: 'workspace_write', sessionId: 'codex-session-1', status: 'running',
         })
         send(ws, {
           type: 'tool_call', tool_id: 'child-1', name: 'Bash',


### PR DESCRIPTION
Closes #171.\n\n## What changed\n- Groups later Codex/Claude provider invocations by provider plus native session ID.\n- Reconciles Work Room queued messages into Working, Completed, or Failed states.\n- Renders the resumed provider result/error inside the original Work Room.\n- Extends the OIP mock and desktop/phone E2E coverage for resumed Codex sessions.\n\n## Verified\n- 96 Vitest tests\n- TypeScript (`npx tsc --noEmit`)\n- Next.js production build\n- Focused Playwright Work Room desktop + 375px: 2 passed\n- Live production root cause reproduced with ConnectOnion 1.7.0a10 and O Chat alpha.9; backend resumed the same Codex session successfully.