### PR TITLE
fix(workroom): show live native coding work

### DIFF
--- a/components/chat/chat-messages.test.tsx
+++ b/components/chat/chat-messages.test.tsx
@@ -15,11 +15,15 @@ vi.mock('./messages', () => {
   const ToolCall = ({ pendingApproval }: { pendingApproval?: PendingApproval }) => (
     pendingApproval ? <button type="button">Allow once</button> : null
   )
+  const CodingAgentCard = ({ pendingApproval }: { pendingApproval?: PendingApproval | null }) => (
+    pendingApproval ? <button type="button">Allow Codex once</button> : <span>Codex card</span>
+  )
   return {
     User: EmptyMessage,
     Agent: EmptyMessage,
     Thinking: EmptyMessage,
     ToolCall,
+    CodingAgentCard,
     AskUser: EmptyMessage,
     OnboardRequired: EmptyMessage,
     OnboardSuccess: EmptyMessage,
@@ -129,6 +133,34 @@ describe('ChatMessages permission decisions', () => {
       button.textContent?.includes('Allow once'),
     )
     expect(allowOnceButtons).toHaveLength(1)
+    expect(element.querySelectorAll('[data-pending-decision]')).toHaveLength(1)
+  })
+
+  it('attaches a correlated native approval to its exact provider card, not a generic codex tool', () => {
+    const provider = {
+      id: 'codex:outer',
+      type: 'provider_invocation',
+      parentToolCallId: 'outer',
+      provider: 'codex',
+      providerDisplayName: 'Codex',
+      status: 'awaiting_approval',
+      activities: [],
+    } as ChatItem
+    const genericCodexTool: ChatItem = {
+      id: 'generic-codex', type: 'tool_call', name: 'codex', status: 'running',
+    }
+    const correlated: PendingApproval = {
+      id: 'approval-codex',
+      tool: 'codex',
+      arguments: { action: 'Run pytest' },
+      provider: 'codex',
+      providerInvocationId: 'codex:outer',
+      parentToolCallId: 'outer',
+    }
+
+    const { element } = render([genericCodexTool, provider], correlated)
+
+    expect(element.textContent).toContain('Allow Codex once')
     expect(element.querySelectorAll('[data-pending-decision]')).toHaveLength(1)
   })
 })

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -10,6 +10,18 @@ import { ChatApproval } from './chat-approval'
 import { ChatFullAccessCheckpoint } from './chat-full-access-checkpoint'
 import type { ChatMessagesProps, OnboardRequiredUI, OnboardSuccessUI, IntentUI, EvalUI, CompactUI, ToolBlockedUI, FullAccessCheckpointUI, FilesReceivedUI } from './types'
 
