### PR TITLE
fix(workroom): preserve provider chronology

### DIFF
--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -103,6 +103,62 @@ describe('CodingAgentCard', () => {
     expect(workroom.textContent).toContain('Changelog updated.')
   })
 
+  it('keeps the first result before resumed messages in chronological order', () => {
+    const continuation: ProviderInvocationUI = {
+      ...invocation,
+      id: 'codex:call-8',
+      parentToolCallId: 'call-8',
+      sessionId: 'codex-session-1',
+      taskSummary: 'Second request',
+      status: 'completed',
+      result: 'Second result',
+    }
+    const { element } = render({
+      invocation: {
+        ...invocation,
+        sessionId: 'codex-session-1',
+        status: 'completed',
+        result: 'First result',
+      },
+      continuations: [continuation],
+    })
+
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const text = document.querySelector<HTMLElement>('[role="dialog"]')!.textContent!
+    expect(text.indexOf('First result')).toBeLessThan(text.indexOf('Second request'))
+    expect(text.indexOf('Second request')).toBeLessThan(text.indexOf('Second result'))
+  })
+
+  it('tracks resumed status, activity and files across the provider session', () => {
+    const continuation: ProviderInvocationUI = {
+      ...invocation,
+      id: 'codex:call-8',
+      parentToolCallId: 'call-8',
+      sessionId: 'codex-session-1',
+      taskSummary: 'Continue',
+      status: 'running',
+      activities: [{
+        id: 'file-2', name: 'Edit', status: 'done',
+        args: { file_path: 'src/resumed.ts' }, result: 'updated',
+      }],
+    }
+    const { element } = render({
+      invocation: { ...invocation, sessionId: 'codex-session-1', status: 'completed' },
+      continuations: [continuation],
+    })
+
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
+    expect(workroom.querySelector('[aria-label="Stop Codex"]')).not.toBeNull()
+
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Activity'))!.click())
+    expect(workroom.textContent).toContain('pytest tests/unit')
+    expect(workroom.textContent).toContain('src/resumed.ts')
+
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Files'))!.click())
+    expect(workroom.textContent).toContain('src/resumed.ts')
+  })
+
   it('exposes Activity and Files as full Work Room sections', () => {
     const withFile = {
       ...invocation,

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -37,10 +37,15 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
   const [tab, setTab] = useState<WorkroomTab>('chat')
   const [draft, setDraft] = useState('')
   const [queued, setQueued] = useState<QueuedMessage[]>([])
-  const running = !['completed', 'failed', 'cancelled'].includes(invocation.status)
+  const current = continuations.at(-1) ?? invocation
+  const running = !['completed', 'failed', 'cancelled'].includes(current.status)
+  const activities = useMemo(
+    () => [invocation, ...continuations].flatMap(item => item.activities),
+    [invocation, continuations],
+  )
   const files = useMemo(
-    () => invocation.activities.map(activity => ({ activity, path: activityPath(activity) })).filter(item => item.path),
-    [invocation.activities],
+    () => activities.map(activity => ({ activity, path: activityPath(activity) })).filter(item => item.path),
+    [activities],
   )
 
   useEffect(() => {
@@ -73,14 +78,14 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
         </button>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <ToolStatus status={invocation.status === 'failed' ? 'error' : invocation.status === 'completed' ? 'done' : 'running'} />
+            <ToolStatus status={current.status === 'failed' ? 'error' : current.status === 'completed' ? 'done' : 'running'} />
             <h1 className="whitespace-nowrap text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
           </div>
           <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || 'Coding task'}</p>
         </div>
-        <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{invocation.status.replace('_', ' ')}</span>
+        <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{current.status.replace('_', ' ')}</span>
         {running && onStop && (
-          <button type="button" onClick={onStop} className="flex min-h-11 items-center gap-2 rounded-lg border border-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-50">
+          <button type="button" onClick={onStop} aria-label={`Stop ${invocation.providerDisplayName}`} className="flex min-h-11 items-center gap-2 rounded-lg border border-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-50">
             <HiOutlineStop className="h-4 w-4" /> Stop
           </button>
         )}
@@ -121,6 +126,12 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
                 <p className="mt-1 text-sm font-medium text-neutral-900">{invocation.providerDisplayName}{invocation.sessionId ? ` · ${invocation.sessionId.slice(0, 12)}…` : ''}</p>
                 <p className="mt-2 text-sm text-neutral-600">{invocation.taskSummary || 'Coding task'}</p>
               </div>
+              {invocation.result && (
+                <div className="max-w-[90%] rounded-xl border border-neutral-200 bg-white px-4 py-3 text-sm text-neutral-700">
+                  {invocation.result}
+                </div>
+              )}
+              {invocation.error && <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{invocation.error}</div>}
               {Array.from({ length: Math.max(queued.length, continuations.length) }, (_, index) => {
                 const message = queued[index]
                 const continuation = continuations[index]
@@ -145,18 +156,12 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
                   </div>
                 )
               })}
-              {invocation.result && (
-                <div className="max-w-[90%] rounded-xl border border-neutral-200 bg-white px-4 py-3 text-sm text-neutral-700">
-                  {invocation.result}
-                </div>
-              )}
-              {invocation.error && <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{invocation.error}</div>}
             </div>
           )}
 
           {tab === 'activity' && (
             <ol className="space-y-2" aria-label={`${invocation.providerDisplayName} Work Room activity`}>
-              {invocation.activities.map(activity => (
+              {activities.map(activity => (
                 <li key={activity.id} className="flex min-w-0 gap-3 rounded-xl border border-neutral-200 bg-white p-4">
                   <ToolStatus status={activity.status} className="mt-0.5" />
                   <div className="min-w-0 flex-1">
@@ -166,7 +171,11 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
                   </div>
                 </li>
               ))}
-              {invocation.activities.length === 0 && <li className="py-12 text-center text-sm text-neutral-500">Waiting for provider activity…</li>}
+              {activities.length === 0 && (
+                <li className="py-12 text-center text-sm text-neutral-500">
+                  {running ? 'Waiting for provider activity…' : 'No provider activity reported.'}
+                </li>
+              )}
             </ol>
           )}
 

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -55,9 +55,25 @@ test('Codex card opens an interactive Work Room with target, queue, activity and
   await shot('codex-workroom-chat-desktop')
   await room.getByRole('tab', { name: /Activity/ }).click()
   await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('pytest -q')
+  await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('src/changelog.md')
   await room.getByRole('tab', { name: /Files/ }).click()
-  await expect(room).toContainText('No file changes reported yet.')
+  await expect(room).toContainText('src/changelog.md')
   await shot('codex-workroom-desktop')
+})
+
+test('Work Room keeps the first result before the resumed request and result', async ({ page }) => {
+  await openCodingRun(page, 'coding-agent-completed', 'completed')
+
+  const card = pane(page).getByRole('region', { name: 'Codex completed' })
+  await card.getByRole('button', { name: 'Open Work Room' }).click()
+  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+  await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
+  await room.getByRole('button', { name: 'Send to Codex' }).click()
+  await expect(room).toContainText('Changelog updated.')
+
+  const text = await room.textContent()
+  expect(text!.indexOf('Codex fixed the Windows tests.')).toBeLessThan(text!.indexOf('Also update the changelog'))
+  expect(text!.indexOf('Also update the changelog')).toBeLessThan(text!.indexOf('Changelog updated.'))
 })
 
 test('completed Codex card shows the result and no Stop action', async ({ page, shot }) => {

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -307,6 +307,21 @@ export async function mockAgent(
             type: 'provider_invocation', invocationId: 'codex:call-8',
             parentToolCallId: 'call-8', provider: 'codex',
             providerDisplayName: 'Codex', taskSummary: 'Also update the changelog',
+            sessionId: 'codex-session-1', status: 'running',
+          })
+          send(ws, {
+            type: 'tool_call', tool_id: 'child-2', name: 'Edit',
+            args: { file_path: 'src/changelog.md' }, status: 'in_progress',
+            parentToolCallId: 'call-8', invocationId: 'codex:call-8',
+          })
+          send(ws, {
+            type: 'tool_result', tool_id: 'child-2', status: 'completed', result: 'updated',
+            parentToolCallId: 'call-8', invocationId: 'codex:call-8',
+          })
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-8',
+            parentToolCallId: 'call-8', provider: 'codex',
+            providerDisplayName: 'Codex', taskSummary: 'Also update the changelog',
             sessionId: 'codex-session-1', status: 'completed', elapsedMs: 900,
             result: 'Changelog updated.',
           })


### PR DESCRIPTION
Fixes #177.

## What changed

- render the initial provider result immediately after the Work Room target
- append each continuation request/result in chronological order
- aggregate Activity and Files across the same provider session
- derive status and Stop from the newest continuation
- distinguish terminal “no activity” from a provider that is still starting
- add an accessible provider-specific Stop label in the room

The OIP and Core provider contracts are unchanged.

## Verification

- red-first component regressions reproduced chronology and stale status
- component tests: 8/8
- full Vitest: 13 files / 100 tests
- targeted Chromium: 7/7, including phone layout
- ESLint: pass
- Next.js 16.3 production build: pass
- real pre-fix Claude/Codex screenshots established the production failure

After merge/deploy, the acceptance gate will repeat the real Claude Work Room resume and capture the corrected chronology.
