### PR TITLE
fix(workroom): preserve mobile title and card status

### DIFF
--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -51,7 +51,9 @@ export function CodingAgentCard({
           <span className="shrink-0 text-sm font-semibold text-neutral-900">{invocation.providerDisplayName}</span>
           <span className="truncate text-sm text-neutral-600">{summary}</span>
         </button>
-        <span className="shrink-0 text-xs capitalize text-neutral-500">{status}</span>
+        <span aria-label={`Status: ${status}`} className="shrink-0 rounded-full bg-neutral-100 px-2 py-1 text-xs capitalize text-neutral-600">
+          <span className="sr-only">Status: </span>{status}
+        </span>
         {invocation.elapsedMs != null && <span className="shrink-0 text-xs tabular-nums text-neutral-400">{elapsed(invocation.elapsedMs)}</span>}
         {running && onStop && (
           <button

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -66,7 +66,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
 
   return createPortal(
     <div className="fixed inset-0 z-[100] flex min-h-0 flex-col bg-neutral-50" role="dialog" aria-modal="true" aria-label={`${invocation.providerDisplayName} Work Room`}>
-      <header className="flex min-h-16 shrink-0 items-center gap-3 border-b border-neutral-200 bg-white px-3 sm:px-5">
+      <header className="flex min-h-16 shrink-0 items-center gap-2 border-b border-neutral-200 bg-white px-3 sm:gap-3 sm:px-5">
         <button type="button" onClick={onClose} className="flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100">
           <HiOutlineArrowLeft className="h-5 w-5" />
           <span className="hidden sm:inline">Back</span>
@@ -74,7 +74,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <ToolStatus status={invocation.status === 'failed' ? 'error' : invocation.status === 'completed' ? 'done' : 'running'} />
-            <h1 className="truncate text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
+            <h1 className="whitespace-nowrap text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
           </div>
           <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || 'Coding task'}</p>
         </div>
@@ -85,8 +85,9 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
           </button>
         )}
         {!running && (
-          <button type="button" onClick={onClose} className="min-h-11 rounded-lg bg-neutral-900 px-3 text-sm font-medium text-white hover:bg-neutral-800">
-            Return to conversation
+          <button type="button" onClick={onClose} aria-label="Return to conversation" className="min-h-11 shrink-0 rounded-lg bg-neutral-900 px-3 text-sm font-medium text-white hover:bg-neutral-800">
+            <span className="sm:hidden">Return</span>
+            <span className="hidden sm:inline">Return to conversation</span>
           </button>
         )}
       </header>

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -65,6 +65,10 @@ test('completed Codex card shows the result and no Stop action', async ({ page, 
 
   const card = pane(page).getByRole('region', { name: 'Codex completed' })
   await expect(card).toContainText('1s')
+  expect(
+    await card.getByLabel('Status: completed').evaluate(element => getComputedStyle(element).backgroundColor),
+    'terminal status should be visually separated from the provider label',
+  ).not.toBe('rgba(0, 0, 0, 0)')
   await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
   await card.getByRole('button', { expanded: false }).click()
   await expect(card).toContainText('Codex fixed the Windows tests.')
@@ -98,11 +102,19 @@ test.describe('phone', () => {
   })
 
   test('Work Room is usable without horizontal overflow on a phone', async ({ page, shot }) => {
-    await openCodingRun(page)
-    await pane(page).getByRole('region', { name: 'Codex running' }).getByRole('button', { name: 'Open Work Room' }).click()
+    await openCodingRun(page, 'coding-agent-completed', 'completed')
+    await pane(page).getByRole('region', { name: 'Codex completed' }).getByRole('button', { name: 'Open Work Room' }).click()
     const room = page.getByRole('dialog', { name: 'Codex Work Room' })
     await expect(room).toBeVisible()
     await expect(room.getByPlaceholder('Message Codex…')).toBeVisible()
+
+    const heading = room.getByRole('heading', { name: 'Codex Work Room' })
+    await expect(heading).toBeVisible()
+    expect(
+      await heading.evaluate(element => element.scrollWidth <= element.clientWidth),
+      'Work Room title is visually truncated on a phone',
+    ).toBe(true)
+    await expect(room.getByRole('button', { name: 'Return to conversation' })).toContainText('Return')
 
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,


### PR DESCRIPTION
Fixes both screenshot regressions from the public Codex/OIP acceptance: completed Work Rooms use a compact mobile Return action so the full title remains readable, and terminal provider state is a distinct labelled status pill instead of visually collapsing into the provider name. Adds red-to-green 375px truncation/no-overflow and status-separation assertions. Verified with 96 unit tests, lint, production build, and all 183 Chromium E2Es. Fixes #173.