### PR TITLE
chore(oip): pin React 0.4.2-alpha.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.9",
+        "@connectonion/react": "0.4.2-alpha.10",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.9",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.9.tgz",
-      "integrity": "sha512-z23Ht/BTb+Fpc7AaVb0xt+qTFvl41YoGdgoIxP3oEe1Gmmj0A4+eWQQcOzqgs74rVlYtg6UUlYGLrleSZwQPNQ==",
+      "version": "0.4.2-alpha.10",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.10.tgz",
+      "integrity": "sha512-HKV8y7782oBZMP9h0u+jpoQvkLUNYIdYQeug8nyRhMT2RF9vZrpmFAxiVAbsPaWTL/Qh1rZJCyqHr5Vw/8q07Q==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.9",
+    "@connectonion/react": "0.4.2-alpha.10",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- consume the exact public `@connectonion/react@0.4.2-alpha.10` OIP adapter release
- bypass browser caches for both Relay and direct agent discovery
- keep npm stable `latest` on 0.4.1 while consuming the opt-in alpha explicitly

## Public artifact
- version: 0.4.2-alpha.10
- integrity: `sha512-HKV8y7782oBZMP9h0u+jpoQvkLUNYIdYQeug8nyRhMT2RF9vZrpmFAxiVAbsPaWTL/Qh1rZJCyqHr5Vw/8q07Q==`

## Verification
- 96/96 Vitest tests
- ESLint
- Next.js production build

Contributes to #156.