### PR TITLE
feat: ship 1.6.11 Control Center modes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Change
+
+<!-- What product outcome does this PR deliver? -->
+
+## Required complete E2E evidence
+
+Every oo-chat PR must complete the single continuous `e2e/pr-evidence.spec.ts`
+journey and attach its final result screenshot. The journey must prove:
+
+- [ ] an invite code was entered and accepted;
+- [ ] the Agent connected and received a prompt or skill request;
+- [ ] Safe/Default, Plan, and bounded Full access mode transitions were exercised;
+- [ ] the Agent updated Control Center and the updated state rendered;
+- [ ] I inspected `pr-release-evidence-invite-prompt-modes-and-control-center--complete-flow.png` in the CI `pr-e2e-evidence` artifact.
+
+Evidence run: <!-- paste the GitHub Actions run URL -->
+
+Do not merge from unit tests or prose alone. If the screenshot is missing,
+cropped, unreadable, or contradicts the assertions, the PR is not review-ready.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,9 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: npx playwright test
 
+      - name: Require the complete PR evidence screenshot
+        run: test -s e2e-screenshots/pr-release-evidence-invite-prompt-modes-and-control-center--complete-flow.png
+
       # Kept on a green run too. A passing suite cannot tell you a control turned
       # white on white — that is what these are for.
       - name: Upload screenshots
@@ -71,6 +74,15 @@ jobs:
           name: screenshots
           path: e2e-screenshots/
           retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload required PR E2E evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-e2e-evidence
+          path: e2e-screenshots/pr-release-evidence-invite-prompt-modes-and-control-center--*.png
+          retention-days: 30
           if-no-files-found: error
 
       - name: Upload the full report
@@ -97,10 +109,11 @@ jobs:
               '<!-- e2e-report -->',
               `### End-to-end: ${ok ? 'passed' : '**failed**'}`,
               '',
-              'Land on an agent, send a message, get a reply — plus tool cards, an approval that',
-              'parks the run, an agent error, and a 375px phone.',
+              'Required continuous journey: invite code → connected prompt/skill → Safe/Default,',
+              'Plan and bounded Full access → updated Control Center.',
               '',
               `**Screenshots:** [\`screenshots\` artifact](${run}#artifacts) — one frame per test, green run included.`,
