### PR TITLE
fix(auth): keep browser credentials out of storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ You paste 0x…  →  /[address] (agent profile)  →  /[address]/[sessionId] (l
                             WebSocket → wss://oo.openonion.ai (relay) → the remote agent
 ```
 
-- **User identity** is a BIP39 mnemonic → Ed25519 keypair generated in your browser
-  (`localStorage['connectonion_keys']`), authenticated against `oo.openonion.ai`.
+- **User identity** is an Ed25519 key held as a non-extractable WebCrypto key in
+  IndexedDB by `@connectonion/react`. Recovery material is shown once and never
+  persisted; short-lived auth tokens remain in memory and are renewed on reload.
 - **Agents** are addressed by their `0x…` public key; profile + online status come
   from the relay (`fetchAgentInfo`).
 - **Transcripts** are persisted by the SDK per session

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,9 +60,13 @@ owner (the SDK); the sidebar store just lists conversations:
 
 | localStorage key | Owner | Holds |
 |---|---|---|
-| `connectonion_keys` | `use-identity` | your keypair (BIP39 → Ed25519) |
-| `oo-chat-storage` | `chat-store` | sidebar index + agents + token — **no messages** |
+| React secure identity store (IndexedDB) | `@connectonion/react` | non-extractable Ed25519 key; recovery material is never persisted |
+| `oo-chat-storage` | `chat-store` | sidebar index + agents — **no messages or credentials** |
 | `co:agent:{addr}:session:{id}` | the SDK | the actual transcript (capped at 20 sessions) |
+
+The OpenOnion auth JWT and account profile are runtime-only. On reload the
+React-owned identity signs a fresh authentication request; hydration also
+removes JWT/profile fields written by older O Chat alpha stores.
 
 ## Where things live
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,6 +15,15 @@ A React SDK change only reaches production once it is published to npm and oo-ch
 bumped to that version. The standalone TypeScript client is retired and is not part of
 this deployment chain; do not add it back as a fallback or parallel protocol owner.
 
+## Runtime credential boundary
+
+`@connectonion/react` owns the browser identity as a non-extractable WebCrypto
+key in IndexedDB. O Chat keeps the short-lived auth JWT and fetched account
+profile in memory only and re-authenticates after reload. Neither release nor
+rollback may add those values to Zustand persistence, localStorage, or
+sessionStorage. The store migration deletes copies left by older alpha builds
+while preserving agent addresses, conversation indexes, and SDK sessions.
+
 ## The dependency, two ways
 
 `oo-chat/package.json` declares published npm versions — that is what Vercel installs and

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -11,8 +11,8 @@ import { type Page } from '@playwright/test'
 import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 
-/** The app mints a BIP39 identity on first paint. Seeding one keeps the recovery
- *  phrase out of the screenshots and stops a fresh key being generated per test. */
+/** Seed the sidebar store before first paint so hydration cannot race the test's
+ *  first interaction. React owns the secure browser identity separately. */
 async function seedIdentity(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem(

--- a/e2e/identity-storage.spec.ts
+++ b/e2e/identity-storage.spec.ts
@@ -1,0 +1,45 @@
+/** Auth credentials are runtime state, never browser persistence. */
+
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
+
+test('legacy persisted auth is scrubbed and stays scrubbed after reload', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations: [],
+        activeSessionId: null,
+        agents: [],
+        openonionApiKey: 'legacy-jwt-must-disappear',
+        userProfile: { public_key: '0xlegacy', balance_usd: 99 },
+      },
+      version: 0,
+    }))
+  })
+
+  await page.route('**/api/auth', async route => {
+    const response = route.request().method() === 'POST'
+      ? { token: 'runtime-jwt' }
+      : { public_key: '0xe2e-user', credits_usd: 4, total_cost_usd: 1, balance_usd: 3 }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(response) })
+  })
+  await mockAgent(page)
+
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+  const storedAfterFirstAuth = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('oo-chat-storage') ?? '{}').state ?? {}
+  )
+  expect(storedAfterFirstAuth).not.toHaveProperty('openonionApiKey')
+  expect(storedAfterFirstAuth).not.toHaveProperty('userProfile')
+
+  await page.reload()
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+
+  const storedAfterReload = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('oo-chat-storage') ?? '{}').state ?? {}
+  )
+  expect(storedAfterReload).not.toHaveProperty('openonionApiKey')
+  expect(storedAfterReload).not.toHaveProperty('userProfile')
+})

--- a/store/chat-store.test.ts
+++ b/store/chat-store.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'oo-chat-storage'
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() { return values.size },
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    key: index => Array.from(values.keys())[index] ?? null,
+    removeItem: key => { values.delete(key) },
+    setItem: (key, value) => { values.set(key, value) },
+  }
+}
+
+async function freshStore() {
+  vi.resetModules()
+  const { useChatStore } = await import('./chat-store')
+  await useChatStore.persist.rehydrate()
+  return useChatStore
+}
+
+function persistedState() {
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}').state ?? {}
+}
+
+describe('chat store credential boundary', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: memoryStorage(),
+    })
+  })
+
+  it('scrubs JWT and profile fields left by an older persisted store', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      state: {
+        conversations: [],
+        activeSessionId: null,
+        agents: ['0xagent'],
+        openonionApiKey: 'legacy-jwt',
+        userProfile: { public_key: '0xuser', balance_usd: 1 },
+      },
+      version: 0,
+    }))
+
+    const store = await freshStore()
+
+    expect(persistedState()).not.toHaveProperty('openonionApiKey')
+    expect(persistedState()).not.toHaveProperty('userProfile')
+    expect(store.getState().openonionApiKey).toBe('')
+    expect(store.getState().userProfile).toBeNull()
+  })
+
+  it('keeps fresh auth state in memory without writing it to localStorage', async () => {
+    const store = await freshStore()
+    const profile = {
+      public_key: '0xuser',
+      credits_usd: 2,
+      total_cost_usd: 1,
+      balance_usd: 1,
+    }
+
+    store.getState().setApiKey('session-jwt')
+    store.getState().setUserProfile(profile)
+
+    expect(store.getState().openonionApiKey).toBe('session-jwt')
+    expect(store.getState().userProfile).toEqual(profile)
+    expect(persistedState()).not.toHaveProperty('openonionApiKey')
+    expect(persistedState()).not.toHaveProperty('userProfile')
+  })
+})

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -23,8 +23,9 @@ interface ChatState {
   conversations: Conversation[]
   activeSessionId: string | null
   agents: string[]  // Saved agent addresses (0x...)
+  // Transient authentication state. The browser identity re-authenticates after
+  // every reload, so persisting either value only exposes credentials at rest.
   openonionApiKey: string  // JWT token for transcription & LLM calls
-  // Auth state (persisted)
   userProfile: UserProfile | null
   // Transient state (not persisted)
   pendingMessage: string | null  // Message to send after navigation
@@ -179,8 +180,6 @@ export const useChatStore = create<ChatStore>()(
         conversations: state.conversations,
         activeSessionId: state.activeSessionId,
         agents: state.agents,
-        openonionApiKey: state.openonionApiKey,
-        userProfile: state.userProfile,
         // pendingMessage is intentionally excluded
       }),
       // Handle Date serialization + migration
@@ -209,9 +208,21 @@ export const useChatStore = create<ChatStore>()(
           if (parsed.state?.defaultAgentAddress && !parsed.state?.agents?.length) {
             parsed.state.agents = [parsed.state.defaultAgentAddress]
           }
+          // Alpha builds once persisted the voice/auth JWT and account profile.
+          // The secure React identity can mint a fresh short-lived token after
+          // every reload, so scrub old copies from disk during hydration.
+          const hadPersistedAuth = Boolean(
+            parsed.state
+            && ('openonionApiKey' in parsed.state || 'userProfile' in parsed.state)
+          )
+          if (parsed.state) {
+            delete parsed.state.openonionApiKey
+            delete parsed.state.userProfile
+          }
           // Clean up old fields
           delete parsed.state?.defaultAgentUrl
           delete parsed.state?.defaultAgentAddress
+          if (hadPersistedAuth) localStorage.setItem(name, JSON.stringify(parsed))
           return parsed
         },
         setItem: (name, value) => {


### PR DESCRIPTION
## Summary
- stop persisting OpenOnion auth JWTs and account profiles in Zustand/localStorage
- scrub credential fields written by older alpha builds during hydration
- document the React-owned non-extractable IndexedDB identity boundary

## Verification
- 98/98 Vitest tests
- focused Chromium reload/storage E2E
- ESLint
- Next.js production build (webpack locally; CI exercises the repository default)

Fixes #151