+function approvalMatchesProvider(
+  approval: ChatMessagesProps['pendingApproval'],
+  invocation: { id: string; parentToolCallId: string; provider: string },
+) {
+  return Boolean(
+    approval
+    && approval.provider === invocation.provider
+    && approval.providerInvocationId === invocation.id
+    && approval.parentToolCallId === invocation.parentToolCallId,
+  )
+}
+
 export function ChatMessages({
   ui = [],
   className,
@@ -114,7 +126,7 @@ export function ChatMessages({
   // whichever same-named call is last in the array, which after a second bash call
   // can be one that already finished. The approval then decorates a completed card
   // while the live one sits plain, and the reader answers about the wrong thing.
-  const pendingToolId = pendingApproval
+  const pendingToolId = pendingApproval && !pendingApproval.providerInvocationId
     ? ui.filter(item => item.type === 'tool_call'
         && item.name.toLowerCase() === approvalToolName
         && item.status === 'running')
@@ -124,8 +136,8 @@ export function ChatMessages({
   // OIP permits a permission request without a preceding tool update.
   // Keep the existing inline tool-card treatment when that context exists;
   // otherwise the latest normalized approval item needs its own decision surface.
-  const pendingStandaloneApprovalId = pendingApproval && !pendingToolId
-    ? ui.filter(item => item.type === 'approval_needed').pop()?.id
+  const pendingStandaloneApprovalId = pendingApproval && !pendingToolId && !pendingApproval.providerInvocationId
+    ? pendingApproval.id || ui.filter(item => item.type === 'approval_needed').pop()?.id
     : null
 
   // Find the last ask_user tool call that's still running
@@ -216,15 +228,22 @@ export function ChatMessages({
               )
             }
             case 'provider_invocation': {
+              const alreadyRenderedForSession = item.sessionId
+                && ui.slice(0, itemIndex).some(candidate =>
+                  candidate.type === 'provider_invocation'
+                  && candidate.provider === item.provider
+                  && candidate.sessionId === item.sessionId,
+                )
+              if (alreadyRenderedForSession) return null
               const continuations = item.sessionId
                 ? ui.slice(itemIndex + 1).filter((candidate): candidate is typeof item =>
                     candidate.type === 'provider_invocation'
                     && candidate.provider === item.provider
                     && candidate.sessionId === item.sessionId)
                 : []
-              const approvalForProvider = pendingApproval
-                && pendingApproval.tool.split(':')[0].toLowerCase() === item.provider
-                ? pendingApproval : undefined
+              const approvalForProvider = [item, ...continuations].some(candidate =>
+                approvalMatchesProvider(pendingApproval, candidate),
+              ) ? pendingApproval : undefined
               return (
                 <div key={item.id} {...(approvalForProvider ? { 'data-pending-decision': '' } : {})}>
                   <CodingAgentCard

--- a/components/chat/messages/coding-agent-activity.ts
+++ b/components/chat/messages/coding-agent-activity.ts
@@ -1,0 +1,48 @@
+import type { ProviderInvocationUI } from '../types'
+
+export type ProviderActivity = ProviderInvocationUI['activities'][number]
+
+export function allProviderActivities(
+  invocation: ProviderInvocationUI,
+  continuations: ProviderInvocationUI[] = [],
+) {
+  return [invocation, ...continuations].flatMap(item => item.activities)
+}
+
+export function latestProviderActivity(
+  invocation: ProviderInvocationUI,
+  continuations: ProviderInvocationUI[] = [],
+) {
+  return allProviderActivities(invocation, continuations).at(-1)
+}
+
+/** A short human description; raw commands and outputs stay behind disclosure. */
+export function activitySummary(activity: ProviderActivity | undefined, running: boolean) {
+  if (!activity) return running ? 'Preparing the workroom' : 'No provider activity recorded'
+  const command = typeof activity.args?.command === 'string'
+    ? activity.args.command.toLowerCase()
+    : ''
+  const path = typeof activity.args?.file_path === 'string'
+    || typeof activity.args?.path === 'string'
+  const name = activity.name.toLowerCase()
+  if (/pytest|vitest|jest|npm test|pnpm test/.test(command)) return 'Running tests'
+  if (/python|py_compile/.test(command)) return 'Running a Python check'
+  if (/git diff|git status|rg |grep |find /.test(command)) return 'Inspecting the workspace'
+  if (path || /file|edit|write|patch/.test(name)) return 'Updating files'
+  if (/search|browse|web/.test(name)) return 'Researching context'
+  if (activity.status === 'running') return 'Working on the next step'
+  return 'Completed a work step'
+}
+
+export function activityRawDetails(activity: ProviderActivity) {
+  const data = {
+    ...(activity.args && { input: activity.args }),
+    ...(activity.result && { result: activity.result }),
+  }
+  return Object.keys(data).length > 0 ? JSON.stringify(data, null, 2) : 'No additional details.'
+}
+
+export function activityPath(activity: ProviderActivity): string | null {
+  const value = activity.args?.file_path ?? activity.args?.path
+  return typeof value === 'string' && value ? value : null
+}

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -43,12 +43,17 @@ describe('CodingAgentCard', () => {
     expect(element.textContent).toContain('Codex')
     expect(element.textContent).toContain('Fix Windows tests')
     expect(element.textContent).not.toContain('pytest tests/unit')
+    expect(element.querySelector('[aria-label="Live activity snapshot"]')).not.toBeNull()
     act(() => element.querySelector<HTMLButtonElement>('[aria-label="Stop Codex"]')!.click())
     expect(props.onStop).toHaveBeenCalledOnce()
   })
 
-  it('shows nested activity inline when expanded without horizontal overflow classes', () => {
+  it('shows semantic nested activity inline and keeps raw details behind disclosure', () => {
     const { element } = render({ expanded: true })
+    expect(element.textContent).toContain('Running tests')
+    const details = element.querySelector('details')!
+    expect(details.open).toBe(false)
+    details.open = true
     expect(element.textContent).toContain('pytest tests/unit')
     expect(element.textContent).toContain('89 passed')
     expect(element.querySelector('section')?.className).toContain('min-w-0')
@@ -68,6 +73,7 @@ describe('CodingAgentCard', () => {
     const workroom = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Codex Work Room"]')!
     expect(workroom).not.toBeNull()
     expect(workroom.textContent).toContain('Fix Windows tests')
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
 
     const composer = workroom.querySelector<HTMLTextAreaElement>('textarea')!
     act(() => {
@@ -98,6 +104,7 @@ describe('CodingAgentCard', () => {
 
     act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
     const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
     expect(workroom.textContent).toContain('Completed #1 by Codex')
     expect(workroom.textContent).toContain('Also update the changelog')
     expect(workroom.textContent).toContain('Changelog updated.')
@@ -124,7 +131,9 @@ describe('CodingAgentCard', () => {
     })
 
     act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const text = document.querySelector<HTMLElement>('[role="dialog"]')!.textContent!
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
+    const text = workroom.textContent!
     expect(text.indexOf('First result')).toBeLessThan(text.indexOf('Second request'))
     expect(text.indexOf('Second request')).toBeLessThan(text.indexOf('Second result'))
   })
@@ -175,5 +184,39 @@ describe('CodingAgentCard', () => {
     expect(workroom.textContent).toContain('pytest tests/unit')
     act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Files'))!.click())
     expect(workroom.textContent).toContain('src/app.tsx')
+  })
+
+  it('keeps a long activity history bounded and hides raw details until disclosure', () => {
+    const activities = Array.from({ length: 10 }, (_, index) => ({
+      id: `step-${index}`,
+      name: 'Bash',
+      status: index === 9 ? 'running' as const : 'done' as const,
+      args: { command: `python3 dijkstra.py --case ${index}` },
+      result: `case ${index} passed`,
+    }))
+    const { element } = render({ invocation: { ...invocation, activities }, expanded: true })
+
+    const activityList = element.querySelector<HTMLOListElement>('[aria-label="Codex activity"]')!
+    expect(activityList.className).toContain('max-h-56')
+    expect(activityList.className).toContain('overflow-y-auto')
+    expect(element.querySelectorAll('details')).toHaveLength(10)
+    expect(Array.from(element.querySelectorAll('details')).every(item => !item.open)).toBe(true)
+    expect(element.textContent).toContain('Running a Python check')
+  })
+
+  it('keeps a native approval visible on the collapsed provider card', () => {
+    const onApprovalResponse = vi.fn()
+    const { element } = render({
+      pendingApproval: {
+        id: 'approval-1',
+        tool: 'codex',
+        arguments: { action: 'Run pytest', cwd: '.workroom-e2e' },
+      },
+      onApprovalResponse,
+    })
+
+    expect(element.querySelector('[aria-label="Approval required for codex"]')).not.toBeNull()
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Allow once'))!.click())
+    expect(onApprovalResponse).toHaveBeenCalledWith(true, 'once', undefined)
   })
 })

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -40,9 +40,9 @@ function elapsed(ms?: number) {
 
 function statusTone(status: ProviderInvocationUI['status']) {
   if (status === 'failed') return 'bg-red-50 text-red-700'
-  if (status === 'cancelled') return 'bg-amber-50 text-amber-700'
+  if (status === 'cancelled') return 'bg-neutral-100 text-neutral-700'
   if (status === 'completed') return 'bg-emerald-50 text-emerald-700'
-  if (status === 'awaiting_approval') return 'bg-amber-50 text-amber-700'
+  if (status === 'awaiting_approval') return 'bg-neutral-100 text-neutral-700'
   return 'bg-blue-50 text-blue-700'
 }
 
@@ -130,7 +130,7 @@ export function CodingAgentCard({
       </div>
 
       {pendingApproval && onApprovalResponse && (
-        <div className="border-b border-amber-100 bg-amber-50/40 px-3 py-2 sm:px-4">
+        <div className="border-b border-neutral-200 bg-neutral-50 px-3 py-2 sm:px-4">
           <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
         </div>
       )}

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -1,9 +1,21 @@
 'use client'
 
 import { useState } from 'react'
-import { HiOutlineChevronDown, HiOutlineChevronRight, HiOutlineStop } from 'react-icons/hi'
+import {
+  HiOutlineChevronDown,
+  HiOutlineChevronRight,
+  HiOutlineClock,
+  HiOutlineEye,
+  HiOutlineStop,
+} from 'react-icons/hi'
 import type { PendingApproval, ProviderInvocationUI } from '../types'
 import { ChatApproval } from '../chat-approval'
+import {
+  activityRawDetails,
+  activitySummary,
+  allProviderActivities,
+  latestProviderActivity,
+} from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
 import { CodingAgentWorkroom } from './coding-agent-workroom'
 
@@ -26,82 +38,133 @@ function elapsed(ms?: number) {
   return `${Math.round(ms / 1000)}s`
 }
 
+function statusTone(status: ProviderInvocationUI['status']) {
+  if (status === 'failed') return 'bg-red-50 text-red-700'
+  if (status === 'cancelled') return 'bg-amber-50 text-amber-700'
+  if (status === 'completed') return 'bg-emerald-50 text-emerald-700'
+  if (status === 'awaiting_approval') return 'bg-amber-50 text-amber-700'
+  return 'bg-blue-50 text-blue-700'
+}
+
 export function CodingAgentCard({
   invocation, continuations = [], expanded, onToggle, onStop, pendingApproval, onApprovalResponse, onMessageProvider,
 }: CodingAgentCardProps) {
   const [workroomOpen, setWorkroomOpen] = useState(false)
-  const running = !terminal.has(invocation.status)
-  const summary = invocation.taskSummary || 'Coding task'
-  const status = invocation.status.replace('_', ' ')
+  const current = continuations.at(-1) ?? invocation
+  const running = !terminal.has(current.status)
+  const summary = invocation.taskSummary || current.taskSummary || 'Coding task'
+  const status = current.status.replace('_', ' ')
+  const activities = allProviderActivities(invocation, continuations)
+  const latest = latestProviderActivity(invocation, continuations)
+  const latestSummary = current.status === 'awaiting_approval'
+    ? 'Waiting for your approval'
+    : activitySummary(latest, running)
 
   return (
     <section
       aria-label={`${invocation.providerDisplayName} ${status}`}
-      className="my-2 min-w-0 overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm"
+      className="my-3 min-w-0 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
     >
-      <div className="flex min-w-0 items-center gap-2 px-3 py-2.5">
-        <ToolStatus status={invocation.status === 'completed' ? 'done' : invocation.status === 'failed' ? 'error' : 'running'} />
-        <button
-          type="button"
-          aria-expanded={expanded}
-          onClick={onToggle}
-          className="flex min-h-9 min-w-0 flex-1 items-center gap-2 text-left"
-        >
-          {expanded ? <HiOutlineChevronDown className="h-4 w-4 shrink-0" /> : <HiOutlineChevronRight className="h-4 w-4 shrink-0" />}
-          <span className="shrink-0 text-sm font-semibold text-neutral-900">{invocation.providerDisplayName}</span>
-          <span className="truncate text-sm text-neutral-600">{summary}</span>
-        </button>
-        <span aria-label={`Status: ${status}`} className="shrink-0 rounded-full bg-neutral-100 px-2 py-1 text-xs capitalize text-neutral-600">
-          <span className="sr-only">Status: </span>{status}
-        </span>
-        {invocation.elapsedMs != null && <span className="shrink-0 text-xs tabular-nums text-neutral-400">{elapsed(invocation.elapsedMs)}</span>}
-        {running && onStop && (
+      <div className="border-b border-neutral-100 px-3 py-3 sm:px-4">
+        <div className="flex min-w-0 items-start gap-2">
+          <ToolStatus status={current.status === 'completed' ? 'done' : current.status === 'failed' ? 'error' : 'running'} className="mt-1" />
           <button
             type="button"
-            onClick={onStop}
-            className="flex min-h-9 min-w-9 items-center justify-center rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-red-600"
-            aria-label={`Stop ${invocation.providerDisplayName}`}
+            aria-expanded={expanded}
+            onClick={onToggle}
+            className="flex min-h-9 min-w-0 flex-1 items-start gap-2 text-left"
           >
-            <HiOutlineStop className="h-4 w-4" />
+            {expanded ? <HiOutlineChevronDown className="mt-0.5 h-4 w-4 shrink-0" /> : <HiOutlineChevronRight className="mt-0.5 h-4 w-4 shrink-0" />}
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold text-neutral-950">{summary}</span>
+              <span className="mt-0.5 block text-xs text-neutral-500">{invocation.providerDisplayName} work room</span>
+            </span>
           </button>
-        )}
-        <button
-          type="button"
-          onClick={() => setWorkroomOpen(true)}
-          className="min-h-9 shrink-0 rounded-md border border-neutral-200 px-2.5 text-xs font-medium text-neutral-700 hover:bg-neutral-50"
+          {running && onStop && (
+            <button
+              type="button"
+              onClick={onStop}
+              className="flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-red-600"
+              aria-label={`Stop ${invocation.providerDisplayName}`}
+            >
+              <HiOutlineStop className="h-4 w-4" />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setWorkroomOpen(true)}
+            className="min-h-9 shrink-0 rounded-md border border-neutral-200 px-2.5 text-xs font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Open Work Room
+          </button>
+        </div>
+
+        {/* This is a true activity snapshot, not a fabricated screenshot. */}
+        <div
+          aria-label="Live activity snapshot"
+          className="mt-3 grid min-h-24 grid-cols-[auto_1fr] gap-x-3 rounded-lg border border-neutral-200 bg-gradient-to-br from-neutral-50 to-white p-3"
         >
-          Open Work Room
-        </button>
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-900 text-white">
+            <HiOutlineEye className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-medium text-neutral-900">{latestSummary}</p>
+              <span
+                aria-label={`Status: ${status}`}
+                className={`rounded-full px-2 py-0.5 text-[11px] font-medium capitalize ${statusTone(current.status)}`}
+              >
+                {status}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-neutral-500">
+              {activities.length === 0 ? 'Live activity will appear here as Codex works.' : `${activities.length} recorded step${activities.length === 1 ? '' : 's'} · newest activity first in Work Room`}
+            </p>
+          </div>
+          <div className="col-span-2 mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-neutral-200 pt-2 text-xs text-neutral-500">
+            <span>{invocation.providerDisplayName}</span>
+            <span className="flex items-center gap-1"><HiOutlineClock className="h-3.5 w-3.5" />{current.elapsedMs != null ? elapsed(current.elapsedMs) : running ? 'Live' : 'Finished'}</span>
+            {current.sessionId && <span>Session connected</span>}
+          </div>
+        </div>
       </div>
 
+      {pendingApproval && onApprovalResponse && (
+        <div className="border-b border-amber-100 bg-amber-50/40 px-3 py-2 sm:px-4">
+          <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
+        </div>
+      )}
+
       {expanded && (
-        <div className="border-t border-neutral-100 px-3 py-2">
-          <ol className="space-y-1" aria-label={`${invocation.providerDisplayName} activity`}>
-            {invocation.activities.map(activity => (
-              <li key={activity.id} className="flex min-w-0 items-start gap-2 py-1 text-xs">
-                <ToolStatus status={activity.status} className="mt-0.5" />
-                <span className="shrink-0 font-medium text-neutral-700">{activity.name}</span>
-                <span className="min-w-0 flex-1 overflow-hidden font-mono text-neutral-500">
-                  <span className="block truncate">
-                    {String(activity.args?.command || activity.args?.file_path || activity.args?.path || activity.result || '')}
-                  </span>
-                  {activity.result != null && Boolean(activity.args?.command || activity.args?.file_path || activity.args?.path) && (
-                    <span className="block break-words text-neutral-400">{String(activity.result)}</span>
-                  )}
-                </span>
+        <div className="px-3 py-3 sm:px-4">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Recent activity</p>
+            <span className="text-xs text-neutral-400">Details stay collapsed by default</span>
+          </div>
+          <ol className="max-h-56 space-y-1 overflow-y-auto overscroll-contain pr-1" aria-label={`${invocation.providerDisplayName} activity`}>
+            {[...activities].reverse().map(activity => (
+              <li key={activity.id} className="rounded-lg border border-neutral-100 bg-neutral-50/70 px-2.5 py-2">
+                <details>
+                  <summary className="flex min-w-0 cursor-pointer list-none items-start gap-2 text-xs marker:hidden">
+                    <ToolStatus status={activity.status} className="mt-0.5" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium text-neutral-800">{activitySummary(activity, running)}</span>
+                      <span className="mt-0.5 block capitalize text-neutral-500">{activity.status}</span>
+                    </span>
+                    <HiOutlineChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-neutral-400" />
+                  </summary>
+                  <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-neutral-900 p-2 text-[11px] leading-5 text-neutral-100">{activityRawDetails(activity)}</pre>
+                </details>
               </li>
             ))}
           </ol>
-          {invocation.activities.length === 0 && running && (
-            <p className="py-1 text-xs text-neutral-500">Starting provider…</p>
+          {activities.length === 0 && (
+            <p className="py-2 text-xs text-neutral-500">{running ? 'Starting provider…' : 'No provider activity reported.'}</p>
           )}
-          {(invocation.error || (invocation.result && terminal.has(invocation.status))) && (
-            <p className={`mt-2 break-words rounded-md px-2 py-1.5 text-xs ${invocation.error ? 'bg-red-50 text-red-700' : 'bg-neutral-50 text-neutral-600'}`}>
-              {invocation.error || invocation.result}
+          {(current.error || (current.result && terminal.has(current.status))) && (
+            <p className={`mt-3 break-words rounded-md px-2.5 py-2 text-xs ${current.error ? 'bg-red-50 text-red-700' : 'bg-neutral-50 text-neutral-600'}`}>
+              {current.error || current.result}
             </p>
-          )}
-          {pendingApproval && onApprovalResponse && (
-            <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
           )}
         </div>
       )}
@@ -112,6 +175,8 @@ export function CodingAgentCard({
           onClose={() => setWorkroomOpen(false)}
           onStop={onStop}
           onMessage={onMessageProvider}
+          pendingApproval={pendingApproval}
+          onApprovalResponse={onApprovalResponse}
         />
       )}
     </section>

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -6,11 +6,20 @@ import {
   HiOutlineArrowLeft,
   HiOutlineChatBubbleLeftRight,
   HiOutlineDocument,
+  HiOutlineEye,
   HiOutlineListBullet,
   HiOutlinePaperAirplane,
   HiOutlineStop,
 } from 'react-icons/hi2'
-import type { ProviderInvocationUI } from '../types'
+import type { PendingApproval, ProviderInvocationUI } from '../types'
+import { ChatApproval } from '../chat-approval'
+import {
+  activityPath,
+  activityRawDetails,
+  activitySummary,
+  allProviderActivities,
+  latestProviderActivity,
+} from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
 
 type WorkroomTab = 'chat' | 'activity' | 'files'
@@ -21,6 +30,8 @@ interface CodingAgentWorkroomProps {
   onClose: () => void
   onStop?: () => void
   onMessage?: (message: string) => void
+  pendingApproval?: PendingApproval | null
+  onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
 }
 
 interface QueuedMessage {
@@ -28,21 +39,17 @@ interface QueuedMessage {
   content: string
 }
 
-function activityPath(activity: ProviderInvocationUI['activities'][number]): string | null {
-  const value = activity.args?.file_path ?? activity.args?.path
-  return typeof value === 'string' && value ? value : null
-}
-
-export function CodingAgentWorkroom({ invocation, continuations = [], onClose, onStop, onMessage }: CodingAgentWorkroomProps) {
-  const [tab, setTab] = useState<WorkroomTab>('chat')
+export function CodingAgentWorkroom({ invocation, continuations = [], onClose, onStop, onMessage, pendingApproval, onApprovalResponse }: CodingAgentWorkroomProps) {
+  const [tab, setTab] = useState<WorkroomTab>('activity')
   const [draft, setDraft] = useState('')
   const [queued, setQueued] = useState<QueuedMessage[]>([])
   const current = continuations.at(-1) ?? invocation
   const running = !['completed', 'failed', 'cancelled'].includes(current.status)
   const activities = useMemo(
-    () => [invocation, ...continuations].flatMap(item => item.activities),
+    () => allProviderActivities(invocation, continuations),
     [invocation, continuations],
   )
+  const latest = latestProviderActivity(invocation, continuations)
   const files = useMemo(
     () => activities.map(activity => ({ activity, path: activityPath(activity) })).filter(item => item.path),
     [activities],
@@ -81,7 +88,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
             <ToolStatus status={current.status === 'failed' ? 'error' : current.status === 'completed' ? 'done' : 'running'} />
             <h1 className="whitespace-nowrap text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
           </div>
-          <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || 'Coding task'}</p>
+          <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || current.taskSummary || 'Coding task'}</p>
         </div>
         <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{current.status.replace('_', ' ')}</span>
         {running && onStop && (
@@ -119,6 +126,21 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
 
       <main className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
         <div className="mx-auto max-w-4xl">
+          <section aria-label="Work Room live summary" className="mb-4 rounded-xl border border-neutral-200 bg-white p-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-neutral-900 text-white"><HiOutlineEye className="h-5 w-5" /></span>
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Live work</p>
+                <p className="mt-1 text-sm font-semibold text-neutral-950">{current.status === 'awaiting_approval' ? 'Waiting for your approval' : activitySummary(latest, running)}</p>
+                <p className="mt-1 text-xs text-neutral-500">{activities.length} recorded step{activities.length === 1 ? '' : 's'} · raw commands and outputs are available only when you expand a step.</p>
+              </div>
+            </div>
+            {pendingApproval && onApprovalResponse && (
+              <div className="mt-4 border-t border-amber-100 pt-3">
+                <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
+              </div>
+            )}
+          </section>
           {tab === 'chat' && (
             <div className="space-y-3">
               <div className="rounded-xl border border-neutral-200 bg-white p-4">
@@ -160,15 +182,19 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
           )}
 
           {tab === 'activity' && (
-            <ol className="space-y-2" aria-label={`${invocation.providerDisplayName} Work Room activity`}>
-              {activities.map(activity => (
-                <li key={activity.id} className="flex min-w-0 gap-3 rounded-xl border border-neutral-200 bg-white p-4">
-                  <ToolStatus status={activity.status} className="mt-0.5" />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-neutral-900">{activity.name}</p>
-                    <p className="mt-1 break-words font-mono text-xs text-neutral-500">{String(activity.args?.command || activity.args?.file_path || activity.args?.path || activity.result || '')}</p>
-                    {activity.result && <p className="mt-2 whitespace-pre-wrap break-words text-xs text-neutral-600">{activity.result}</p>}
-                  </div>
+            <ol className="max-h-[calc(100dvh-16rem)] space-y-2 overflow-y-auto overscroll-contain pr-1" aria-label={`${invocation.providerDisplayName} Work Room activity`}>
+              {[...activities].reverse().map(activity => (
+                <li key={activity.id} className="rounded-xl border border-neutral-200 bg-white p-3 sm:p-4">
+                  <details>
+                    <summary className="flex min-w-0 cursor-pointer list-none gap-3 marker:hidden">
+                      <ToolStatus status={activity.status} className="mt-0.5" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-neutral-900">{activitySummary(activity, running)}</p>
+                        <p className="mt-1 text-xs capitalize text-neutral-500">{activity.status}</p>
+                      </div>
+                    </summary>
+                    <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-neutral-900 p-3 text-xs leading-5 text-neutral-100">{activityRawDetails(activity)}</pre>
+                  </details>
                 </li>
               ))}
               {activities.length === 0 && (

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -136,7 +136,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
               </div>
             </div>
             {pendingApproval && onApprovalResponse && (
-              <div className="mt-4 border-t border-amber-100 pt-3">
+              <div className="mt-4 border-t border-neutral-200 pt-3">
                 <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
               </div>
             )}

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -72,10 +72,16 @@ export interface AskUserField {
 }
 
 export interface PendingApproval {
+  id?: string
   tool: string
   arguments: Record<string, unknown>
   description?: string
   batch_remaining?: Array<{ tool: string; arguments: string }>
+  /** Native coding-provider correlation; never an authority token. */
+  provider?: 'codex' | 'claude_code'
+  providerInvocationId?: string
+  parentToolCallId?: string
+  activityId?: string
 }
 
 export interface PendingOnboard {

--- a/components/chat/use-agent-sdk.test.ts
+++ b/components/chat/use-agent-sdk.test.ts
@@ -29,6 +29,7 @@ function approval(answered?: boolean): ChatItem {
 describe('extractPendingStates', () => {
   it('keeps an unanswered approval attached to its running tool', () => {
     expect(extractPendingStates([runningTool, approval()]).pendingApproval).toEqual({
+      id: 'permission-1',
       tool: 'write',
       arguments: { path: 'release.txt' },
     })
@@ -36,6 +37,65 @@ describe('extractPendingStates', () => {
 
   it('clears an answered approval even before the tool receives a terminal update', () => {
     expect(extractPendingStates([runningTool, approval(true)]).pendingApproval).toBeNull()
+  })
+
+  it('attaches a native approval only while its exact provider invocation is live', () => {
+    const provider: Extract<ChatItem, { type: 'provider_invocation' }> = {
+      id: 'codex:outer',
+      type: 'provider_invocation',
+      parentToolCallId: 'outer',
+      provider: 'codex',
+      providerDisplayName: 'Codex',
+      status: 'awaiting_approval',
+      activities: [],
+    }
+    const nativeApproval = {
+      id: 'permission-codex',
+      type: 'approval_needed',
+      tool: 'codex',
+      arguments: { action: 'Run pytest' },
+      provider: 'codex',
+      providerInvocationId: 'codex:outer',
+      parentToolCallId: 'outer',
+    } as ChatItem
+
+    expect(extractPendingStates([provider, nativeApproval]).pendingApproval).toMatchObject({
+      id: 'permission-codex',
+      provider: 'codex',
+      providerInvocationId: 'codex:outer',
+      parentToolCallId: 'outer',
+    })
+
+    expect(extractPendingStates([
+      { ...provider, status: 'completed' },
+      nativeApproval,
+    ]).pendingApproval).toBeNull()
+
+    expect(extractPendingStates([
+      provider,
+      nativeApproval,
+      { ...provider, status: 'cancelled' },
+    ]).pendingApproval).toBeNull()
+  })
+
+  it('treats incomplete native correlation as a legacy approval instead of hiding it', () => {
+    const genericCodex: ChatItem = {
+      id: 'generic-codex', type: 'tool_call', name: 'codex', status: 'running',
+    }
+    const incomplete = {
+      id: 'permission-incomplete',
+      type: 'approval_needed',
+      tool: 'codex',
+      arguments: { action: 'Run pytest' },
+      provider: 'codex',
+      providerInvocationId: 'codex:outer',
+    } as ChatItem
+
+    expect(extractPendingStates([genericCodex, incomplete]).pendingApproval).toEqual({
+      id: 'permission-incomplete',
+      tool: 'codex',
+      arguments: { action: 'Run pytest' },
+    })
   })
 })
 

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -42,6 +42,28 @@ export function deriveSessionState(
 // Re-export ChatItem as UI for compatibility
 export type UI = ChatItem
 
+type ApprovalItem = Extract<ChatItem, { type: 'approval_needed' }>
+
+function nativeProviderApproval(item: ApprovalItem): Pick<PendingApproval, 'provider' | 'providerInvocationId' | 'parentToolCallId' | 'activityId'> | null {
+  const candidate = item as ApprovalItem & {
+    provider?: PendingApproval['provider']
+    providerInvocationId?: string
+    parentToolCallId?: string
+    activityId?: string
+  }
+  if (
+    (candidate.provider !== 'codex' && candidate.provider !== 'claude_code')
+    || !candidate.providerInvocationId
+    || !candidate.parentToolCallId
+  ) return null
+  return {
+    provider: candidate.provider,
+    providerInvocationId: candidate.providerInvocationId,
+    parentToolCallId: candidate.parentToolCallId,
+    ...(candidate.activityId && { activityId: candidate.activityId }),
+  }
+}
+
 /** Resolve the browser signature before handing an onboarding frame to the socket. */
 export async function submitSignedOnboard(
   signOnboard: (
@@ -153,11 +175,15 @@ export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingA
   let pendingFullAccessCheckpoint: PendingFullAccessCheckpoint | null = null
   let pendingPlanReview: PendingPlanReview | null = null
   const toolStatuses = new Map<string, string>()
+  const providerStatuses = new Map<string, string>()
+  let pendingApprovalItem: ApprovalItem | null = null
   let hasOnboardSuccess = false
 
   for (const item of ui) {
     if (item.type === 'tool_call') {
       toolStatuses.set(item.name.toLowerCase(), item.status)
+    } else if (item.type === 'provider_invocation') {
+      providerStatuses.set(item.id, item.status)
     } else if (item.type === 'ask_user') {
       if ((item as { answered?: boolean }).answered) {
         pendingAskUser = null
@@ -177,19 +203,10 @@ export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingA
       }
     } else if (item.type === 'approval_needed') {
       if (item.answered) {
-        pendingApproval = null
+        pendingApprovalItem = null
         continue
       }
-      // Only set pendingApproval if the tool is still running
-      const toolStatus = toolStatuses.get(item.tool.split(':')[0].toLowerCase())
-      if (toolStatus === 'running' || toolStatus === undefined) {
-        pendingApproval = {
-          tool: item.tool,
-          arguments: item.arguments,
-          ...(item.description && { description: item.description }),
-          ...(item.batch_remaining && { batch_remaining: item.batch_remaining }),
-        }
-      }
+      pendingApprovalItem = item
     } else if (item.type === 'onboard_required') {
       if (!hasOnboardSuccess) {
         pendingOnboard = {
@@ -216,6 +233,27 @@ export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingA
     if (maybePlanReview.type === 'plan_review') {
       pendingPlanReview = {
         plan_content: maybePlanReview.plan_content ?? '',
+      }
+    }
+  }
+
+  if (pendingApprovalItem) {
+    const providerApproval = nativeProviderApproval(pendingApprovalItem)
+    const providerStatus = providerApproval
+      ? providerStatuses.get(providerApproval.providerInvocationId!)
+      : undefined
+    const toolStatus = toolStatuses.get(pendingApprovalItem.tool.split(':')[0].toLowerCase())
+    const stillRunning = providerApproval
+      ? providerStatus === 'starting' || providerStatus === 'running' || providerStatus === 'awaiting_approval'
+      : toolStatus === 'running' || toolStatus === undefined
+    if (stillRunning) {
+      pendingApproval = {
+        id: pendingApprovalItem.id,
+        tool: pendingApprovalItem.tool,
+        arguments: pendingApprovalItem.arguments,
+        ...(pendingApprovalItem.description && { description: pendingApprovalItem.description }),
+        ...(pendingApprovalItem.batch_remaining && { batch_remaining: pendingApprovalItem.batch_remaining }),
+        ...(providerApproval || {}),
       }
     }
   }

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -6,8 +6,8 @@ import { mockAgent, AGENT_ADDRESS, PROFILE, type Scenario } from './mock-agent'
 
 async function openCodingRun(
   page: Page,
-  scenario: Extract<Scenario, 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed'> = 'coding-agent',
-  status: 'running' | 'completed' | 'failed' = 'running',
+  scenario: Extract<Scenario, 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval'> = 'coding-agent',
+  status: 'running' | 'completed' | 'failed' | 'awaiting approval' = 'running',
 ) {
   await page.addInitScript(() => {
     localStorage.setItem(
@@ -32,9 +32,12 @@ test('running Codex activity stays nested under one expandable card', async ({ p
   await expect(card).toContainText('running')
   await expect(card.getByRole('button', { name: 'Stop Codex' })).toBeVisible()
   await card.getByRole('button', { expanded: false }).click()
-  await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('Bash')
-  await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('pytest -q')
-  await expect(card.getByRole('list', { name: 'Codex activity' })).toContainText('89 passed')
+  const activity = card.getByRole('list', { name: 'Codex activity' })
+  await expect(activity).toContainText('Running tests')
+  await expect(activity.locator('details:not([open])')).toHaveCount(1)
+  await activity.locator('summary').click()
+  await expect(activity).toContainText('pytest -q')
+  await expect(activity).toContainText('89 passed')
   await expect(pane(page).getByRole('region', { name: 'Codex running' })).toHaveCount(1)
   await shot('codex-running-expanded')
 })
@@ -48,6 +51,7 @@ test('Codex card opens an interactive Work Room with target, queue, activity and
   await expect(room).toBeVisible()
   await expect(room).toContainText('Fix Windows tests')
 
+  await room.getByRole('tab', { name: /Chat/ }).click()
   await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
   await room.getByRole('button', { name: 'Send to Codex' }).click()
   await expect(room).toContainText('Completed #1 by Codex')
@@ -67,6 +71,7 @@ test('Work Room keeps the first result before the resumed request and result', a
   const card = pane(page).getByRole('region', { name: 'Codex completed' })
   await card.getByRole('button', { name: 'Open Work Room' }).click()
   const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+  await room.getByRole('tab', { name: /Chat/ }).click()
   await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
   await room.getByRole('button', { name: 'Send to Codex' }).click()
   await expect(room).toContainText('Changelog updated.')
@@ -101,6 +106,27 @@ test('failed Codex card exposes the error and no Stop action', async ({ page, sh
   await shot('codex-failed-expanded')
 })
 
+test('long native work keeps one actionable card, bounded history, and the approval on that card', async ({ page, shot }) => {
+  await openCodingRun(page, 'coding-agent-long-approval', 'awaiting approval')
+
+  const card = pane(page).getByRole('region', { name: 'Codex awaiting approval' })
+  await expect(card).toContainText('Waiting for your approval')
+  await expect(card.getByLabel('Live activity snapshot')).toBeVisible()
+  await expect(card.getByRole('button', { name: /Allow once/ })).toBeVisible()
+  await card.getByRole('button', { expanded: false }).click()
+  const activity = card.getByRole('list', { name: 'Codex activity' })
+  await expect(activity.locator('li')).toHaveCount(8)
+  await expect(activity).toHaveCSS('overflow-y', 'auto')
+  await shot('codex-long-approval-card')
+
+  await card.getByRole('button', { name: 'Open Work Room' }).click()
+  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+  await expect(room.getByLabel('Work Room live summary')).toContainText('Waiting for your approval')
+  await expect(room.getByRole('button', { name: /Allow once/ })).toBeVisible()
+  await expect(room.getByRole('list', { name: 'Codex Work Room activity' }).locator('li')).toHaveCount(8)
+  await shot('codex-long-approval-workroom')
+})
+
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
@@ -122,6 +148,7 @@ test.describe('phone', () => {
     await pane(page).getByRole('region', { name: 'Codex completed' }).getByRole('button', { name: 'Open Work Room' }).click()
     const room = page.getByRole('dialog', { name: 'Codex Work Room' })
     await expect(room).toBeVisible()
+    await room.getByRole('tab', { name: /Chat/ }).click()
     await expect(room.getByPlaceholder('Message Codex…')).toBeVisible()
 
     const heading = room.getByRole('heading', { name: 'Codex Work Room' })

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
+export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -300,7 +300,7 @@ export async function mockAgent(
 
       send(ws, { type: 'thinking', id: 't1', status: 'running' })
 
-      if (scenario === 'coding-agent' || scenario === 'coding-agent-completed' || scenario === 'coding-agent-failed') {
+      if (scenario === 'coding-agent' || scenario === 'coding-agent-completed' || scenario === 'coding-agent-failed' || scenario === 'coding-agent-long-approval') {
         codingAgentInputs += 1
         if (codingAgentInputs > 1) {
           send(ws, {
@@ -341,6 +341,45 @@ export async function mockAgent(
           providerDisplayName: 'Codex', taskSummary: 'Fix Windows tests',
           permissionMode: 'workspace_write', sessionId: 'codex-session-1', status: 'running',
         })
+        if (scenario === 'coding-agent-long-approval') {
+          const steps = [
+            ['Read', { path: 'dijkstra.py' }],
+            ['Bash', { command: 'python3 dijkstra.py --case 1' }],
+            ['Bash', { command: 'python3 dijkstra.py --case 2' }],
+            ['File change', { file_path: 'test_dijkstra.py' }],
+            ['Bash', { command: 'pytest -q' }],
+            ['Read', { path: 'test_dijkstra.py' }],
+            ['Bash', { command: 'python3 -m py_compile dijkstra.py' }],
+          ] as const
+          for (const [index, [name, args]] of steps.entries()) {
+            const toolId = `long-child-${index}`
+            send(ws, {
+              type: 'tool_call', tool_id: toolId, name, args, status: 'in_progress',
+              parentToolCallId: 'call-7', invocationId: 'codex:call-7',
+            })
+            send(ws, {
+              type: 'tool_result', tool_id: toolId, status: 'completed', result: 'Completed',
+              parentToolCallId: 'call-7', invocationId: 'codex:call-7',
+            })
+          }
+          send(ws, {
+            type: 'tool_call', tool_id: 'long-child-7', name: 'Bash',
+            args: { command: 'pytest -q' }, status: 'in_progress',
+            parentToolCallId: 'call-7', invocationId: 'codex:call-7',
+          })
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-7',
+            parentToolCallId: 'call-7', provider: 'codex',
+            providerDisplayName: 'Codex', status: 'awaiting_approval',
+          })
+          send(ws, {
+            type: 'approval_needed', id: 'approval-codex-long', tool: 'codex',
+            arguments: { action: 'Run pytest -q', cwd: '.workroom-e2e' },
+            provider: 'codex', invocationId: 'codex:call-7',
+            parentToolCallId: 'call-7', activityId: 'long-child-7',
+          })
+          return
+        }
         send(ws, {
           type: 'tool_call', tool_id: 'child-1', name: 'Bash',
           args: { command: 'pytest -q' }, status: 'in_progress',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.10",
+        "@connectonion/react": "0.4.2-alpha.11",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.10",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.10.tgz",
-      "integrity": "sha512-HKV8y7782oBZMP9h0u+jpoQvkLUNYIdYQeug8nyRhMT2RF9vZrpmFAxiVAbsPaWTL/Qh1rZJCyqHr5Vw/8q07Q==",
+      "version": "0.4.2-alpha.11",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.11.tgz",
+      "integrity": "sha512-CLNE7MBwfCggf3EcAjJU2kPgSi1XjsgfpT0cbR9bbaTVVChVTxvz93sHuRqpMigE+b0OArQJJ2MvTUzH8liWlw==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.10",
+    "@connectonion/react": "0.4.2-alpha.11",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## What changed
- promote task + current semantic activity to a durable parent Codex/Claude Code card
- keep raw commands and outputs behind per-step disclosure, with bounded independent scrolling
- make Activity the Work Room default and keep Chat / Files available
- attach a correlated native provider approval to its exact card and Work Room, never the generic outer tool
- pin `@connectonion/react` to public `0.4.2-alpha.11`

## Why
A real multi-step native Codex run could look like a one-line generic tool until it finished. Its nested approval could render outside the Work Room because the earlier React SDK discarded the provider correlation fields.

## Visual policy
When an adapter emits no genuine image artifact, the card renders a visibly labelled **live activity snapshot** rather than a fabricated screenshot. The newest semantic event is prominent; raw terminal content remains optional.

## Validation
- `npm test -- --run components/chat/messages/coding-agent-card.test.tsx components/chat/chat-messages.test.tsx components/chat/use-agent-sdk.test.ts` — 29 passed
- `npx tsc --noEmit`
- `npm run build`
- `npx playwright test e2e/coding-agent-card.spec.ts --reporter=line` — 8 passed against public `@connectonion/react@0.4.2-alpha.11`
- inspected desktop eight-step card/Work Room and phone screenshots under `/tmp/frontend-test-screenshots/`

Closes #180. Depends on openonion/connectonion#1102 and openonion/connectonion-react#75.