+              `**Required review frame:** [\`pr-e2e-evidence\` artifact](${run}#artifacts) → \`...--complete-flow.png\`.`,
               ok ? '' : '**Trace and video:** `playwright-report` on the same run.',
               '',
               'Look at them before merging.',

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -141,7 +141,8 @@ export default function ChatSessionPage() {
     sessionState,
     collaborationMode,
     permissionProfile,
-    availablePermissionProfiles,
+    executionProfile,
+    availableExecutionProfiles,
     permissionProfileChangePending,
     permissionProfileChangeError,
     permissionProfileRecoveryAction,
@@ -153,7 +154,7 @@ export default function ChatSessionPage() {
     submitOnboard,
     respondToPlanReview,
     setCollaborationMode,
-    setPermissionProfile,
+    setExecutionProfile,
     retryPermissionProfileChange,
     reconnect,
     connect,
@@ -330,7 +331,7 @@ export default function ChatSessionPage() {
 
         {/* Full access mode banner */}
         {isFullAccessActive && (
-          <FullAccessModeBanner turnsRemaining={fullAccessTurnsRemaining} onExit={() => void setPermissionProfile(':read-only')} />
+          <FullAccessModeBanner turnsRemaining={fullAccessTurnsRemaining} onExit={() => void setExecutionProfile('safe')} />
         )}
 
         <CurrentPlanPanel entries={currentPlan} />
@@ -358,10 +359,10 @@ export default function ChatSessionPage() {
           statusBar={
             <ModeStatusBar
               collaborationMode={collaborationMode}
-              permissionProfile={permissionProfile}
-              availablePermissionProfiles={availablePermissionProfiles}
+              executionProfile={executionProfile}
+              availableExecutionProfiles={availableExecutionProfiles}
               onCollaborationModeChange={setCollaborationMode}
-              onPermissionProfileChange={(profile) => void setPermissionProfile(profile)}
+              onExecutionProfileChange={(profile) => void setExecutionProfile(profile)}
               disabled={isLoading}
               permissionProfileChangePending={permissionProfileChangePending}
               permissionProfileChangeError={permissionProfileChangeError}

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -99,13 +99,13 @@ export default function AgentLandingPage() {
     submitOnboard,
     pendingOnboard,
     collaborationMode,
-    permissionProfile,
-    availablePermissionProfiles,
+    executionProfile,
+    availableExecutionProfiles,
     permissionProfileChangePending,
     permissionProfileChangeError,
     permissionProfileRecoveryAction,
     setCollaborationMode,
-    setPermissionProfile,
+    setExecutionProfile,
     retryPermissionProfileChange,
   } = useAgentSDK({
     agentAddress: address, sessionId: draftSessionId, onError: onGateError,
@@ -413,10 +413,10 @@ export default function AgentLandingPage() {
                 statusBar={
                   <ModeStatusBar
                     collaborationMode={collaborationMode}
-                    permissionProfile={permissionProfile}
-                    availablePermissionProfiles={availablePermissionProfiles}
+                    executionProfile={executionProfile}
+                    availableExecutionProfiles={availableExecutionProfiles}
                     onCollaborationModeChange={setCollaborationMode}
-                    onPermissionProfileChange={(profile) => void setPermissionProfile(profile)}
+                    onExecutionProfileChange={(profile) => void setExecutionProfile(profile)}
                     permissionProfileChangePending={permissionProfileChangePending}
                     permissionProfileChangeError={permissionProfileChangeError}
                     permissionProfileRecoveryAction={permissionProfileRecoveryAction}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   HiOutlineRefresh,
@@ -24,6 +24,7 @@ import { useIdentity } from '@/hooks/use-identity'
 import { useAgentInfo, shortAddress, isAgentAddress, ADDRESS_ERROR } from '@/hooks/use-agent-info'
 import { TopUp } from '@/components/agent-address'
 import { ConfirmDialog } from '@/components/confirm-dialog'
+import { orderAgents } from '@/lib/agent-order'
 
 export default function SettingsPage() {
   const router = useRouter()
@@ -36,6 +37,20 @@ export default function SettingsPage() {
   } = useChatStore()
 
   const infoMap = useAgentInfo(agents)
+  const recentActivity = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const conversation of conversations) {
+      result[conversation.agentAddress] = Math.max(
+        result[conversation.agentAddress] ?? 0,
+        new Date(conversation.createdAt).getTime(),
+      )
+    }
+    return result
+  }, [conversations])
+  const orderedAgents = useMemo(
+    () => orderAgents(agents, infoMap, null, recentActivity),
+    [agents, infoMap, recentActivity],
+  )
 
   const {
     identity,
@@ -269,7 +284,7 @@ export default function SettingsPage() {
               {/* Agent list */}
               {agents.length > 0 ? (
                 <div className="divide-y divide-neutral-100">
-                  {agents.map(address => {
+                  {orderedAgents.map(({ address, presence }) => {
                     const info = infoMap[address]
                     return (
                       // Stacked on a phone. In one row the fixed parts — 64px of
@@ -281,8 +296,8 @@ export default function SettingsPage() {
                         <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
                         {/* Online indicator */}
                         <div className="shrink-0">
-                          {info?.online !== undefined ? (
-                            info.online
+                          {presence !== 'unknown' ? (
+                            presence === 'online'
                               ? <HiOutlineStatusOnline className="w-5 h-5 text-brand-500" />
                               : <HiOutlineStatusOffline className="w-5 h-5 text-neutral-300" />
                           ) : (
@@ -303,6 +318,9 @@ export default function SettingsPage() {
                                 {info.trust}
                               </span>
                             )}
+                            <span className="text-[11px] font-medium capitalize text-neutral-500">
+                              {presence}
+                            </span>
                           </div>
                           <div className="flex items-center gap-2 mt-1">
                             <span className="text-xs font-mono text-neutral-500 truncate">

--- a/components/chat/mode-indicator.tsx
+++ b/components/chat/mode-indicator.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import { useCallback, useEffect } from 'react'
-import type { CollaborationMode, PermissionProfile } from './types'
+import { useCallback, useEffect, useState } from 'react'
+import type { CollaborationMode, ExecutionProfile } from '@connectonion/react'
 import {
-  selectablePermissionProfiles,
+  selectableExecutionProfiles,
   type HostPermissionOption,
 } from './mode-policy'
 
 interface ModeStatusBarProps {
   collaborationMode: CollaborationMode
-  permissionProfile: PermissionProfile
+  executionProfile: ExecutionProfile
   onCollaborationModeChange: (mode: CollaborationMode) => void
-  onPermissionProfileChange: (profile: PermissionProfile) => void
-  availablePermissionProfiles?: ReadonlyArray<HostPermissionOption>
+  onExecutionProfileChange: (profile: ExecutionProfile) => void
+  availableExecutionProfiles?: ReadonlyArray<HostPermissionOption>
   disabled?: boolean
   permissionProfileChangePending?: boolean
   permissionProfileChangeError?: string | null
@@ -20,33 +20,20 @@ interface ModeStatusBarProps {
   onPermissionProfileRetry?: () => void
   fullAccessTurnsRemaining?: number | null
   sessionState?: 'idle' | 'connected' | 'active' | 'disconnected' | 'reconnecting'
-  isLoading?: boolean
   connectionError?: string | null
   onReconnect?: () => void
 }
 
-const COLLABORATION_MODES: CollaborationMode[] = ['default', 'plan']
-const PERMISSION_PROFILES: PermissionProfile[] = [
-  ':read-only',
-  ':workspace',
-  ':danger-full-access',
-]
-
-const COLLABORATION_LABELS: Record<CollaborationMode, string> = {
+const LABELS: Record<ExecutionProfile, string> = {
+  safe: 'Safe',
   default: 'Default',
-  plan: 'Plan',
+  full_access: 'Full access',
 }
 
-const PERMISSION_LABELS: Record<PermissionProfile, string> = {
-  ':read-only': 'Read only',
-  ':workspace': 'Auto',
-  ':danger-full-access': 'Full access',
-}
-
-const PERMISSION_DESCRIPTIONS: Record<PermissionProfile, string> = {
-  ':read-only': 'Read freely; ask before edits and commands',
-  ':workspace': 'Edit the workspace automatically; broader actions still ask',
-  ':danger-full-access': 'Skip approval prompts within the configured turn limit',
+const DESCRIPTIONS: Record<ExecutionProfile, string> = {
+  safe: 'Read normally; unresolved effects ask for approval',
+  default: 'Automatically allow low-risk workspace work; risky or unresolved work asks or is denied',
+  full_access: 'Bypass per-action approval only within the Host-defined bound',
 }
 
 function isTypingTarget(el: Element | null) {
@@ -55,13 +42,13 @@ function isTypingTarget(el: Element | null) {
   return tag === 'TEXTAREA' || tag === 'INPUT' || (el as HTMLElement).isContentEditable
 }
 
-/** Codex-style status bar: collaboration intent and permissions are independent. */
+/** One product execution control; Plan remains an independent workflow action. */
 export function ModeStatusBar({
   collaborationMode,
-  permissionProfile,
+  executionProfile,
   onCollaborationModeChange,
-  onPermissionProfileChange,
-  availablePermissionProfiles = [],
+  onExecutionProfileChange,
+  availableExecutionProfiles = [],
   disabled,
   permissionProfileChangePending,
   permissionProfileChangeError,
@@ -72,13 +59,11 @@ export function ModeStatusBar({
   onReconnect,
   fullAccessTurnsRemaining,
 }: ModeStatusBarProps) {
+  const [confirmFullAccess, setConfirmFullAccess] = useState(false)
   const controlsDisabled = disabled || permissionProfileChangePending
-  const cycleCollaborationMode = useCallback(() => {
+  const togglePlan = useCallback(() => {
     if (controlsDisabled) return
-    const currentIndex = COLLABORATION_MODES.indexOf(collaborationMode)
-    onCollaborationModeChange(
-      COLLABORATION_MODES[(currentIndex + 1) % COLLABORATION_MODES.length],
-    )
+    onCollaborationModeChange(collaborationMode === 'plan' ? 'default' : 'plan')
   }, [collaborationMode, controlsDisabled, onCollaborationModeChange])
 
   useEffect(() => {
@@ -86,16 +71,15 @@ export function ModeStatusBar({
       if (isTypingTarget(document.activeElement)) return
       if (event.shiftKey && event.key === 'Tab') {
         event.preventDefault()
-        cycleCollaborationMode()
+        togglePlan()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [cycleCollaborationMode])
+  }, [togglePlan])
 
-  const permissionChoices = selectablePermissionProfiles(
-    availablePermissionProfiles,
-  ).filter((profile) => PERMISSION_PROFILES.includes(profile))
+  const choices = selectableExecutionProfiles(availableExecutionProfiles)
+  const fullOption = availableExecutionProfiles.find((option) => option.profile === 'full_access')
   const showConnection = sessionState === 'active'
     || sessionState === 'connected'
     || sessionState === 'disconnected'
@@ -104,7 +88,7 @@ export function ModeStatusBar({
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-2">
-      <div className="flex items-center gap-1.5">
+      <div className="flex min-h-11 items-center gap-1.5">
         {permissionProfileChangeError ? (
           <div className="flex items-center gap-1.5">
             <span className="text-[11px] text-red-600">{permissionProfileChangeError}</span>
@@ -115,15 +99,10 @@ export function ModeStatusBar({
             )}
           </div>
         ) : permissionProfileChangePending ? (
-          <span role="status" className="text-[11px] text-neutral-500">
-            changing permissions…
-          </span>
+          <span role="status" className="text-[11px] text-neutral-500">changing execution mode…</span>
         ) : showConnection && (
           connectionError ? (
-            <div className="flex items-center gap-1.5">
-              <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
-              <span className="text-[11px] text-red-600">error</span>
-            </div>
+            <div className="flex items-center gap-1.5"><span className="h-1.5 w-1.5 rounded-full bg-red-500" /><span className="text-[11px] text-red-600">error</span></div>
           ) : sessionState === 'disconnected' ? (
             <div className="flex items-center gap-1.5">
               <span className="h-1.5 w-1.5 rounded-full bg-neutral-400" />
@@ -139,54 +118,60 @@ export function ModeStatusBar({
       </div>
 
       <div className="ml-auto flex flex-wrap items-center justify-end gap-1.5">
-        <div className="inline-flex gap-0.5 rounded-md border border-neutral-200 bg-neutral-100 p-0.5" role="group" aria-label="Collaboration mode">
-          {COLLABORATION_MODES.map((mode) => (
-            <button
-              key={mode}
-              onClick={() => onCollaborationModeChange(mode)}
-              disabled={controlsDisabled}
-              className={`min-h-11 min-w-11 rounded px-2.5 py-1 text-[11px] transition-colors disabled:opacity-50 ${
-                mode === collaborationMode
-                  ? 'bg-neutral-900 font-medium text-white'
-                  : 'text-neutral-500 hover:text-neutral-700'
-              }`}
-              title={`${COLLABORATION_LABELS[mode]} collaboration mode · ⇧Tab to switch`}
-              aria-pressed={mode === collaborationMode}
-            >
-              {COLLABORATION_LABELS[mode]}
-            </button>
-          ))}
-        </div>
+        <button
+          onClick={togglePlan}
+          disabled={controlsDisabled}
+          aria-pressed={collaborationMode === 'plan'}
+          title="Plan the work without changing Host permissions · ⇧Tab to switch"
+          className="min-h-11 rounded-md border border-neutral-200 px-2.5 text-[11px] text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 aria-pressed:bg-neutral-900 aria-pressed:text-white"
+        >
+          {collaborationMode === 'plan' ? 'Exit plan' : 'Plan'}
+        </button>
 
-        <div className="inline-flex gap-0.5 rounded-md border border-neutral-200 bg-white p-0.5" role="group" aria-label="Permission profile">
-          {permissionChoices.map((profile) => {
-            const fullAccess = profile === ':danger-full-access'
-            const active = profile === permissionProfile
-            return (
-              <button
-                key={profile}
-                onClick={() => onPermissionProfileChange(profile)}
-                disabled={controlsDisabled}
-                className={`min-h-11 min-w-11 rounded px-2.5 py-1 text-[11px] transition-colors disabled:opacity-50 ${
-                  active
-                    ? fullAccess
-                      ? 'bg-red-50 font-medium text-red-700'
-                      : 'bg-neutral-200 font-medium text-neutral-900'
-                    : fullAccess
-                      ? 'text-red-600 hover:bg-red-50'
-                      : 'text-neutral-500 hover:bg-neutral-100'
-                }`}
-                title={PERMISSION_DESCRIPTIONS[profile]}
-                aria-pressed={active}
-              >
-                {PERMISSION_LABELS[profile]}
-                {active && fullAccess && typeof fullAccessTurnsRemaining === 'number'
-                  ? ` · ${fullAccessTurnsRemaining} left`
-                  : ''}
-              </button>
-            )
-          })}
-        </div>
+        {confirmFullAccess ? (
+          <div role="group" aria-label="Confirm Full access" className="flex min-h-11 flex-wrap items-center gap-1 rounded-md border border-red-300 bg-red-50 p-1 text-[11px] text-red-800">
+            <span className="px-1">Host limit: {fullOption?.bound || 'configured by Host'}</span>
+            <button
+              className="min-h-9 rounded bg-red-700 px-2.5 font-medium text-white"
+              onClick={() => { setConfirmFullAccess(false); onExecutionProfileChange('full_access') }}
+            >Enable</button>
+            <button className="min-h-9 rounded px-2.5" onClick={() => setConfirmFullAccess(false)}>Cancel</button>
+          </div>
+        ) : (
+          <div className="inline-flex gap-0.5 rounded-md border border-neutral-200 bg-white p-0.5" role="group" aria-label="Execution mode">
+            {choices.map((profile) => {
+              const fullAccess = profile === 'full_access'
+              const active = profile === executionProfile
+              const recommended = profile === 'default'
+              return (
+                <button
+                  key={profile}
+                  onClick={() => fullAccess && !active
+                    ? setConfirmFullAccess(true)
+                    : onExecutionProfileChange(profile)}
+                  disabled={controlsDisabled}
+                  className={`min-h-11 min-w-11 rounded px-2.5 py-1 text-[11px] transition-colors disabled:opacity-50 ${
+                    active
+                      ? fullAccess
+                        ? 'bg-red-100 font-semibold text-red-800 ring-1 ring-red-300'
+                        : 'bg-neutral-200 font-semibold text-neutral-900'
+                      : fullAccess
+                        ? 'text-red-700 hover:bg-red-50'
+                        : 'text-neutral-600 hover:bg-neutral-100'
+                  }`}
+                  title={`${DESCRIPTIONS[profile]}${recommended ? ' · recommended' : ''}`}
+                  aria-label={`${LABELS[profile]}${recommended ? ', recommended' : ''}${active ? ', current mode' : ''}`}
+                  aria-pressed={active}
+                >
+                  {LABELS[profile]}
+                  {active && fullAccess && typeof fullAccessTurnsRemaining === 'number'
+                    ? ` · ${fullAccessTurnsRemaining} left`
+                    : ''}
+                </button>
+              )
+            })}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/components/chat/mode-policy.test.ts
+++ b/components/chat/mode-policy.test.ts
@@ -3,10 +3,16 @@ import type { HostPermissionOption } from './mode-policy'
 import {
   COLLABORATION_MODES,
   permissionProfileRecoveryAction,
+  selectableExecutionProfiles,
   selectablePermissionProfiles,
 } from './mode-policy'
 
-const profile = (id: HostPermissionOption['id']): HostPermissionOption => ({ id, name: id })
+const profile = (id: HostPermissionOption['id']): HostPermissionOption => ({
+  id,
+  wireId: id,
+  profile: id === ':read-only' ? 'safe' : id === ':workspace' ? 'default' : 'full_access',
+  name: id,
+})
 
 describe('O Chat Codex-style mode policy', () => {
   test('keeps collaboration independent from permission authority', () => {
@@ -21,6 +27,14 @@ describe('O Chat Codex-style mode policy', () => {
       profile(':workspace'),
       profile(':danger-full-access'),
     ])).toEqual([':read-only', ':workspace', ':danger-full-access'])
+  })
+
+  test('exposes the product vocabulary without reparsing Host wire aliases', () => {
+    expect(selectableExecutionProfiles([
+      profile(':read-only'),
+      profile(':workspace'),
+      profile(':danger-full-access'),
+    ])).toEqual(['safe', 'default', 'full_access'])
   })
 
   test.each([

--- a/components/chat/mode-policy.ts
+++ b/components/chat/mode-policy.ts
@@ -1,5 +1,6 @@
 import type {
   CollaborationMode,
+  ExecutionProfile,
   HostSessionModeState,
   PermissionProfile,
 } from '@connectonion/react'
@@ -23,6 +24,22 @@ export function selectablePermissionProfiles(
       case ':workspace':
       case ':danger-full-access':
         return [profile.id]
+      default:
+        return []
+    }
+  })
+}
+
+/** Product choices are already normalized by React from authenticated Host state. */
+export function selectableExecutionProfiles(
+  availableProfiles: ReadonlyArray<HostPermissionOption>,
+): ExecutionProfile[] {
+  return availableProfiles.flatMap((profile) => {
+    switch (profile.profile) {
+      case 'safe':
+      case 'default':
+      case 'full_access':
+        return [profile.profile]
       default:
         return []
     }

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -7,6 +7,7 @@ import {
   type ChatItem,
   type CollaborationMode,
   type ConnectionState,
+  type ExecutionProfile,
   type HostSessionModeState,
   type OutgoingMessage,
   type PermissionProfile,
@@ -122,8 +123,11 @@ interface UseAgentSDKReturn {
   currentSession: CurrentSession | null
   collaborationMode: CollaborationMode
   permissionProfile: PermissionProfile
+  executionProfile: ExecutionProfile
   /** Exact permission profiles advertised through React. */
   availablePermissionProfiles: ReadonlyArray<HostSessionModeState['availableModes'][number]>
+  availableExecutionProfiles: ReadonlyArray<HostSessionModeState['availableModes'][number]>
+  approvalPolicy: HostSessionModeState['policy']
   /** True until React receives the owned Host acknowledgement. */
   permissionProfileChangePending: boolean
   /** Last permission transaction failure; authoritative profile is unchanged. */
@@ -147,6 +151,7 @@ interface UseAgentSDKReturn {
   submitOnboard: (options: { inviteCode?: string; payment?: number }) => void
   setCollaborationMode: (mode: CollaborationMode) => void
   setPermissionProfile: (profile: PermissionProfile) => Promise<void>
+  setExecutionProfile: (profile: ExecutionProfile) => Promise<void>
   retryPermissionProfileChange: () => void
   /** Check server session status via WebSocket (checks active registry) */
   checkSessionStatus: (sessionId: string) => Promise<string>
@@ -326,7 +331,10 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     checkSessionStatus,
     collaborationMode: sdkCollaborationMode,
     permissionProfile,
+    executionProfile,
     availablePermissionProfiles = [],
+    availableExecutionProfiles = [],
+    approvalPolicy = null,
     permissionProfileChangePending: sdkPermissionProfileChangePending = false,
     fullAccessTurns,
     fullAccessTurnsUsed,
@@ -336,6 +344,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     signOnboard,
     setCollaborationMode: setSDKCollaborationMode,
     setPermissionProfile: setSDKPermissionProfile,
+    setExecutionProfile: setSDKExecutionProfile,
     reconnect: sdkReconnect,
     dashboardHtml,
     profile,
@@ -351,6 +360,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
   const [permissionProfileChangeError, setPermissionProfileChangeError] = useState<string | null>(null)
   const [permissionProfileRecovery, setPermissionProfileRecovery] = useState<PermissionProfileRecoveryAction | null>(null)
   const lastPermissionRequest = useRef<PermissionProfile | null>(null)
+  const lastExecutionRequest = useRef<ExecutionProfile | null>(null)
   const permissionProfileRequestInFlight = useRef(false)
   const ownedPermissionProfileErrors = useRef(new Set<string>())
   const permissionProfileChangePending = sdkPermissionProfileChangePending || localPermissionProfilePending
@@ -519,6 +529,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     if (permissionProfileRequestInFlight.current) return
     permissionProfileRequestInFlight.current = true
     lastPermissionRequest.current = newProfile
+    lastExecutionRequest.current = null
     setLocalPermissionProfilePending(true)
     setPermissionProfileChangeError(null)
     setPermissionProfileRecovery(null)
@@ -537,6 +548,27 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     }
   }, [permissionProfile, setSDKPermissionProfile])
 
+  const setExecutionProfile = useCallback(async (newProfile: ExecutionProfile) => {
+    if (permissionProfileRequestInFlight.current) return
+    permissionProfileRequestInFlight.current = true
+    lastExecutionRequest.current = newProfile
+    lastPermissionRequest.current = null
+    setLocalPermissionProfilePending(true)
+    setPermissionProfileChangeError(null)
+    setPermissionProfileRecovery(null)
+    try {
+      if (newProfile !== executionProfile) await setSDKExecutionProfile(newProfile)
+    } catch (caught) {
+      const profileError = caught instanceof Error ? caught : new Error(String(caught))
+      ownedPermissionProfileErrors.current.add(profileError.message)
+      setPermissionProfileChangeError(profileError.message || 'Unable to change execution mode')
+      setPermissionProfileRecovery(permissionProfileRecoveryAction(profileError))
+    } finally {
+      permissionProfileRequestInFlight.current = false
+      setLocalPermissionProfilePending(false)
+    }
+  }, [executionProfile, setSDKExecutionProfile])
+
   const retryPermissionProfileChange = useCallback(() => {
     if (permissionProfileRecovery === 'reconnect') {
       setPermissionProfileChangeError(null)
@@ -546,8 +578,10 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     }
     if (lastPermissionRequest.current) {
       void setPermissionProfile(lastPermissionRequest.current)
+    } else if (lastExecutionRequest.current) {
+      void setExecutionProfile(lastExecutionRequest.current)
     }
-  }, [permissionProfileRecovery, sdkReconnect, setPermissionProfile])
+  }, [permissionProfileRecovery, sdkReconnect, setExecutionProfile, setPermissionProfile])
 
   // Clear/reset
   const clear = useCallback(() => {
@@ -577,7 +611,10 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     currentSession,
     collaborationMode,
     permissionProfile,
+    executionProfile,
     availablePermissionProfiles,
+    availableExecutionProfiles,
+    approvalPolicy,
     permissionProfileChangePending,
     permissionProfileChangeError,
     permissionProfileRecoveryAction: permissionProfileRecovery,
@@ -593,6 +630,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     submitOnboard,
     setCollaborationMode,
     setPermissionProfile,
+    setExecutionProfile,
     retryPermissionProfileChange,
     checkSessionStatus,
     reconnect: sdkReconnect,

--- a/components/dashboard/build-srcdoc.test.ts
+++ b/components/dashboard/build-srcdoc.test.ts
@@ -77,7 +77,7 @@ describe('buildSrcDoc — the wrapper document', () => {
   })
 
   it('carries the agent content in the body', () => {
-    expect(buildSrcDoc('<h1>Home</h1>', NONCE)).toContain('<body>\n<h1>Home</h1>\n</body>')
+    expect(buildSrcDoc('<h1>Control Center</h1>', NONCE)).toContain('<body>\n<h1>Control Center</h1>\n</body>')
   })
 })
 
@@ -96,7 +96,7 @@ describe('bridgeScript', () => {
 
 describe('bridgeScript — a dashboard does not link out', () => {
   // Neither the CSP nor the sandbox stops a frame navigating itself, so a link is
-  // the one way agent HTML could replace Home with a page running under its own
+  // the one way agent HTML could replace Control Center with a page running under its own
   // CSP. A dashboard is one self-contained page, so the bridge cancels them.
   it('cancels clicks on external links but leaves same-page fragments alone', () => {
     const src = bridgeScript(NONCE)

--- a/components/dashboard/build-srcdoc.ts
+++ b/components/dashboard/build-srcdoc.ts
@@ -69,23 +69,74 @@ export function cspMeta(nonce: string): string {
  */
 export function componentStyles(): string {
   return `<style>
+/* O Chat owns the Control Center component contract. Agent pages may keep their
+   existing layout, while bridge-owned controls share one accessible token set. */
+:root {
+  color-scheme: light dark;
+  --cc-canvas: #f7f8f6;
+  --cc-surface: #ffffff;
+  --cc-text: #171a17;
+  --cc-muted: #505650;
+  --cc-border: #d9ddd7;
+  --cc-focus: #075985;
+  --cc-accent: #14733a;
+  --cc-success: #14733a;
+  --cc-warning: #8a4b08;
+  --cc-danger: #b42318;
+  --cc-radius: 10px;
+  --cc-space: 12px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cc-canvas: #111411;
+    --cc-surface: #191d19;
+    --cc-text: #f1f5f1;
+    --cc-muted: #bbc4bb;
+    --cc-border: #343b34;
+    --cc-focus: #7dd3fc;
+    --cc-accent: #62d68a;
+    --cc-success: #62d68a;
+    --cc-warning: #f7b955;
+    --cc-danger: #ff8a80;
+  }
+}
 co-filter { display: block; margin: 0 0 12px; }
 co-filter input {
   width: 100%; box-sizing: border-box;
-  padding: 8px 10px; border: 1px solid rgba(127,127,127,.35); border-radius: 8px;
-  font: inherit; color: inherit; background: transparent;
+  min-height: 44px; padding: 9px 11px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius);
+  font: inherit; color: var(--cc-text); background: var(--cc-surface);
 }
-co-filter input:focus { outline: 2px solid rgba(127,127,127,.45); outline-offset: -1px; }
-co-filter [data-ochat-count] { display: block; margin-top: 6px; font-size: .85em; opacity: .6; }
+co-filter input:focus-visible { outline: 3px solid var(--cc-focus); outline-offset: 2px; }
+co-filter [data-ochat-count] { display: block; margin-top: 6px; color: var(--cc-muted); font-size: .85em; }
 [data-ochat-hidden] { display: none !important; }
+
+co-chart { display: block; color: var(--cc-text); }
+co-chart figure { margin: 0; }
+co-chart figcaption { margin-bottom: 10px; font-weight: 700; }
+co-chart [data-ochat-chart] { min-height: 140px; }
+co-chart [data-ochat-bars] { display: grid; gap: 8px; }
+co-chart [data-ochat-bar] { display: grid; grid-template-columns: minmax(70px,.4fr) 1fr auto; gap: 8px; align-items: center; }
+co-chart [data-ochat-track] { height: 12px; overflow: hidden; border-radius: 999px; background: var(--cc-border); }
+co-chart [data-ochat-fill] { height: 100%; min-width: 2px; border-radius: inherit; background: var(--cc-accent); }
+co-chart [data-ochat-donut] { width: 148px; height: 148px; margin: 0 auto; border-radius: 50%; }
+co-chart svg { display: block; width: 100%; height: 160px; overflow: visible; }
+co-chart details { margin-top: 12px; }
+co-chart summary { min-height: 44px; cursor: pointer; color: var(--cc-muted); }
+co-chart table { width: 100%; border-collapse: collapse; }
+co-chart th, co-chart td { padding: 7px 8px; border-top: 1px solid var(--cc-border); text-align: left; }
+co-chart [data-ochat-chart-error] { padding: 12px; border: 1px solid var(--cc-border); border-radius: var(--cc-radius); color: var(--cc-muted); }
 
 co-table { display: none; }
 [data-ochat-sortable] th[data-ochat-sort] { cursor: pointer; user-select: none; }
+[data-ochat-sortable] th[data-ochat-sort]:focus-visible { outline: 3px solid var(--cc-focus); outline-offset: 2px; }
 [data-ochat-sortable] th[data-ochat-sort]::after {
   content: ''; opacity: .35; margin-left: .4em; font-size: .85em;
 }
 [data-ochat-sortable] th[aria-sort="ascending"]::after { content: '\\2191'; opacity: .9; }
 [data-ochat-sortable] th[aria-sort="descending"]::after { content: '\\2193'; opacity: .9; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+}
 </style>`
 }
 
@@ -214,11 +265,106 @@ function ochatTable(host) {
   }
 }
 
+// <co-chart type="bar" data='[{"label":"Passed","value":42}]'> — bounded,
+// inline data only. The visible details table is the accessible equivalent, so
+// no result is encoded only by colour, canvas pixels, or hover interaction.
+function ochatChart(host) {
+  if (host.getAttribute('data-ochat-ready')) return;
+  host.setAttribute('data-ochat-ready', '1');
+  var raw = host.getAttribute('data') || '';
+  var type = host.getAttribute('type') || 'bar';
+  var title = (host.getAttribute('title') || 'Chart').slice(0, 120);
+  var values;
+  try { values = raw.length <= 8192 ? JSON.parse(raw) : null; } catch (_) { values = null; }
+  var valid = Array.isArray(values) && values.length > 0 && values.length <= 50
+    && (type === 'bar' || type === 'line' || type === 'donut')
+    && values.every(function (item) {
+      return item && typeof item === 'object' && typeof item.label === 'string'
+        && item.label.length > 0 && item.label.length <= 80
+        && typeof item.value === 'number' && isFinite(item.value) && item.value >= 0;
+    });
+  host.textContent = '';
+  if (!valid) {
+    var error = document.createElement('p');
+    error.setAttribute('data-ochat-chart-error', '1');
+    error.textContent = 'Chart unavailable: use 1–50 non-negative numeric values.';
+    host.appendChild(error);
+    return;
+  }
+
+  var figure = document.createElement('figure');
+  var caption = document.createElement('figcaption');
+  caption.textContent = title;
+  figure.appendChild(caption);
+  var visual = document.createElement('div');
+  visual.setAttribute('data-ochat-chart', type);
+  visual.setAttribute('aria-hidden', 'true');
+  var max = Math.max.apply(null, values.map(function (item) { return item.value; })) || 1;
+
+  if (type === 'bar') {
+    var bars = document.createElement('div');
+    bars.setAttribute('data-ochat-bars', '1');
+    values.forEach(function (item) {
+      var row = document.createElement('div');
+      row.setAttribute('data-ochat-bar', '1');
+      var label = document.createElement('span'); label.textContent = item.label;
+      var track = document.createElement('span'); track.setAttribute('data-ochat-track', '1');
+      var fill = document.createElement('span'); fill.setAttribute('data-ochat-fill', '1');
+      fill.style.width = ((item.value / max) * 100) + '%'; track.appendChild(fill);
+      var value = document.createElement('span'); value.textContent = String(item.value);
+      row.appendChild(label); row.appendChild(track); row.appendChild(value); bars.appendChild(row);
+    });
+    visual.appendChild(bars);
+  } else if (type === 'line') {
+    var ns = 'http://www.w3.org/2000/svg';
+    var svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('viewBox', '0 0 600 160');
+    var points = values.map(function (item, index) {
+      var x = values.length === 1 ? 300 : 10 + index * (580 / (values.length - 1));
+      var y = 150 - (item.value / max) * 140;
+      return x + ',' + y;
+    }).join(' ');
+    var line = document.createElementNS(ns, 'polyline');
+    line.setAttribute('points', points); line.setAttribute('fill', 'none');
+    line.setAttribute('stroke', 'var(--cc-accent)'); line.setAttribute('stroke-width', '4');
+    svg.appendChild(line); visual.appendChild(svg);
+  } else {
+    var total = values.reduce(function (sum, item) { return sum + item.value; }, 0) || 1;
+    var colors = ['#14733a','#2563eb','#8a4b08','#7c3aed','#b42318','#0e7490'];
+    var cursor = 0;
+    var stops = values.map(function (item, index) {
+      var start = cursor; cursor += (item.value / total) * 100;
+      return colors[index % colors.length] + ' ' + start + '% ' + cursor + '%';
+    });
+    var donut = document.createElement('div'); donut.setAttribute('data-ochat-donut', '1');
+    donut.style.background = 'conic-gradient(' + stops.join(',') + ')'; visual.appendChild(donut);
+  }
+  figure.appendChild(visual);
+
+  var details = document.createElement('details');
+  var summary = document.createElement('summary'); summary.textContent = 'Data table';
+  var table = document.createElement('table');
+  var head = document.createElement('thead'); var headRow = document.createElement('tr');
+  ['Label', 'Value'].forEach(function (text) { var th = document.createElement('th'); th.textContent = text; headRow.appendChild(th); });
+  head.appendChild(headRow); table.appendChild(head);
+  var body = document.createElement('tbody');
+  values.forEach(function (item) {
+    var row = document.createElement('tr');
+    var label = document.createElement('td'); label.textContent = item.label;
+    var value = document.createElement('td'); value.textContent = String(item.value);
+    row.appendChild(label); row.appendChild(value); body.appendChild(row);
+  });
+  table.appendChild(body); details.appendChild(summary); details.appendChild(table);
+  figure.appendChild(details); host.appendChild(figure);
+}
+
 function ochatComponents() {
   var filters = document.querySelectorAll('co-filter');
   for (var i = 0; i < filters.length; i++) ochatFilter(filters[i]);
   var tables = document.querySelectorAll('co-table');
   for (var j = 0; j < tables.length; j++) ochatTable(tables[j]);
+  var charts = document.querySelectorAll('co-chart');
+  for (var k = 0; k < charts.length; k++) ochatChart(charts[k]);
 }
 
 if (document.readyState === 'loading') {

--- a/components/dashboard/co-chart.test.ts
+++ b/components/dashboard/co-chart.test.ts
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { bridgeScript, componentStyles } from './build-srcdoc'
+
+const NONCE = 'deadbeefdeadbeefdeadbeefdeadbeef'
+
+function render(markup: string) {
+  document.head.innerHTML = componentStyles()
+  document.body.innerHTML = markup
+  const source = bridgeScript(NONCE)
+    .replace(/^<script nonce="[^"]*">/, '')
+    .replace(/<\/script>$/, '')
+  new Function(source)()
+}
+
+describe('<co-chart>', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it.each(['bar', 'line', 'donut'])('renders a bounded %s chart with a data table', (type) => {
+    render(`<co-chart type="${type}" title="Release health"
+      data='[{"label":"Passed","value":42},{"label":"Failed","value":2}]'></co-chart>`)
+
+    expect(document.querySelector(`[data-ochat-chart="${type}"]`)).not.toBeNull()
+    expect(document.querySelector('figcaption')?.textContent).toBe('Release health')
+    expect(Array.from(document.querySelectorAll('tbody tr')).map((row) => row.textContent)).toEqual([
+      'Passed42',
+      'Failed2',
+    ])
+    expect(document.querySelector('summary')?.textContent).toBe('Data table')
+  })
+
+  it.each([
+    'not json',
+    '[]',
+    '[{"label":"negative","value":-1}]',
+    '[{"label":"script","value":"alert(1)"}]',
+  ])('fails malformed data honestly without rendering a visual: %s', (data) => {
+    render(`<co-chart data='${data}'></co-chart>`)
+
+    expect(document.querySelector('[data-ochat-chart]')).toBeNull()
+    expect(document.querySelector('[data-ochat-chart-error]')?.textContent).toContain('Chart unavailable')
+  })
+
+  it('treats labels and titles as text rather than markup', () => {
+    render(`<co-chart title="&lt;img src=x onerror=alert(1)&gt;"
+      data='[{"label":"&lt;script&gt;bad&lt;/script&gt;","value":1}]'></co-chart>`)
+
+    expect(document.querySelector('co-chart img')).toBeNull()
+    expect(document.querySelector('co-chart script')).toBeNull()
+    expect(document.querySelector('figcaption')?.textContent).toContain('<img')
+    expect(document.querySelector('tbody')?.textContent).toContain('<script>')
+  })
+
+  it('rejects oversized data before parsing', () => {
+    const oversized = JSON.stringify([{ label: 'x'.repeat(8_200), value: 1 }])
+    render(`<co-chart data='${oversized}'></co-chart>`)
+
+    expect(document.querySelector('[data-ochat-chart-error]')).not.toBeNull()
+  })
+})

--- a/components/dashboard/dashboard-pane.tsx
+++ b/components/dashboard/dashboard-pane.tsx
@@ -79,7 +79,7 @@ export function DashboardPane({ html, skills, onRunSkill, loading, className }: 
       <div className={className}>
         <div className="h-full flex items-center justify-center p-8 text-center">
           <p className="text-sm text-neutral-400">
-            This dashboard tried to navigate away and was blocked. A Home page is a
+            This Control Center tried to navigate away and was blocked. It is a
             single self-contained page — it can run skills, but not link out.
           </p>
         </div>
@@ -96,7 +96,7 @@ export function DashboardPane({ html, skills, onRunSkill, loading, className }: 
       <div className={className}>
         <div className="h-full flex items-center justify-center p-8 text-center">
           <p className="text-sm text-neutral-400">
-            {loading ? 'Loading dashboard…' : 'This agent has no Home page yet.'}
+            {loading ? 'Loading Control Center…' : 'This agent has no Control Center yet.'}
           </p>
         </div>
       </div>
@@ -106,7 +106,7 @@ export function DashboardPane({ html, skills, onRunSkill, loading, className }: 
   return (
     <iframe
       ref={iframeRef}
-      title="Agent dashboard"
+      title="Agent Control Center"
       sandbox="allow-scripts"
       srcDoc={srcDoc}
       onLoad={() => {

--- a/components/dashboard/use-pane-width.ts
+++ b/components/dashboard/use-pane-width.ts
@@ -1,8 +1,8 @@
 /**
- * @purpose Remember how wide the reader wants the Home pane, and drag it there.
+ * @purpose Remember how wide the reader wants the Control Center pane, and drag it there.
  * @llm-note The pane used to be `lg:w-[440px] xl:w-[500px] shrink-0` — three fixed
  *   sizes we picked. But the pane holds agent-authored HTML we do not control: one
- *   agent's Home is a four-column table, another's is a wide chart. There is no
+ *   agent's Control Center is a four-column table, another's is a wide chart. There is no
  *   single width that fits them, and the reader is the only one who knows whether
  *   they are here to read the dashboard or the chat. So the width is theirs.
  *

--- a/components/dashboard/view-switch.tsx
+++ b/components/dashboard/view-switch.tsx
@@ -29,8 +29,8 @@ import { cn } from '@/components/chat/utils'
 export type MobileView = 'chat' | 'home'
 
 const SEGMENTS = [
-  { key: 'home' as const, label: 'Home', Icon: HiOutlineViewGrid },
-  { key: 'chat' as const, label: 'Chat', Icon: HiOutlineChatAlt2 },
+  { key: 'home' as const, label: 'Control', accessibleLabel: 'Control Center', Icon: HiOutlineViewGrid },
+  { key: 'chat' as const, label: 'Chat', accessibleLabel: 'Chat', Icon: HiOutlineChatAlt2 },
 ]
 
 export function ViewSwitch({
@@ -52,7 +52,7 @@ export function ViewSwitch({
       aria-label="Agent view"
       className="lg:hidden flex shrink-0 items-center gap-0.5 rounded-lg bg-neutral-200/70 p-0.5"
     >
-      {SEGMENTS.map(({ key, label, Icon }) => {
+      {SEGMENTS.map(({ key, label, accessibleLabel, Icon }) => {
         // Only on the side you are not looking at: a dot on the pane already in
         // front of you points at something you can see, which is noise.
         const waiting = attention === key && view !== key
@@ -60,6 +60,7 @@ export function ViewSwitch({
         <button
           key={key}
           role="tab"
+          aria-label={waiting ? `${accessibleLabel}, waiting for you` : accessibleLabel}
           aria-selected={view === key}
           onClick={() => onChange(key)}
           className={cn(
@@ -90,7 +91,6 @@ export function ViewSwitch({
                 aria-hidden
                 className="ml-0.5 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-neutral-400"
               />
-              <span className="sr-only">, waiting for you</span>
             </>
           )}
         </button>

--- a/components/dashboard/workspace-shell.tsx
+++ b/components/dashboard/workspace-shell.tsx
@@ -103,7 +103,7 @@ export function WorkspaceShell({
         <div
           role="separator"
           aria-orientation="vertical"
-          aria-label="Resize dashboard"
+          aria-label="Resize Control Center"
           aria-valuenow={pane.width}
           aria-valuemin={MIN_PANE}
           aria-valuemax={MAX_PANE}
@@ -133,11 +133,11 @@ export function WorkspaceShell({
           )}
         >
           <div className="hidden lg:flex items-center justify-between px-4 py-2 border-b border-neutral-200">
-            <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Home</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Control Center</span>
             <button
               onClick={() => setDashboardOpen(false)}
               className="p-1 rounded hover:bg-neutral-100 text-neutral-400"
-              aria-label="Collapse dashboard"
+              aria-label="Collapse Control Center"
             >
               <HiOutlineChevronRight className="w-4 h-4" />
             </button>
@@ -151,7 +151,7 @@ export function WorkspaceShell({
           <button
             onClick={() => setDashboardOpen(true)}
             className="hidden lg:flex items-center justify-center w-8 border-l border-neutral-200 bg-neutral-50 hover:bg-neutral-100 text-neutral-400"
-            aria-label="Open dashboard"
+            aria-label="Open Control Center"
           >
             <HiOutlineViewGrid className="w-4 h-4" />
           </button>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-icons/hi'
 import { useChatStore } from '@/store/chat-store'
 import { useAgentInfo } from '@/hooks/use-agent-info'
+import { orderAgents } from '@/lib/agent-order'
 import { AgentHeader } from '@/components/agent-header'
 import { SessionList } from '@/components/session-list'
 import { ConfirmDialog } from '@/components/confirm-dialog'
@@ -44,6 +45,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   // Track which agents are expanded (all expanded by default)
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set())
   const [pendingRemove, setPendingRemove] = useState<string | null>(null)
+  const [offlineExpanded, setOfflineExpanded] = useState(false)
+  const [agentQuery, setAgentQuery] = useState('')
 
   // Auto-expand new agents
   const isExpanded = (address: string) => !expandedAgents.has(address) // inverted: Set tracks collapsed agents
@@ -77,6 +80,32 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     () => agents.filter(a => infoMap[a]?.online).length,
     [agents, infoMap]
   )
+
+  const recentActivity = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const conversation of conversations) {
+      result[conversation.agentAddress] = Math.max(
+        result[conversation.agentAddress] ?? 0,
+        new Date(conversation.createdAt).getTime(),
+      )
+    }
+    return result
+  }, [conversations])
+
+  const orderedAgents = useMemo(
+    () => orderAgents(agents, infoMap, activeAgent, recentActivity),
+    [agents, infoMap, activeAgent, recentActivity],
+  )
+  const normalizedQuery = agentQuery.trim().toLocaleLowerCase()
+  const matchingAgents = orderedAgents.filter(({ address }) => {
+    if (!normalizedQuery) return true
+    return address.toLocaleLowerCase().includes(normalizedQuery)
+      || (infoMap[address]?.name || '').toLocaleLowerCase().includes(normalizedQuery)
+  })
+  const offlineAgents = matchingAgents.filter(item => item.presence === 'offline' && !item.selected)
+  const primaryAgents = matchingAgents.filter(item => item.presence !== 'offline' || item.selected)
+  const revealOffline = offlineExpanded || normalizedQuery.length > 0 || primaryAgents.length === 0
+  const visibleAgents = revealOffline ? [...primaryAgents, ...offlineAgents] : primaryAgents
 
   const toggleAgent = (address: string) => {
     setExpandedAgents(prev => {
@@ -186,6 +215,20 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <span className="text-[11px] font-mono text-neutral-500">{agents.length}</span>
         </div>
 
+        {agents.length > 5 && (
+          <div className="px-3 pb-2">
+            <label htmlFor="agent-search" className="sr-only">Search agents</label>
+            <input
+              id="agent-search"
+              type="search"
+              value={agentQuery}
+              onChange={event => setAgentQuery(event.target.value)}
+              placeholder="Search agents"
+              className="min-h-11 w-full rounded-lg border border-neutral-200 bg-neutral-50 px-3 text-sm text-neutral-800 outline-none focus:border-neutral-400 focus:ring-2 focus:ring-neutral-200"
+            />
+          </div>
+        )}
+
         {/* Agent Folders */}
         <div className="flex-1 overflow-y-auto no-scrollbar px-2 pb-3">
           {agents.length === 0 ? (
@@ -198,7 +241,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             </div>
           ) : (
             <div className="space-y-0.5">
-              {agents.map(address => {
+              {visibleAgents.map(({ address, presence }, index) => {
                 const info = infoMap[address]
                 const sessions = sessionsByAgent[address] || []
                 const expanded = isExpanded(address)
@@ -207,6 +250,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
                 return (
                   <div key={address}>
+                    {presence === 'offline' && !isActive && (index === 0 || visibleAgents[index - 1]?.presence !== 'offline' || visibleAgents[index - 1]?.selected) && (
+                      <div className="px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-neutral-400">Offline</div>
+                    )}
                     {/* Agent Row */}
                     <div
                       className={`group relative flex items-center gap-1 pl-1 pr-1.5 py-1.5 rounded-lg transition-colors ${
@@ -294,6 +340,16 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   </div>
                 )
               })}
+              {offlineAgents.length > 0 && !normalizedQuery && (
+                <button
+                  type="button"
+                  aria-expanded={revealOffline}
+                  onClick={() => setOfflineExpanded(value => !value)}
+                  className="mt-1 flex min-h-11 w-full items-center rounded-lg px-3 text-left text-xs font-medium text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800"
+                >
+                  {revealOffline ? 'Hide offline' : `Show offline (${offlineAgents.length})`}
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -249,7 +249,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 const isAgentActive = isActive && !activeSessionId
 
                 return (
-                  <div key={address}>
+                  <div key={address} data-agent-address={address}>
                     {presence === 'offline' && !isActive && (index === 0 || visibleAgents[index - 1]?.presence !== 'offline' || visibleAgents[index - 1]?.selected) && (
                       <div className="px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-neutral-400">Offline</div>
                     )}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -11,11 +11,11 @@ import {
   HiOutlineChevronDown,
   HiOutlineChevronRight,
   HiOutlineSparkles,
+  HiOutlineDotsHorizontal,
 } from 'react-icons/hi'
 import { useChatStore } from '@/store/chat-store'
-import { useAgentInfo } from '@/hooks/use-agent-info'
+import { agentInitial, shortAddress, useAgentInfo } from '@/hooks/use-agent-info'
 import { orderAgents } from '@/lib/agent-order'
-import { AgentHeader } from '@/components/agent-header'
 import { SessionList } from '@/components/session-list'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 // O Chat directly consumes the React integration package. The retired standalone
@@ -47,6 +47,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [pendingRemove, setPendingRemove] = useState<string | null>(null)
   const [offlineExpanded, setOfflineExpanded] = useState(false)
   const [agentQuery, setAgentQuery] = useState('')
+  const [agentMenu, setAgentMenu] = useState<string | null>(null)
 
   // Auto-expand new agents
   const isExpanded = (address: string) => !expandedAgents.has(address) // inverted: Set tracks collapsed agents
@@ -190,27 +191,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           </button>
         </div>
 
-        {/* Live status — quiet mono strip */}
-        <div className="px-4 pb-1 flex items-center gap-2">
-          {onlineCount > 0 ? (
-            <span className="relative flex h-1.5 w-1.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-500 opacity-75" />
-              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-brand-500" />
-            </span>
-          ) : (
-            <span className="h-1.5 w-1.5 rounded-full bg-neutral-300" />
-          )}
-          <span className="text-[11px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
-            {onlineCount > 0
-              ? `${onlineCount} agent${onlineCount > 1 ? 's' : ''} online`
-              : 'all agents offline'}
-          </span>
-        </div>
-
         {/* Agents section label */}
-        <div className="px-4 pt-3 pb-1 flex items-center justify-between shrink-0">
-          <span className="text-[11px] font-mono tracking-[0.12em] text-neutral-500 uppercase">
-            Agents
+        <div className="px-4 pt-3 pb-2 flex items-center justify-between shrink-0">
+          <span className="text-[11px] font-semibold tracking-[0.08em] text-neutral-500 uppercase">
+            Agents <span className="font-normal text-neutral-400">· {onlineCount} online</span>
           </span>
           <span className="text-[11px] font-mono text-neutral-500">{agents.length}</span>
         </div>
@@ -240,85 +224,88 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               <p className="text-neutral-400 text-xs mt-0.5">Add one below to start chatting</p>
             </div>
           ) : (
-            <div className="space-y-0.5">
+            <div className="space-y-2">
               {visibleAgents.map(({ address, presence }, index) => {
                 const info = infoMap[address]
                 const sessions = sessionsByAgent[address] || []
                 const expanded = isExpanded(address)
                 const isActive = activeAgent === address
-                const isAgentActive = isActive && !activeSessionId
 
                 return (
-                  <div key={address} data-agent-address={address}>
+                  <div
+                    key={address}
+                    data-agent-address={address}
+                    className={`relative overflow-visible rounded-xl border bg-white transition-shadow ${
+                      isActive ? 'border-neutral-300 shadow-sm' : 'border-neutral-100 hover:border-neutral-200'
+                    } ${presence === 'offline' && !isActive ? 'opacity-70' : ''}`}
+                  >
                     {presence === 'offline' && !isActive && (index === 0 || visibleAgents[index - 1]?.presence !== 'offline' || visibleAgents[index - 1]?.selected) && (
                       <div className="px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-neutral-400">Offline</div>
                     )}
-                    {/* Agent Row */}
-                    <div
-                      className={`group relative flex items-center gap-1 pl-1 pr-1.5 py-1.5 rounded-lg transition-colors ${
-                        isAgentActive
-                          ? 'bg-neutral-100'
-                          : 'hover:bg-neutral-100/70'
-                      }`}
-                    >
-                      {isAgentActive && (
-                        <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-neutral-900" />
-                      )}
-                      {/* Expand/Collapse */}
-                      <button
-                        onClick={() => toggleAgent(address)}
-                        className="flex min-h-9 min-w-9 items-center justify-center lg:min-h-0 lg:min-w-0 lg:p-1 text-neutral-400 hover:text-neutral-700 rounded transition-colors shrink-0"
-                        aria-label={expanded ? 'Collapse' : 'Expand'}
-                      >
-                        {expanded ? (
-                          <HiOutlineChevronDown className="w-3.5 h-3.5" />
-                        ) : (
-                          <HiOutlineChevronRight className="w-3.5 h-3.5" />
-                        )}
-                      </button>
-
-                      {/* Agent Link */}
+                    <div className="flex min-h-14 items-center gap-2 px-2">
                       <Link
                         href={`/${address}`}
                         onClick={onClose}
-                        className="flex-1 min-w-0"
+                        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1 py-2 outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
                       >
-                        <AgentHeader address={address} info={info} variant="compact" />
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-neutral-900 text-xs font-semibold text-white">
+                          {agentInitial(info?.name || shortAddress(address), address)}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-semibold text-neutral-800">
+                            {info?.name || shortAddress(address)}
+                          </span>
+                          <span className={`block text-[11px] font-medium capitalize ${
+                            presence === 'online' ? 'text-emerald-600' : 'text-neutral-400'
+                          }`}>
+                            {presence === 'unknown' ? 'Checking status' : presence}
+                          </span>
+                        </span>
                       </Link>
-
-                      {/* Action buttons — always visible on touch, hover-revealed on desktop */}
-                      {/* 36px+ touch targets on mobile; compact on desktop. The gap is 8px, not 4:
-                          × removes the agent and sits next to +, which starts a chat, and a
-                          thumb is about 9mm wide. The confirm dialog is the real backstop,
-                          but nobody should be reaching it by accident. */}
-                      <div className="flex items-center gap-2 lg:gap-0 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100 transition-opacity">
-                        <Link
-                          href={`/${address}`}
-                          onClick={onClose}
-                          className="flex min-h-9 min-w-9 items-center justify-center lg:min-h-0 lg:min-w-0 lg:p-1 text-neutral-400 hover:text-neutral-700 rounded transition-colors"
-                          title="New chat"
-                          aria-label="New chat"
-                        >
-                          <HiOutlinePlus className="w-3.5 h-3.5" />
-                        </Link>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setPendingRemove(address)
-                          }}
-                          className="flex min-h-9 min-w-9 items-center justify-center lg:min-h-0 lg:min-w-0 lg:p-1 text-neutral-400 hover:text-red-500 rounded transition-colors"
-                          title="Remove agent"
-                          aria-label="Remove agent"
-                        >
-                          <HiOutlineX className="w-3.5 h-3.5" />
-                        </button>
-                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Actions for ${info?.name || shortAddress(address)}`}
+                        aria-expanded={agentMenu === address}
+                        onClick={() => setAgentMenu(current => current === address ? null : address)}
+                        className="flex min-h-11 min-w-11 items-center justify-center rounded-lg text-neutral-400 hover:bg-neutral-100 hover:text-neutral-700"
+                      >
+                        <HiOutlineDotsHorizontal className="h-5 w-5" />
+                      </button>
+                      {agentMenu === address && (
+                        <div className="absolute right-2 top-12 z-20 w-36 rounded-xl border border-neutral-200 bg-white p-1.5 shadow-lg">
+                          <Link
+                            href={`/${address}`}
+                            onClick={() => { setAgentMenu(null); onClose() }}
+                            className="flex min-h-11 items-center rounded-lg px-3 text-sm text-neutral-700 hover:bg-neutral-100"
+                            aria-label="New chat"
+                          >
+                            New chat
+                          </Link>
+                          <button
+                            type="button"
+                            onClick={() => { setAgentMenu(null); setPendingRemove(address) }}
+                            className="flex min-h-11 w-full items-center rounded-lg px-3 text-left text-sm text-red-600 hover:bg-red-50"
+                            aria-label="Remove agent"
+                          >
+                            Remove agent
+                          </button>
+                        </div>
+                      )}
                     </div>
 
-                    {/* Sessions (expanded) — newest 8, with the rest one press away. The list
-                        area scrolls, so showing all of them is safe. */}
+                    {sessions.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => toggleAgent(address)}
+                        aria-expanded={expanded}
+                        className="flex min-h-9 w-full items-center justify-between border-t border-neutral-100 px-3 text-xs font-medium text-neutral-500 hover:bg-neutral-50"
+                      >
+                        <span>{sessions.length} conversation{sessions.length === 1 ? '' : 's'}</span>
+                        {expanded ? <HiOutlineChevronDown className="h-3.5 w-3.5" /> : <HiOutlineChevronRight className="h-3.5 w-3.5" />}
+                      </button>
+                    )}
                     {expanded && sessions.length > 0 && (
-                      <div className="ml-5 mt-0.5 mb-1 pl-2 border-l border-neutral-200">
+                      <div className="border-t border-neutral-100 bg-neutral-50/70 px-1.5 py-1.5">
                         <SessionList
                           sessions={showAllFor.has(address) ? sessions : sessions.slice(0, 8)}
                           agentAddress={address}

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -133,18 +133,19 @@ test.describe('the other decisions that reach the agent', () => {
     // The compact labels differ from their wire values. A vocabulary migration
     // can leave perfect-looking controls sending stale IDs, which silently
     // changes whether the agent asks before edits or runs with full access.
-    await page.getByRole('button', { name: 'Auto', exact: true }).click()
+    await page.getByRole('button', { name: /Default, recommended/ }).click()
     await expect.poll(() => agent.sent('mode_change').length).toBe(1)
     await page.getByRole('button', { name: 'Plan', exact: true }).click()
-    await expect(page.getByRole('button', { name: 'Plan', exact: true })).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: 'Exit plan', exact: true })).toHaveAttribute('aria-pressed', 'true')
     expect(agent.sent('mode_change')).toHaveLength(1)
     await page.getByRole('button', { name: 'Full access', exact: true }).click()
+    await page.getByRole('button', { name: 'Enable', exact: true }).click()
 
     await expect
       .poll(() => agent.sent('mode_change'), { timeout: 10_000 })
       .toEqual([
-        { type: 'mode_change', mode: ':workspace' },
-        { type: 'mode_change', mode: ':danger-full-access' },
+        { type: 'mode_change', mode: 'default' },
+        { type: 'mode_change', mode: 'full_access' },
       ])
   })
 
@@ -152,26 +153,26 @@ test.describe('the other decisions that reach the agent', () => {
     test.setTimeout(120_000)
     const agent = await mockAgent(page, 'mode-delay')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('button', { name: 'Auto', exact: true })).toBeVisible({ timeout: 90_000 })
+    await expect(page.getByRole('button', { name: /Default, recommended/ })).toBeVisible({ timeout: 90_000 })
 
-    await page.getByRole('button', { name: 'Auto', exact: true }).click()
-    await expect(page.getByRole('status')).toHaveText('changing permissions…')
+    await page.getByRole('button', { name: /Default, recommended/ }).click()
+    await expect(page.getByRole('status')).toHaveText('changing execution mode…')
     await expect(page.getByPlaceholder('Changing permissions…')).toBeDisabled()
     expect(agent.sent('INPUT')).toEqual([])
     agent.acknowledgeMode()
-    await expect(page.getByRole('button', { name: 'Auto', exact: true })).toBeEnabled({ timeout: 10_000 })
+    await expect(page.getByRole('button', { name: /Default, recommended/ })).toBeEnabled({ timeout: 10_000 })
   })
 
   test('an acknowledged Host rejection keeps Read only and offers retry', async ({ page }) => {
     test.setTimeout(120_000)
     const agent = await mockAgent(page, 'mode-reject')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('button', { name: 'Auto', exact: true })).toBeVisible({ timeout: 90_000 })
+    await expect(page.getByRole('button', { name: /Default, recommended/ })).toBeVisible({ timeout: 90_000 })
 
-    await page.getByRole('button', { name: 'Auto', exact: true }).click()
+    await page.getByRole('button', { name: /Default, recommended/ }).click()
     await expect(page.getByText('Session is busy')).toBeVisible()
     await expect(page.getByRole('button', { name: 'retry', exact: true })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Read only', exact: true })).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: /Safe, current mode/ })).toHaveAttribute('aria-pressed', 'true')
     expect(agent.sent('INPUT')).toEqual([])
   })
 
@@ -179,16 +180,16 @@ test.describe('the other decisions that reach the agent', () => {
     test.setTimeout(120_000)
     const agent = await mockAgent(page, 'mode-disconnect')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('button', { name: 'Auto', exact: true })).toBeVisible({ timeout: 90_000 })
+    await expect(page.getByRole('button', { name: /Default, recommended/ })).toBeVisible({ timeout: 90_000 })
 
-    await page.getByRole('button', { name: 'Auto', exact: true }).click()
+    await page.getByRole('button', { name: /Default, recommended/ }).click()
     await expect(page.getByText(/permission profile acknowledgement/i)).toBeVisible()
     const beforeReconnect = agent.connects()
     await page.getByRole('button', { name: 'reconnect', exact: true }).click()
 
     await expect.poll(() => agent.connects()).toBeGreaterThan(beforeReconnect)
     await expect(page.getByText(/permission profile acknowledgement/i)).toBeHidden()
-    await expect(page.getByRole('button', { name: 'Read only', exact: true })).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: /Safe, current mode/ })).toHaveAttribute('aria-pressed', 'true')
     expect(agent.sent('mode_change')).toHaveLength(1)
   })
 })

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -33,7 +33,10 @@ test.describe('agent landing page', () => {
   test('shows who the agent is, its address, and how to pay it', async ({ page }) => {
     await landing(page)
 
-    await expect(page.getByText('online', { exact: true })).toBeVisible()
+    // The sidebar now carries its own textual presence state. Scope identity
+    // assertions to the page content so adding useful navigation context cannot
+    // turn this into a strict-locator collision.
+    await expect(page.getByRole('main').getByText('online', { exact: true })).toBeVisible()
     await expect(page.getByText(PROFILE.model)).toBeVisible()
 
     // The address is the agent's only durable name and the target of a top-up.

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,14 +1,14 @@
 /**
- * Home and Chat, and the switch between them.
+ * Control Center and Chat, and the switch between them.
  *
  * On a phone the two panes are exclusive — one is `hidden` while the other shows —
  * so the switch is not a convenience, it is the only way back. It is rendered
  * through a portal into a slot the layout above owns, looked up once on mount.
- * If that lookup ever misses, a reader who lands on Home is stuck on Home with a
+ * If that lookup ever misses, a reader who lands on Control Center is stuck on Control Center with a
  * dashboard whose buttons do nothing, and nothing on screen says why.
  *
  * On a desktop both panes are visible at once and the question is different:
- * collapsing Home must not take the chat with it.
+ * collapsing Control Center must not take the chat with it.
  */
 
 import { test, expect, pane } from './fixtures'
@@ -17,30 +17,30 @@ import { mockAgent, AGENT_ADDRESS, PROFILE } from './mock-agent'
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  test('an agent with a dashboard opens on Home and can get back to Chat', async ({ page, shot }) => {
+  test('an agent with a dashboard opens on Control Center and can get back to Chat', async ({ page, shot }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
 
-    const switcher = page.getByRole('tab', { name: 'Home' })
-    await expect(switcher, 'the view switch never rendered — Home would be a dead end').toBeVisible({ timeout: 15_000 })
+    const switcher = page.getByRole('tab', { name: 'Control Center' })
+    await expect(switcher, 'the view switch never rendered — Control Center would be a dead end').toBeVisible({ timeout: 15_000 })
     await shot('home')
 
-    // Home first, per defaultMobileView.
+    // Control Center first, per defaultMobileView.
     await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
 
     await page.getByRole('tab', { name: 'Chat' }).click()
     await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
     await shot('chat')
 
-    // And back again — the switch works in both directions, not just away from Home.
-    await page.getByRole('tab', { name: 'Home' }).click()
+    // And back again — the switch works in both directions, not just away from Control Center.
+    await page.getByRole('tab', { name: 'Control Center' }).click()
     await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
   })
 
   test('the dashboard fits the viewport it is given', async ({ page }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
 
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth
@@ -57,12 +57,12 @@ test.describe('phone', () => {
     await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
 
     // A switch with nothing to switch to is worse than no switch.
-    await expect(page.getByRole('tab', { name: 'Home' })).toHaveCount(0)
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toHaveCount(0)
   })
 })
 
 test.describe('desktop', () => {
-  test('both panes show at once, and collapsing Home keeps the chat', async ({ page, shot }) => {
+  test('both panes show at once, and collapsing Control Center keeps the chat', async ({ page, shot }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
 
@@ -70,44 +70,44 @@ test.describe('desktop', () => {
     await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
     await shot('split')
 
-    await page.getByRole('button', { name: /collapse dashboard/i }).click()
+    await page.getByRole('button', { name: /collapse control center/i }).click()
     await expect(page.locator('iframe')).toBeHidden()
     await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
 
     // The reopen strip is the only way back; without it the pane is gone for good.
-    await page.getByRole('button', { name: /open dashboard/i }).click()
+    await page.getByRole('button', { name: /open control center/i }).click()
     await expect(page.frameLocator('iframe').getByText('Deploy board')).toBeVisible()
   })
 })
 
-test.describe('a run that stops while the reader is on Home', () => {
+test.describe('a run that stops while the reader is on Control Center', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  /** Settle on the session page, then move to Home before the approval lands. */
+  /** Settle on the session page, then move to Control Center before the approval lands. */
   async function waitOnHome(page: import('@playwright/test').Page) {
     await mockAgent(page, 'dashboard-approval')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     // The tool card means the session page has mounted and the socket is live —
     // switching before this races the navigation and silently tests the landing page.
     await expect(page.getByText('check the kernel')).toBeVisible({ timeout: 20_000 })
-    await page.getByRole('tab', { name: 'Home' }).click()
-    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+    await page.getByRole('tab', { name: 'Control Center' }).click()
+    await expect(page.getByRole('tab', { name: /^Control Center/ })).toHaveAttribute('aria-selected', 'true')
   }
 
   test('the Chat tab says the agent is waiting', async ({ page, shot }) => {
     await waitOnHome(page)
 
-    // On a phone the two panes are exclusive, so a reader on Home cannot see that
+    // On a phone the two panes are exclusive, so a reader on Control Center cannot see that
     // the run has parked. The agent is blocked until they answer, and the only
     // thing on screen is a dashboard that does not change. Without a marker here
     // the run simply never proceeds.
     const chatTab = page.getByRole('tab', { name: /Chat/ })
     await expect(
       chatTab.locator('[data-attention]'),
-      'nothing on Home says the run has stopped and is waiting for an answer',
+      'nothing on Control Center says the run has stopped and is waiting for an answer',
     ).toBeVisible({ timeout: 15_000 })
 
     await shot('waiting')
@@ -150,11 +150,11 @@ test.describe('a run that stops while the reader is on Home', () => {
   test('a run that needs nothing shows no marker', async ({ page }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
-    await page.getByRole('tab', { name: 'Home' }).click()
+    await page.getByRole('tab', { name: 'Control Center' }).click()
 
     // The marker earns its meaning by being absent the rest of the time.
     await expect(page.getByRole('tab', { name: /Chat/ }).locator('[data-attention]')).toHaveCount(0)
@@ -164,24 +164,24 @@ test.describe('a run that stops while the reader is on Home', () => {
 test.describe('what the agent needs the reader to know, from either pane', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  /** Settle in a conversation, switch to Home, and let the credit run down. */
+  /** Settle in a conversation, switch to Control Center, and let the credit run down. */
   async function watchingHome(page: import('@playwright/test').Page) {
     await mockAgent(page, 'dashboard-drains')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(pane(page).getByText('Working on it.')).toBeVisible({ timeout: 20_000 })
-    await page.getByRole('tab', { name: 'Home' }).click()
-    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+    await page.getByRole('tab', { name: 'Control Center' }).click()
+    await expect(page.getByRole('tab', { name: /^Control Center/ })).toHaveAttribute('aria-selected', 'true')
   }
 
-  test('a balance running out is visible from Home', async ({ page, shot }) => {
+  test('a balance running out is visible from Control Center', async ({ page, shot }) => {
     await watchingHome(page)
 
     // #88 gave prompts a marker on the other tab, which is right for something
     // you must answer. This is a standing fact about the agent, and the reader on
-    // Home is exactly the person watching a dashboard that is about to stop
+    // Control Center is exactly the person watching a dashboard that is about to stop
     // updating — a breadcrumb pointing at the other pane is not the answer.
     await expect(
       page.getByText(/running low/i),
@@ -212,29 +212,29 @@ test.describe('what the agent needs the reader to know, from either pane', () =>
   test('a healthy agent shows no notice on either pane', async ({ page }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
 
     await expect(page.getByText(/running low|may not be delivered/i)).toHaveCount(0)
-    await page.getByRole('tab', { name: 'Home' }).click()
+    await page.getByRole('tab', { name: 'Control Center' }).click()
     await expect(page.getByText(/running low|may not be delivered/i)).toHaveCount(0)
   })
 })
 
-test.describe('a connection that drops while the reader is on Home', () => {
+test.describe('a connection that drops while the reader is on Control Center', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
   async function droppedOnHome(page: import('@playwright/test').Page) {
     await mockAgent(page, 'dashboard-drop')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(page.getByText('Connection lost', { exact: true })).toBeVisible({ timeout: 20_000 })
-    await page.getByRole('tab', { name: 'Home' }).click()
-    await expect(page.getByRole('tab', { name: /^Home/ })).toHaveAttribute('aria-selected', 'true')
+    await page.getByRole('tab', { name: 'Control Center' }).click()
+    await expect(page.getByRole('tab', { name: /^Control Center/ })).toHaveAttribute('aria-selected', 'true')
   }
 
   test('says the connection dropped', async ({ page, shot }) => {
@@ -242,7 +242,7 @@ test.describe('a connection that drops while the reader is on Home', () => {
 
     // The dashboard cannot update over a dead socket, so it sits there looking
     // like an agent with nothing to report. The composer's status bar says
-    // "disconnected · reconnect" — to a reader on Home that is inside the pane
+    // "disconnected · reconnect" — to a reader on Control Center that is inside the pane
     // they cannot see.
     await expect(
       page.getByText(/connection to this agent dropped/i),
@@ -273,14 +273,14 @@ test.describe('a connection that drops while the reader is on Home', () => {
     await expect(page.getByText('Connection lost', { exact: true })).toBeVisible()
   })
 
-  test('a healthy connection says nothing on Home', async ({ page }) => {
+  test('a healthy connection says nothing on Control Center', async ({ page }) => {
     await mockAgent(page, 'dashboard')
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('tab', { name: 'Chat' }).click()
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(pane(page).getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
-    await page.getByRole('tab', { name: 'Home' }).click()
+    await page.getByRole('tab', { name: 'Control Center' }).click()
 
     await expect(page.getByText(/connection to this agent dropped/i)).toHaveCount(0)
   })

--- a/e2e/drawer.spec.ts
+++ b/e2e/drawer.spec.ts
@@ -2,7 +2,7 @@
  * The drawer, control by control.
  *
  * The existing coverage checks two specific controls — New chat and Remove agent —
- * and the gap between them. Everything else in there had never been measured, and
+ * inside the agent action menu. Everything else in there had never been measured, and
  * three things were wrong: the close button, which on a phone is the drawer's only
  * labelled way out, announced as "button" with no name at all; Delete chat was a
  * 20px destructive target under the app's own 24px floor; and that same delete

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -94,6 +94,11 @@ test.describe('the drawer', () => {
     await page.goto(`/${AGENT_ADDRESS}`)
     await page.getByRole('button', { name: /menu/i }).first().click()
 
+    // Agent actions no longer compete with the identity and status row. The
+    // destructive option stays behind one clearly labelled overflow control.
+    await expect(page.getByRole('button', { name: /remove agent/i })).toBeHidden()
+    await page.getByRole('button', { name: /actions for/i }).first().click()
+
     const remove = page.getByRole('button', { name: /remove agent/i }).first()
     const newChat = page.getByRole('link', { name: /new chat/i }).first()
     await expect(remove).toBeVisible()
@@ -103,9 +108,10 @@ test.describe('the drawer', () => {
       expect(box!.width).toBeGreaterThanOrEqual(24)
       expect(box!.height).toBeGreaterThanOrEqual(24)
     }
-    // Removing an agent is confirmed, but nobody should reach the confirm by
-    // accident. A thumb is about 9mm; 4px of air between + and x is not enough.
-    expect(b!.x - (a!.x + a!.width), 'gap between New chat and Remove agent').toBeGreaterThanOrEqual(8)
+    // The old plus and x sat beside one another. Routine and destructive actions
+    // now occupy separate full-width rows, so a horizontal thumb slip cannot
+    // cross from one into the other.
+    expect(b!.y, 'Remove agent is below New chat').toBeGreaterThanOrEqual(a!.y + a!.height)
   })
 
   test('opens, lists the agent, and closes again', async ({ page, shot }) => {

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -4,7 +4,7 @@
  * Most people open a shared agent link on a phone, and this path had never been
  * walked at 375px: land, read who the agent is, find its balance, reach the
  * top-up, send a message, answer an approval, open the drawer, switch between
- * Home and Chat. Each step here is a thing a user does, not a thing a component
+ * Control Center and Chat. Each step here is a thing a user does, not a thing a component
  * renders — and every one of them leaves a screenshot.
  */
 

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
+export type Scenario = 'reply' | 'tools' | 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'pr-evidence' | 'ask-user' | 'full-access-checkpoint' | 'plan' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -46,6 +46,14 @@ export const DASHBOARD_HTML =
   '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1">' +
   '<h1 style="font:600 18px system-ui;padding:16px">Deploy board</h1>' +
   '<p style="font:14px system-ui;padding:0 16px">Last ship: 4 minutes ago.</p>'
+
+export const UPDATED_DASHBOARD_HTML =
+  '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1">' +
+  '<main style="font:14px system-ui;padding:16px">' +
+  '<h1 style="font-size:18px">Release Control Center</h1>' +
+  '<p role="status">Release 1.6.11 verified</p>' +
+  '<p>Invite accepted · prompt completed · execution modes acknowledged</p>' +
+  '</main>'
 
 const send = (ws: WebSocketRoute, frame: Record<string, unknown>) =>
   ws.send(JSON.stringify(frame))
@@ -87,6 +95,7 @@ export async function mockAgent(
   let currentMode = 'safe'
   let pendingModeAcknowledgement: (() => void) | null = null
   let fullAccessCheckpointSent = false
+  let onboarded = false
   /** Every frame the client sent. The approval buttons differ only in the frame
    *  they produce — the UI is identical whichever one is wired to which — so the
    *  wire is the only place that difference is observable. */
@@ -113,10 +122,12 @@ export async function mockAgent(
       if (scenario === 'offline') return
 
       if (msg.type === 'CONNECT') {
+        connectedSessionId = msg.session_id || connectedSessionId
+        activeSessionId = connectedSessionId
         // The gate answers CONNECT instead of granting it. Unreachable with the
         // agents in use today — both take invite codes only — which is why this
         // branch drifted far enough to promise a charge it never made.
-        if (scenario === 'onboard-payment') {
+        if (scenario === 'onboard-payment' || (scenario === 'pr-evidence' && !onboarded)) {
           send(ws, {
             type: 'ONBOARD_REQUIRED',
             methods: ['invite_code', 'payment'],
@@ -126,8 +137,6 @@ export async function mockAgent(
           return
         }
         connects += 1
-        connectedSessionId = msg.session_id || connectedSessionId
-        activeSessionId = connectedSessionId
         // A real WebSocket delivers the Host reply in a later event-loop turn.
         // Preserve that boundary: Playwright's in-page route can otherwise answer
         // synchronously inside send(CONNECT), before the SDK installs its waiter.
@@ -151,7 +160,7 @@ export async function mockAgent(
           send(ws, { type: 'AGENT_PROFILE', ...profile })
           // Pushed on connect for agents that ship one. Its arrival is what flips
           // hasDashboard, which is what splits the workspace in two.
-          if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains' || scenario === 'dashboard-error' || scenario === 'dashboard-drop') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
+          if (scenario === 'dashboard' || scenario === 'dashboard-approval' || scenario === 'dashboard-drains' || scenario === 'dashboard-error' || scenario === 'dashboard-drop' || scenario === 'pr-evidence') send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
         }, 0)
 
         // The connection goes away after it was working: a tunnel, a handover
@@ -159,6 +168,30 @@ export async function mockAgent(
         // on INPUT because sending from the landing page navigates to the session
         // page, which opens a *fresh* socket — an INPUT-triggered close lands on
         // the socket already being torn down and the session never notices.
+        return
+      }
+
+      if (scenario === 'pr-evidence' && msg.type === 'ONBOARD_SUBMIT') {
+        onboarded = true
+        send(ws, { type: 'ONBOARD_SUCCESS', level: 'contact', message: 'Invite accepted' })
+        send(ws, {
+          type: 'CONNECTED',
+          protocol: { name: 'oip', version: '0.1' },
+          session_id: connectedSessionId,
+          status: 'idle',
+          session_modes: {
+            schemaVersion: 1,
+            currentModeId: currentMode,
+            policy: { id: 'connectonion.auto-approve', version: 1 },
+            availableModes: [
+              { id: 'safe', name: 'Safe', description: 'Read normally; unresolved effects ask.' },
+              { id: 'default', name: 'Default', description: 'Low-risk workspace work proceeds automatically.', recommended: true },
+              { id: 'full_access', name: 'Full access', description: 'Use the Host-defined autonomous limit.', dangerous: true, bound: '10 turns' },
+            ],
+          },
+        })
+        send(ws, { type: 'AGENT_PROFILE', ...profile })
+        send(ws, { type: 'DASHBOARD_SNAPSHOT', html: DASHBOARD_HTML })
         return
       }
 
@@ -201,6 +234,17 @@ export async function mockAgent(
       }
 
       if (msg.type !== 'INPUT') return
+
+      if (scenario === 'pr-evidence') {
+        send(ws, { type: 'thinking', id: 'evidence-thinking', status: 'done' })
+        send(ws, {
+          type: 'OUTPUT',
+          result: `Completed the release prompt: ${msg.prompt}`,
+          session: { session_id: connectedSessionId },
+        })
+        send(ws, { type: 'DASHBOARD_SNAPSHOT', html: UPDATED_DASHBOARD_HTML })
+        return
+      }
 
       // Keep the turn running until the test presses Stop. The mock records the
       // resulting OIP frame; React, not O Chat, owns that wire contract.

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -84,7 +84,7 @@ export async function mockAgent(
   let terminalErrorInputs = 0
   let codingAgentInputs = 0
   /** Authoritative policy changes only after the mock Host acknowledges OIP. */
-  let currentMode = ':read-only'
+  let currentMode = 'safe'
   let pendingModeAcknowledgement: (() => void) | null = null
   let fullAccessCheckpointSent = false
   /** Every frame the client sent. The approval buttons differ only in the frame
@@ -138,11 +138,13 @@ export async function mockAgent(
             session_id: connectedSessionId,
             status: scenario === 'mode-disconnect' && connects > 1 ? 'connected' : 'idle',
             session_modes: {
+              schemaVersion: 1,
               currentModeId: currentMode,
+              policy: { id: 'connectonion.auto-approve', version: 1 },
               availableModes: [
-                { id: ':read-only', name: 'Read only', description: 'Read freely; ask before edits, commands, or broader access.' },
-                { id: ':workspace', name: 'Auto', description: 'Edit the workspace automatically; broader actions still ask.' },
-                { id: ':danger-full-access', name: 'Full access', description: 'Use the Host-defined autonomous limit.' },
+                { id: 'safe', name: 'Safe', description: 'Read normally; unresolved effects ask.' },
+                { id: 'default', name: 'Default', description: 'Low-risk workspace work proceeds automatically.', recommended: true },
+                { id: 'full_access', name: 'Full access', description: 'Use the Host-defined autonomous limit.', dangerous: true, bound: '10 turns' },
               ],
             },
           })

--- a/e2e/mode-controls.spec.ts
+++ b/e2e/mode-controls.spec.ts
@@ -10,7 +10,7 @@ for (const viewport of [
     await page.setViewportSize({ width: viewport.width, height: viewport.height })
     await mockAgent(page)
     await page.goto(`/${AGENT_ADDRESS}`)
-    await expect(page.getByRole('button', { name: 'Auto', exact: true })).toBeVisible({ timeout: 90_000 })
+    await expect(page.getByRole('button', { name: /Default, recommended/ })).toBeVisible({ timeout: 90_000 })
 
     const metrics = await page.evaluate(() => ({
       innerWidth: window.innerWidth,
@@ -20,8 +20,8 @@ for (const viewport of [
     expect(metrics.documentWidth).toBeLessThanOrEqual(metrics.innerWidth)
     expect(metrics.bodyWidth).toBeLessThanOrEqual(metrics.innerWidth)
 
-    for (const label of ['Default', 'Plan', 'Read only', 'Auto', 'Full access']) {
-      const box = await page.getByRole('button', { name: label, exact: true }).boundingBox()
+    for (const label of [/^Plan$/, /^Safe/, /Default, recommended/, /^Full access/]) {
+      const box = await page.getByRole('button', { name: label }).boundingBox()
       expect(box, `${label} should be visible`).not.toBeNull()
       expect(box!.height, `${label} should be at least 44px tall`).toBeGreaterThanOrEqual(44)
       expect(box!.width, `${label} should be at least 44px wide`).toBeGreaterThanOrEqual(44)

--- a/e2e/pr-evidence.spec.ts
+++ b/e2e/pr-evidence.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * The mandatory pull-request evidence journey.
+ *
+ * This is deliberately one continuous browser session. Separate green tests for
+ * onboarding, modes, chat, and Control Center cannot prove the hand-offs between
+ * them, and cannot produce the one final screenshot a reviewer must inspect.
+ */
+import { test, expect } from './fixtures'
+import { mockAgent, AGENT_ADDRESS } from './mock-agent'
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('PR release evidence: invite, prompt, modes, and Control Center', async ({ page, shot }) => {
+  test.setTimeout(120_000)
+  const agent = await mockAgent(page, 'pr-evidence')
+
+  await page.goto(`/${AGENT_ADDRESS}`)
+  const gate = page.getByRole('dialog')
+  await expect(gate).toBeVisible({ timeout: 20_000 })
+  await gate.getByRole('textbox').fill('RELEASE-1.6.11')
+  await shot('01-invite-code')
+  await gate.getByRole('button', { name: /continue/i }).click()
+  await expect.poll(() => agent.sent('ONBOARD_SUBMIT').length).toBe(1)
+
+  await expect(page.getByRole('tab', { name: 'Control Center' })).toBeVisible({ timeout: 20_000 })
+  await page.getByRole('tab', { name: 'Chat' }).click()
+
+  await page.getByRole('button', { name: /Default, recommended/ }).click()
+  await expect.poll(() => agent.sent('mode_change').some(frame => frame.mode === 'default')).toBe(true)
+  await page.getByRole('button', { name: 'Plan', exact: true }).click()
+  await expect(page.getByRole('button', { name: 'Exit plan', exact: true })).toHaveAttribute('aria-pressed', 'true')
+  await page.getByRole('button', { name: 'Exit plan', exact: true }).click()
+  await page.getByRole('button', { name: 'Full access', exact: true }).click()
+  await page.getByRole('button', { name: 'Enable', exact: true }).click()
+  await expect.poll(() => agent.sent('mode_change').some(frame => frame.mode === 'full_access')).toBe(true)
+  await shot('02-modes-acknowledged')
+
+  const prompt = 'Use the deploy skill to update the Control Center for release 1.6.11'
+  await page.getByPlaceholder(/message/i).fill(prompt)
+  await page.keyboard.press('Enter')
+  await expect(page.getByText(`Completed the release prompt: ${prompt}`)).toBeVisible({ timeout: 20_000 })
+  await shot('03-prompt-and-skill')
+
+  await page.getByRole('tab', { name: 'Control Center' }).click()
+  await expect(page.frameLocator('iframe').getByText('Release 1.6.11 verified')).toBeVisible({ timeout: 20_000 })
+  await expect(page.frameLocator('iframe').getByText(/Invite accepted.*prompt completed.*execution modes acknowledged/)).toBeVisible()
+  await shot('complete-flow')
+})

--- a/e2e/remove-agent.spec.ts
+++ b/e2e/remove-agent.spec.ts
@@ -23,6 +23,14 @@ function storedAgents(page: import('@playwright/test').Page) {
   })
 }
 
+/** Open the intentionally tucked-away destructive action in the phone drawer. */
+async function chooseRemoveAgent(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: /menu/i }).first().click()
+  const drawer = page.locator('aside')
+  await drawer.getByRole('button', { name: /actions for/i }).first().click()
+  await drawer.getByRole('button', { name: /remove agent/i }).first().click()
+}
+
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
@@ -34,8 +42,7 @@ test.describe('phone', () => {
 
     expect(await storedAgents(page)).toContain(AGENT_ADDRESS)
 
-    await page.getByRole('button', { name: /menu/i }).first().click()
-    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await chooseRemoveAgent(page)
     await page.getByRole('button', { name: /^remove$/i }).first().click()
 
     await expect
@@ -51,8 +58,7 @@ test.describe('phone', () => {
     await page.getByRole('button', { name: 'What can you do?' }).click()
     await expect(page.getByText('You said: What can you do?')).toBeVisible({ timeout: 20_000 })
 
-    await page.getByRole('button', { name: /menu/i }).first().click()
-    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await chooseRemoveAgent(page)
     await page.getByRole('button', { name: /^remove$/i }).first().click()
     await page.waitForTimeout(2000)
 
@@ -81,8 +87,7 @@ test.describe('phone', () => {
     await page.goto(`/${AGENT_ADDRESS}`)
     await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible({ timeout: 20_000 })
 
-    await page.getByRole('button', { name: /menu/i }).first().click()
-    await page.locator('aside').getByRole('button', { name: /remove agent/i }).first().click()
+    await chooseRemoveAgent(page)
     await page.getByRole('button', { name: /^remove$/i }).first().click()
     await expect.poll(() => storedAgents(page), { timeout: 10_000 }).not.toContain(AGENT_ADDRESS)
 

--- a/e2e/two-agents.spec.ts
+++ b/e2e/two-agents.spec.ts
@@ -64,16 +64,15 @@ test.describe('phone', () => {
     await expect(drawer.getByText(PROFILE.name)).toBeVisible()
     await expect(drawer.getByText(SECOND_PROFILE.name)).toBeVisible()
 
-    const first = await drawer.getByText(PROFILE.name).first().boundingBox()
-    const second = await drawer.getByText(SECOND_PROFILE.name).first().boundingBox()
-    const firstThread = await drawer.getByText('first thread').first().boundingBox()
-    const secondThread = await drawer.getByText('second thread').first().boundingBox()
+    const firstAgent = drawer.locator(`[data-agent-address="${AGENT_ADDRESS}"]`)
+    const secondAgent = drawer.locator(`[data-agent-address="${SECOND_ADDRESS}"]`)
 
-    // Each thread sits below its own agent and above the next one — the ordering
-    // is what a reader uses to tell whose conversation this is.
-    expect(firstThread!.y, 'the first thread is not under its agent').toBeGreaterThan(first!.y)
-    expect(secondThread!.y, 'the second thread is not under its agent').toBeGreaterThan(second!.y)
-    expect(firstThread!.y, 'the threads are interleaved between agents').toBeLessThan(second!.y)
+    // Status-first sorting may move either Agent. Ownership is structural: each
+    // thread must stay inside its address-keyed Agent group and out of the other.
+    await expect(firstAgent.getByText('first thread')).toBeVisible()
+    await expect(firstAgent.getByText('second thread')).toHaveCount(0)
+    await expect(secondAgent.getByText('second thread')).toBeVisible()
+    await expect(secondAgent.getByText('first thread')).toHaveCount(0)
 
     await shot('drawer')
   })

--- a/hooks/use-agent-info.ts
+++ b/hooks/use-agent-info.ts
@@ -56,13 +56,13 @@ export function useAgentInfo(addresses: string[]): Record<string, AgentInfo> {
           return { ...prev, [addr]: info }
         })
       }).catch(() => {
-        // Transient fetch error: reflect offline in the live map but DON'T write
-        // it to infoCache — a network blip shouldn't overwrite the last-known
-        // (likely online) status that seeds the next remount. Keep the other
-        // fields (name, etc.) so the sidebar doesn't degrade to a hex label.
+        // A transport failure is unknown, not authoritative offline. Preserve
+        // last-known data; without any, leave the map entry absent so navigation
+        // never hides an Agent on a blip.
         setInfoMap(prev => {
-          if (prev[addr]?.online === false) return prev
-          return { ...prev, [addr]: { ...(prev[addr] ?? infoCache[addr]), address: addr, online: false } }
+          const known = prev[addr] ?? infoCache[addr]
+          if (!known || prev[addr] === known) return prev
+          return { ...prev, [addr]: known }
         })
       })
     }

--- a/lib/agent-order.test.ts
+++ b/lib/agent-order.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { orderAgents } from './agent-order'
+
+const info = (name: string, online: boolean) => ({ address: name, name, online })
+
+describe('orderAgents', () => {
+  it('pins selected, then orders online, unknown, and offline', () => {
+    const result = orderAgents(
+      ['offline', 'unknown', 'online', 'selected'],
+      {
+        offline: info('Offline', false),
+        unknown: undefined,
+        online: info('Online', true),
+        selected: info('Selected', false),
+      },
+      'selected',
+    )
+    expect(result.map(item => [item.address, item.presence])).toEqual([
+      ['selected', 'offline'],
+      ['online', 'online'],
+      ['unknown', 'unknown'],
+      ['offline', 'offline'],
+    ])
+  })
+
+  it('uses activity, name, then address as deterministic tie-breakers', () => {
+    const result = orderAgents(
+      ['z', 'b', 'a'],
+      { z: info('Zulu', true), b: info('Alpha', true), a: info('Alpha', true) },
+      null,
+      { z: 20, b: 10, a: 10 },
+    )
+    expect(result.map(item => item.address)).toEqual(['z', 'a', 'b'])
+  })
+})

--- a/lib/agent-order.ts
+++ b/lib/agent-order.ts
@@ -1,0 +1,40 @@
+import type { AgentInfo } from '@connectonion/react'
+
+export type AgentPresence = 'online' | 'unknown' | 'offline'
+
+export interface AgentOrderItem {
+  address: string
+  presence: AgentPresence
+  selected: boolean
+}
+
+export function agentPresence(info?: AgentInfo): AgentPresence {
+  if (info?.online === true) return 'online'
+  if (info?.online === false) return 'offline'
+  return 'unknown'
+}
+
+/** Stable, shared ordering for navigation and management surfaces. */
+export function orderAgents(
+  addresses: string[],
+  infoMap: Record<string, AgentInfo | undefined>,
+  selectedAddress?: string | null,
+  recentActivity: Record<string, number> = {},
+): AgentOrderItem[] {
+  const rank: Record<AgentPresence, number> = { online: 0, unknown: 1, offline: 2 }
+
+  return addresses.map(address => ({
+    address,
+    presence: agentPresence(infoMap[address]),
+    selected: address === selectedAddress,
+  })).sort((a, b) => {
+    if (a.selected !== b.selected) return a.selected ? -1 : 1
+    if (rank[a.presence] !== rank[b.presence]) return rank[a.presence] - rank[b.presence]
+    const activityDelta = (recentActivity[b.address] ?? 0) - (recentActivity[a.address] ?? 0)
+    if (activityDelta) return activityDelta
+    const aName = (infoMap[a.address]?.name || '').trim().toLocaleLowerCase()
+    const bName = (infoMap[b.address]?.name || '').trim().toLocaleLowerCase()
+    const nameDelta = aName.localeCompare(bName)
+    return nameDelta || a.address.localeCompare(b.address)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.11",
+        "@connectonion/react": "0.4.2-alpha.12",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.11",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.11.tgz",
-      "integrity": "sha512-CLNE7MBwfCggf3EcAjJU2kPgSi1XjsgfpT0cbR9bbaTVVChVTxvz93sHuRqpMigE+b0OArQJJ2MvTUzH8liWlw==",
+      "version": "0.4.2-alpha.12",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.12.tgz",
+      "integrity": "sha512-ZjgW6XeJfoJwlAWxUn7Rr9o6Mt9B0E98LwDbaYxypxhH2fv2SF8qm8wCLDD8nePa2606tx/V0mF5Eqxp8hmmOw==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.11",
+    "@connectonion/react": "0.4.2-alpha.12",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Outcome

Ships the O Chat side of ConnectOnion 1.6.11 Control Center and versioned execution profiles.

- renames Dashboard to Control Center across responsive UI and accessibility labels
- consumes @connectonion/react 0.4.2-alpha.12 and uses acknowledged Safe / Default / Full access Host profiles
- keeps Plan as a separate workflow mode
- makes Full access an explicit two-step, Host-bound choice
- adds safe, accessible co-chart rendering and shared Control Center visual tokens
- simplifies the sidebar into a quiet Agent-first hierarchy: one status row, conversations as a secondary disclosure, and destructive actions behind a labelled menu
- sorts Agents status-first with the selected Agent pinned, unknown preserved, and offline Agents disclosed instead of forgotten
- requires every future PR to upload one continuous invite → prompt/skill → modes → Control Center browser evidence run and final review screenshot

Closes #38
Closes #181
Closes #182

## Verification

- npm test: 120 tests passed
- npm run lint: passed
- npm run build: passed, including TypeScript and static generation
- focused Control Center tests: 49 passed
- sidebar/mobile browser tests: 10 passed
- mandatory PR release evidence journey: passed locally; CI uploads four screenshots plus the final complete-flow frame
- responsive Control Center inspected at 320, 440, and 900 px with no horizontal overflow or console errors
- redesigned mobile sidebar screenshot inspected at 375 px