### PR TITLE
fix(workroom): keep provider prompts out of compact cards

### DIFF
--- a/components/chat/messages/coding-agent-activity.ts
+++ b/components/chat/messages/coding-agent-activity.ts
@@ -16,6 +16,21 @@ export function latestProviderActivity(
   return allProviderActivities(invocation, continuations).at(-1)
 }
 
+/**
+ * Provider adapters sometimes send their entire internal instruction as
+ * `taskSummary`. That belongs in the explicit Work Room chat, never in the
+ * compact conversation card. Keep genuinely short task names useful while
+ * falling back to a stable, provider-specific heading for everything else.
+ */
+export function compactProviderTaskHeading(
+  taskSummary: string | undefined,
+  providerDisplayName: string,
+) {
+  const summary = taskSummary?.replace(/\s+/g, ' ').trim()
+  if (!summary || summary.length > 80) return `${providerDisplayName} work room`
+  return summary
+}
+
 /** A short human description; raw commands and outputs stay behind disclosure. */
 export function activitySummary(activity: ProviderActivity | undefined, running: boolean) {
   if (!activity) return running ? 'Preparing the workroom' : 'No provider activity recorded'

--- a/components/chat/messages/coding-agent-activity.ts
+++ b/components/chat/messages/coding-agent-activity.ts
@@ -31,6 +31,18 @@ export function compactProviderTaskHeading(
   return summary
 }
 
+/** Keep a terminal provider state from looking like a live operation. */
+export function providerSnapshotSummary(
+  status: ProviderInvocationUI['status'],
+  activity: ProviderActivity | undefined,
+) {
+  if (status === 'awaiting_approval') return 'Waiting for your approval'
+  if (status === 'completed') return 'Completed the work'
+  if (status === 'failed') return 'Work stopped before completion'
+  if (status === 'cancelled') return 'Work stopped'
+  return activitySummary(activity, true)
+}
+
 /** A short human description; raw commands and outputs stay behind disclosure. */
 export function activitySummary(activity: ProviderActivity | undefined, running: boolean) {
   if (!activity) return running ? 'Preparing the workroom' : 'No provider activity recorded'

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -48,6 +48,22 @@ describe('CodingAgentCard', () => {
     expect(props.onStop).toHaveBeenCalledOnce()
   })
 
+  it('keeps a long provider instruction out of the collapsed card and default Work Room view', () => {
+    const providerInstruction = 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
+    const { element } = render({ invocation: { ...invocation, taskSummary: providerInstruction } })
+
+    expect(element.textContent).toContain('Codex work room')
+    expect(element.textContent).not.toContain(providerInstruction)
+    expect(element.querySelector('.line-clamp-2')).not.toBeNull()
+
+    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
+    const workroom = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Codex Work Room"]')!
+    expect(workroom.textContent).not.toContain(providerInstruction)
+
+    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
+    expect(workroom.textContent).toContain(providerInstruction)
+  })
+
   it('shows semantic nested activity inline and keeps raw details behind disclosure', () => {
     const { element } = render({ expanded: true })
     expect(element.textContent).toContain('Running tests')

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -81,6 +81,20 @@ describe('CodingAgentCard', () => {
     expect(element.querySelector('[aria-label="Stop Codex"]')).toBeNull()
   })
 
+  it('does not present a failed provider as if it were still working', () => {
+    const { element } = render({
+      invocation: {
+        ...invocation,
+        status: 'failed',
+        activities: [{ ...invocation.activities[0], status: 'running' }],
+      },
+    })
+
+    const snapshot = element.querySelector('[aria-label="Live activity snapshot"]')!
+    expect(snapshot.textContent).toContain('Work stopped before completion')
+    expect(snapshot.textContent).not.toContain('Working on the next step')
+  })
+
   it('opens an interactive Work Room and targets messages to Codex', () => {
     const onMessageProvider = vi.fn()
     const { element } = render({ onMessageProvider })

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -14,6 +14,7 @@ import {
   activityRawDetails,
   activitySummary,
   allProviderActivities,
+  compactProviderTaskHeading,
   latestProviderActivity,
 } from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
@@ -52,7 +53,11 @@ export function CodingAgentCard({
   const [workroomOpen, setWorkroomOpen] = useState(false)
   const current = continuations.at(-1) ?? invocation
   const running = !terminal.has(current.status)
-  const summary = invocation.taskSummary || current.taskSummary || 'Coding task'
+  const summary = compactProviderTaskHeading(
+    invocation.taskSummary || current.taskSummary,
+    invocation.providerDisplayName,
+  )
+  const genericSummary = summary === `${invocation.providerDisplayName} work room`
   const status = current.status.replace('_', ' ')
   const activities = allProviderActivities(invocation, continuations)
   const latest = latestProviderActivity(invocation, continuations)
@@ -76,8 +81,8 @@ export function CodingAgentCard({
           >
             {expanded ? <HiOutlineChevronDown className="mt-0.5 h-4 w-4 shrink-0" /> : <HiOutlineChevronRight className="mt-0.5 h-4 w-4 shrink-0" />}
             <span className="min-w-0">
-              <span className="block text-sm font-semibold text-neutral-950">{summary}</span>
-              <span className="mt-0.5 block text-xs text-neutral-500">{invocation.providerDisplayName} work room</span>
+              <span className="block line-clamp-2 text-sm font-semibold text-neutral-950">{summary}</span>
+              <span className="mt-0.5 block text-xs text-neutral-500">{genericSummary ? 'Live activity' : `${invocation.providerDisplayName} work room`}</span>
             </span>
           </button>
           {running && onStop && (

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -16,6 +16,7 @@ import {
   allProviderActivities,
   compactProviderTaskHeading,
   latestProviderActivity,
+  providerSnapshotSummary,
 } from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
 import { CodingAgentWorkroom } from './coding-agent-workroom'
@@ -61,9 +62,7 @@ export function CodingAgentCard({
   const status = current.status.replace('_', ' ')
   const activities = allProviderActivities(invocation, continuations)
   const latest = latestProviderActivity(invocation, continuations)
-  const latestSummary = current.status === 'awaiting_approval'
-    ? 'Waiting for your approval'
-    : activitySummary(latest, running)
+  const latestSummary = providerSnapshotSummary(current.status, latest)
 
   return (
     <section

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -18,6 +18,7 @@ import {
   activityRawDetails,
   activitySummary,
   allProviderActivities,
+  compactProviderTaskHeading,
   latestProviderActivity,
 } from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
@@ -45,6 +46,11 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
   const [queued, setQueued] = useState<QueuedMessage[]>([])
   const current = continuations.at(-1) ?? invocation
   const running = !['completed', 'failed', 'cancelled'].includes(current.status)
+  const taskHeading = compactProviderTaskHeading(
+    invocation.taskSummary || current.taskSummary,
+    invocation.providerDisplayName,
+  )
+  const genericTaskHeading = taskHeading === `${invocation.providerDisplayName} work room`
   const activities = useMemo(
     () => allProviderActivities(invocation, continuations),
     [invocation, continuations],
@@ -88,7 +94,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
             <ToolStatus status={current.status === 'failed' ? 'error' : current.status === 'completed' ? 'done' : 'running'} />
             <h1 className="whitespace-nowrap text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
           </div>
-          <p className="truncate text-xs text-neutral-500">{invocation.taskSummary || current.taskSummary || 'Coding task'}</p>
+          <p className="truncate text-xs text-neutral-500">{genericTaskHeading ? 'Live activity and approvals' : taskHeading}</p>
         </div>
         <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{current.status.replace('_', ' ')}</span>
         {running && onStop && (

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -20,6 +20,7 @@ import {
   allProviderActivities,
   compactProviderTaskHeading,
   latestProviderActivity,
+  providerSnapshotSummary,
 } from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
 
@@ -137,7 +138,7 @@ export function CodingAgentWorkroom({ invocation, continuations = [], onClose, o
               <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-neutral-900 text-white"><HiOutlineEye className="h-5 w-5" /></span>
               <div className="min-w-0 flex-1">
                 <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Live work</p>
-                <p className="mt-1 text-sm font-semibold text-neutral-950">{current.status === 'awaiting_approval' ? 'Waiting for your approval' : activitySummary(latest, running)}</p>
+                <p className="mt-1 text-sm font-semibold text-neutral-950">{providerSnapshotSummary(current.status, latest)}</p>
                 <p className="mt-1 text-xs text-neutral-500">{activities.length} recorded step{activities.length === 1 ? '' : 's'} · raw commands and outputs are available only when you expand a step.</p>
               </div>
             </div>

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -100,6 +100,7 @@ test('failed Codex card exposes the error and no Stop action', async ({ page, sh
   await openCodingRun(page, 'coding-agent-failed', 'failed')
 
   const card = pane(page).getByRole('region', { name: 'Codex failed' })
+  await expect(card.getByLabel('Live activity snapshot')).toContainText('Work stopped before completion')
   await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
   await card.getByRole('button', { expanded: false }).click()
   await expect(card).toContainText('Codex exited before applying the patch.')

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -110,7 +110,11 @@ test('long native work keeps one actionable card, bounded history, and the appro
   await openCodingRun(page, 'coding-agent-long-approval', 'awaiting approval')
 
   const card = pane(page).getByRole('region', { name: 'Codex awaiting approval' })
+  const providerInstruction = 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
   await expect(card).toContainText('Waiting for your approval')
+  await expect(card).toContainText('Codex work room')
+  await expect(card).not.toContainText(providerInstruction)
+  await expect(card.locator('.line-clamp-2')).toHaveCount(1)
   await expect(card.getByLabel('Live activity snapshot')).toBeVisible()
   await expect(card.getByRole('button', { name: /Allow once/ })).toBeVisible()
   await card.getByRole('button', { expanded: false }).click()
@@ -122,8 +126,11 @@ test('long native work keeps one actionable card, bounded history, and the appro
   await card.getByRole('button', { name: 'Open Work Room' }).click()
   const room = page.getByRole('dialog', { name: 'Codex Work Room' })
   await expect(room.getByLabel('Work Room live summary')).toContainText('Waiting for your approval')
+  await expect(room).not.toContainText(providerInstruction)
   await expect(room.getByRole('button', { name: /Allow once/ })).toBeVisible()
   await expect(room.getByRole('list', { name: 'Codex Work Room activity' }).locator('li')).toHaveCount(8)
+  await room.getByRole('tab', { name: /Chat/ }).click()
+  await expect(room).toContainText(providerInstruction)
   await shot('codex-long-approval-workroom')
 })
 

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -331,14 +331,17 @@ export async function mockAgent(
           })
           return
         }
+        const taskSummary = scenario === 'coding-agent-long-approval'
+          ? 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
+          : 'Fix Windows tests'
         send(ws, {
           type: 'tool_call', id: 'call-7', name: 'codex',
-          args: { prompt: 'Fix Windows tests' }, status: 'running',
+          args: { prompt: taskSummary }, status: 'running',
         })
         send(ws, {
           type: 'provider_invocation', invocationId: 'codex:call-7',
           parentToolCallId: 'call-7', provider: 'codex',
-          providerDisplayName: 'Codex', taskSummary: 'Fix Windows tests',
+          providerDisplayName: 'Codex', taskSummary,
           permissionMode: 'workspace_write', sessionId: 'codex-session-1', status: 'running',
         })
         if (scenario === 'coding-agent-long-approval') {


### PR DESCRIPTION
Closes #184.\n\nA provider adapter may send its full internal instruction as taskSummary. This keeps genuinely short names useful, but replaces long task summaries with a compact provider-specific Work Room heading in the conversation card and default Activity view. The original prompt remains in the explicit Work Room Chat tab.\n\nVerification:\n- coding-agent-card Vitest: 11 passing\n- targeted TypeScript check\n- targeted ESLint\n- coding-agent-card Playwright desktop and phone coverage\n\nThe long eight-step approval fixture now uses a deliberately long prompt and asserts it is absent from the compact card/default Work Room and present only in Chat.