### PR TITLE
feat: simplify the native coding Work Room

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,165 @@
+# Work Room: simple, safe, observable
+
+## Decision gate
+
+This plan follows the first independent UI and interaction audits recorded in
+oo-chat#187 and the OIP contract follow-up in connectonion#1109. No release is
+ready until every required gate below has evidence from a real native Codex C
+sorting run. This is OIP-only: it must not restore ACP UI or add a generic third
+coding adapter.
+
+## Product contract
+
+The product has four separate information layers. A reader should never have to
+parse source code or provider transport to understand the default screen.
+
+1. **Conversation summary** — who is working, current natural-language action,
+   current state or concise result, and one entry action.
+2. **Decision** — approval meaning, verified boundary, reason, and a deliberate
+   action. This lives in the Work Room, not in the transcript.
+3. **Evidence** — semantic activity, checks, files, and a genuine provider
+   artifact if one exists.
+4. **Technical detail** — bounded, redacted per-step detail behind explicit
+   disclosure. It is never the default view.
+
+## UI design to implement
+
+### Parent conversation card
+
+- Normal height is approximately 96px; approval state may grow to approximately
+  124px, never into a terminal transcript.
+- It shows a safe task title, one current semantic action, state/result, and one
+  action: **Open Work Room** or **Review decision**.
+- It contains no raw command, cwd, session identifier, JSON, local path, tool
+  result, or fabricated terminal/screenshot treatment.
+- If there is no real provider artifact, use the literal label **Real-time
+  activity**, not "thumbnail", "screen", or a terminal-like panel.
+- Completion includes a concise verified outcome; failure includes the last safe
+  checkpoint and next action.
+
+### Work Room
+
+- The default is **Overview**: safe task title, progress/check summary, current
+  activity, at most three recent semantic steps, and a short file list only
+  when Core supplied genuine file evidence.
+- **Activity** is the one secondary section. Files belong inline in Overview;
+  Messages and technical disclosure are not rendered until they have a real
+  typed OIP contract. This keeps the default to two clear levels rather than
+  three competing page tabs.
+- There is one vertical scrolling surface. "Show earlier steps" expands inside
+  that surface; it must not create a second hidden scroll region.
+- The dialog opens with focus in the current decision or heading, traps focus,
+  makes the background inert, restores focus to its opener, announces new
+  blocking decisions, and supports Escape.
+- The Work Room is the only place that can show technical detail or approval
+  controls. Stop identifies the target provider session and moves to a disabled
+  stopping state after one click.
+
+## Current delivery checklist
+
+- [x] OIP-only native Codex and Claude Code envelope; no ACP fallback is added.
+- [x] Core emits a finite, redacted task/activity/approval vocabulary and
+  React rejects arbitrary provider text rather than rendering transport data.
+- [x] Unknown and elevated approval boundaries fail closed.
+- [x] A targeted Stop sends `PROVIDER_INTERRUPT` for the exact invocation and
+  does not send a global turn interrupt.
+- [x] Simplified information hierarchy: compact card; Overview + Activity;
+  real file evidence inline only; no fabricated thumbnail.
+- [x] Core unit gate, React contract gate, O Chat type gate, and O Chat unit
+  gate pass for the current slice.
+- [x] Complete browser acceptance for the long C-sorting mock, targeted Stop,
+  approval, desktop, 375px, and 320px views; inspect the captured screenshots.
+  All nine Chromium scenarios passed after the final mobile and stopped-state
+  changes.
+- [x] Run the same C-sorting task through a real native Codex invocation in an
+  isolated workspace, then record only its safe OIP evidence. The localhost
+  Host run exercised two one-time approvals, completed a strict C11 rebuild
+  and test run, and a separate run proved exact provider Stop reaches a
+  `cancelled` terminal state without cancelling the outer turn.
+- [ ] Define and implement a real `provider_continuation` protocol before any
+  continuation composer is exposed. Do not ship a fake chat input.
+- [ ] Update preview package/repository pins, release notes, deployment skill,
+  PRs/issues, and alpha release only after all acceptance gates are green.
+
+### Approval presentation
+
+- First show **what will happen**, **where it applies**, and **why** in
+  non-technical language. Core—not the browser—provides verified scope.
+- **Allow once** and **Reject this request** are the two equally reachable
+  decision actions. This is not a global Stop: it resolves the current native
+  permission request only.
+- **Trust for this session** and **Reject and ask for an explanation** live
+  under Other review options. **Stop** appears only for a starting/running
+  provider invocation, targets its exact invocation ID, and never appears
+  while an approval is waiting.
+- A scope outside the declared Work Room is elevated and cannot receive an
+  ordinary allow action.
+- Technical arguments are redacted and disclosed only on demand.
+
+## OIP / React contract required before the final UI claims
+
+Core translates Codex and Claude Code native events into typed, provider-neutral
+events. React normalizes ordering, replay, compatibility, and action
+correlation. O Chat renders that type only.
+
+Required additive forms:
+
+- `provider_invocation`: stable IDs, safe `taskTitle`, `currentSummary`,
+  permission mode, terminal `resultSummary` or safe error.
+- `provider_activity`: stable sequence and invocation correlation; semantic
+  kind/state/title/summary; safe relative files/checks; bounded technical detail.
+- `approval_needed` with `providerApproval`: native request correlation; human
+  summary; Core-verified scope classification; authoritative resolution
+  options. The browser must fail closed if that presentation is absent.
+- `provider_artifact`: optional real renderable evidence, source, alt text,
+  timestamp, and activity correlation. No artifact means no preview image.
+- `provider_continuation`: invocation/session/client-message correlation and
+  explicit Sending, Queued, Delivered, Running, Completed, or Failed lifecycle.
+
+Old Hosts retain the generic correlated-tool fallback. That fallback is labelled
+legacy activity and cannot be presented as verified files, checks, or visuals.
+The current remote `@connectonion/react` OIP reader already removed ACP from
+its active path; implementation starts from that current reader and must never
+restore ACP as a second path. The older local checkout is not a valid source.
+
+## Implementation order
+
+1. **Contract first** — write Core and React fixtures for the envelope, ordering,
+   scope validation, artifact absence, and old-host fallback. Publish a React
+   preview reader before Core writes new fields.
+2. **Safe interactions** — implement approval information architecture, dialog
+   focus/keyboard behavior, and targeted Stop against those fixtures.
+3. **Presentation** — implement the parent summary and Work Room Overview,
+   then one secondary Activity view. Inline files appear only with typed evidence.
+4. **Evidence** — add an actual native Codex C sorting run and the equivalent
+   Claude Code run. Do not use an injected screenshot or a toy one-shot prompt.
+5. **Release** — require green unit/type/lint/browser gates, GitHub preview,
+   production Vercel deployment, public package verification where package code
+   changed, and a final browser replay.
+
+## Required real C acceptance flow
+
+Use a fresh, dedicated workspace only. Native Codex must inspect it, describe a
+plan, create `sort.c` and `test_sort.c`, inspect both, compile with strict C11
+warnings, run at least three sort inputs, run the test binary, inspect final
+sources/output, and report checks. The run must create at least eight observable
+transitions. A continuation is a separate acceptance item only once the typed
+continuation protocol exists.
+
+Capture and inspect desktop and 375px screenshots for: running parent card,
+approval, Work Room overview, Activity, completion, failure handling, and
+targeted Stop. Verify no horizontal overflow, no double scroll, no raw data in
+the parent card, 44px-or-larger critical touch targets, and a single clear next
+action. Also test a 320px approval viewport.
+
+## Review gate for every implementation round
+
+Before starting a new implementation slice and after taking its screenshots:
+
+1. a UI review ranks visual hierarchy, density, truthfulness of evidence,
+   desktop/mobile composition, and accessibility; and
+2. an interaction review ranks the ten largest remaining user/safety risks,
+   including approval, continuation, result accuracy, Stop, focus, and mobile.
+
+Any P0 finding blocks release. The next implementation slice starts only after
+the findings, exact acceptance checks, and responsible layer are recorded.

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -158,6 +158,7 @@ export default function ChatSessionPage() {
     reconnect,
     connect,
     interrupt,
+    interruptProvider,
     dashboardHtml,
     profile,
   } = useAgentSDK({
@@ -340,6 +341,7 @@ export default function ChatSessionPage() {
           ui={transcriptUI}
           onSend={handleSend}
           onStop={interrupt}
+          onProviderStop={interruptProvider}
           isLoading={isLoading}
           inputDisabled={permissionProfileChangePending}
           suggestions={[]}

--- a/components/chat/chat-approval.tsx
+++ b/components/chat/chat-approval.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import type { PendingApproval } from './types'
 import { ApprovalButtons, type ApprovalState } from './messages/tools/approval-buttons'
-import { KVRows } from './messages/tools/kv-rows'
 
 interface ChatApprovalProps {
   approval: PendingApproval
@@ -15,11 +14,26 @@ interface ChatApprovalProps {
   ) => void
 }
 
-/** Decision surface for a permission request that has no separate tool update. */
+function safeFallback(approval: PendingApproval): NonNullable<PendingApproval['providerApproval']> {
+  const provider = approval.provider === 'codex' ? 'Codex' : approval.provider === 'claude_code' ? 'Claude Code' : 'The agent'
+  const nativeProvider = approval.provider === 'codex' || approval.provider === 'claude_code'
+  return {
+    action: `${provider} requested an action`,
+    scope: nativeProvider ? 'Boundary could not be verified' : 'This request only',
+    reason: 'Review the request before allowing it to continue',
+    scopeClassification: 'unknown' as const,
+    // A missing native presentation is not evidence that the request is small.
+    // Generic framework approvals retain their normal one-shot decision, but a
+    // Codex/Claude request without Core verification must fail closed.
+    allowOnce: !nativeProvider,
+    allowSession: false,
+  }
+}
+
+/** A safe decision surface: default content never renders raw approval arguments. */
 export function ChatApproval({ approval, onResponse }: ChatApprovalProps) {
   const [approvalSent, setApprovalSent] = useState<ApprovalState>(null)
-  const toolName = approval.tool.split(':')[0]
-  const hasArguments = Object.keys(approval.arguments).length > 0
+  const presentation = approval.providerApproval || safeFallback(approval)
 
   const handleApproval = (
     approved: boolean,
@@ -33,26 +47,30 @@ export function ChatApproval({ approval, onResponse }: ChatApprovalProps) {
   }
 
   return (
-    <section
-      aria-label={`Approval required for ${toolName}`}
-      className="my-2 overflow-hidden rounded-lg border border-neutral-200 bg-white px-3 py-2 shadow-sm"
-    >
-      <div className="flex items-baseline gap-2">
-        <span className="text-xs font-medium uppercase tracking-wide text-neutral-500">Approval required</span>
-        <span className="font-mono text-sm font-semibold text-neutral-800">{toolName}</span>
-      </div>
-
-      {hasArguments && (
-        <div className="mt-2 rounded-md bg-neutral-50 px-3 py-2">
-          <KVRows data={approval.arguments} />
+    <section aria-label="Approval required" className="rounded-xl bg-white p-4 sm:p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">Needs your decision</p>
+      <h2 className="mt-1 text-base font-semibold text-neutral-950">{presentation.action}</h2>
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-lg bg-neutral-50 p-3">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Where</dt>
+          <dd className="mt-1 text-sm font-medium text-neutral-900">{presentation.scope}</dd>
         </div>
-      )}
-
+        <div className="rounded-lg bg-neutral-50 p-3">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Why</dt>
+          <dd className="mt-1 text-sm font-medium text-neutral-900">{presentation.reason}</dd>
+        </div>
+      </dl>
+      {presentation.files?.length ? (
+        <p className="mt-3 text-sm text-neutral-600">Files: {presentation.files.join(', ')}</p>
+      ) : null}
       <ApprovalButtons
         approvalSent={approvalSent}
         onApproval={handleApproval}
-        toolName={toolName}
-        description={approval.description}
+        allowOnce={presentation.allowOnce}
+        allowSession={presentation.allowSession}
+        blockedMessage={presentation.scopeClassification === 'unknown'
+          ? 'The Work Room boundary could not be verified, so this request cannot be allowed here.'
+          : undefined}
         batchRemaining={approval.batch_remaining}
       />
     </section>

--- a/components/chat/chat-approval.tsx
+++ b/components/chat/chat-approval.tsx
@@ -48,7 +48,7 @@ export function ChatApproval({ approval, onResponse }: ChatApprovalProps) {
 
   return (
     <section aria-label="Approval required" className="rounded-xl bg-white p-4 sm:p-5">
-      <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">Needs your decision</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-neutral-700">Needs your decision</p>
       <h2 className="mt-1 text-base font-semibold text-neutral-950">{presentation.action}</h2>
       <dl className="mt-4 grid gap-3 sm:grid-cols-2">
         <div className="rounded-lg bg-neutral-50 p-3">

--- a/components/chat/chat-messages.test.tsx
+++ b/components/chat/chat-messages.test.tsx
@@ -7,16 +7,23 @@ import type { ChatItem } from '@connectonion/react'
 import { ChatMessages } from './chat-messages'
 import type { PendingApproval } from './types'
 
-// The message barrel pulls in every specialised tool renderer, including modules
-// whose Next.js path alias is not configured in Vitest. This suite is about the
-// decision placement in ChatMessages, so keep unrelated renderers outside it.
+// This suite checks where a decision is placed. Keep unrelated specialised tool
+// renderers out of the DOM; the real approval surface is intentionally retained.
 vi.mock('./messages', () => {
   const EmptyMessage = () => null
   const ToolCall = ({ pendingApproval }: { pendingApproval?: PendingApproval }) => (
-    pendingApproval ? <button type="button">Allow once</button> : null
+    pendingApproval ? <button type="button">Inline allow once</button> : null
   )
-  const CodingAgentCard = ({ pendingApproval }: { pendingApproval?: PendingApproval | null }) => (
-    pendingApproval ? <button type="button">Allow Codex once</button> : <span>Codex card</span>
+  const CodingAgentCard = ({
+    invocation,
+    pendingApproval,
+  }: {
+    invocation: { id: string }
+    pendingApproval?: PendingApproval | null
+  }) => (
+    <div data-provider-card={invocation.id}>
+      {pendingApproval ? <span data-native-decision="">Native decision</span> : <span>Provider card</span>}
+    </div>
   )
   return {
     User: EmptyMessage,
@@ -63,10 +70,16 @@ function render(ui: ChatItem[], pendingApproval: PendingApproval, onApprovalResp
   return { element: container, onApprovalResponse }
 }
 
-function buttonNamed(element: HTMLElement, name: string) {
-  return Array.from(element.querySelectorAll('button')).find(button =>
+function buttonNamed(element: ParentNode, name: string) {
+  return Array.from(element.querySelectorAll<HTMLButtonElement>('button')).find(button =>
     button.textContent?.replace(/\s+/g, ' ').trim().startsWith(name),
   )
+}
+
+function revealMoreOptions(element: ParentNode) {
+  const more = element.querySelector<HTMLElement>('summary')
+  if (!more) throw new Error('More options was not rendered')
+  act(() => more.click())
 }
 
 afterEach(() => {
@@ -78,7 +91,7 @@ afterEach(() => {
 
 const approval: PendingApproval = {
   tool: 'write',
-  arguments: { path: 'release.txt' },
+  arguments: { path: '/private/tmp/release.txt', command: 'echo release > release.txt' },
   description: 'Write the release marker',
 }
 
@@ -89,33 +102,33 @@ const approvalItem: ChatItem = {
 }
 
 describe('ChatMessages permission decisions', () => {
-  it('renders every decision for a normalized permission without a tool update', () => {
+  it('renders a standalone generic approval with no raw arguments or broad trust action', () => {
     const { element } = render([approvalItem], approval)
 
-    expect(element.querySelector('[aria-label="Approval required for write"]')).not.toBeNull()
+    expect(element.querySelector('[aria-label="Approval required"]')).not.toBeNull()
     expect(element.querySelector('[data-pending-decision]')).not.toBeNull()
-    expect(element.textContent).toContain('release.txt')
+    expect(element.textContent).toContain('Needs your decision')
+    expect(element.textContent).not.toContain('/private/tmp/release.txt')
+    expect(element.textContent).not.toContain('echo release')
     expect(buttonNamed(element, 'Allow once')).toBeDefined()
-    expect(buttonNamed(element, 'Trust write')).toBeDefined()
-    expect(buttonNamed(element, 'Reject')).toBeDefined()
-    expect(buttonNamed(element, 'Stop')).toBeDefined()
-    expect(buttonNamed(element, 'Explain')).toBeDefined()
+    expect(buttonNamed(element, 'Trust write')).toBeUndefined()
+    expect(buttonNamed(element, 'Stop')).toBeUndefined()
+  })
 
+  it('routes Allow once through the typed approval callback', () => {
+    const { element, onApprovalResponse } = render([approvalItem], approval)
+    act(() => buttonNamed(element, 'Allow once')!.click())
+    expect(onApprovalResponse).toHaveBeenCalledWith(true, 'once', undefined)
   })
 
   it.each([
-    ['Allow once', true, 'once', undefined],
-    ['Trust write', true, 'session', undefined],
-    ['Reject', false, 'once', 'reject_soft'],
-    ['Stop', false, 'once', 'reject_hard'],
-    ['Explain', false, 'once', 'reject_explain'],
-  ] as const)('routes %s through the typed approval callback', (label, approved, scope, mode) => {
+    ['Reject this request', 'reject_soft'],
+    ['Reject and ask for an explanation', 'reject_explain'],
+  ] as const)('routes %s through the typed approval callback', (label, mode) => {
     const { element, onApprovalResponse } = render([approvalItem], approval)
-
+    if (label !== 'Reject this request') revealMoreOptions(element)
     act(() => buttonNamed(element, label)!.click())
-
-    expect(onApprovalResponse).toHaveBeenCalledOnce()
-    expect(onApprovalResponse).toHaveBeenCalledWith(approved, scope, mode)
+    expect(onApprovalResponse).toHaveBeenCalledWith(false, 'once', mode)
   })
 
   it('keeps approval inline when a matching running tool card exists', () => {
@@ -128,15 +141,12 @@ describe('ChatMessages permission decisions', () => {
     }
     const { element } = render([toolItem, approvalItem], approval)
 
-    expect(element.querySelector('[aria-label="Approval required for write"]')).toBeNull()
-    const allowOnceButtons = Array.from(element.querySelectorAll('button')).filter(button =>
-      button.textContent?.includes('Allow once'),
-    )
-    expect(allowOnceButtons).toHaveLength(1)
+    expect(element.querySelector('[aria-label="Approval required"]')).toBeNull()
+    expect(buttonNamed(element, 'Inline allow once')).toBeDefined()
     expect(element.querySelectorAll('[data-pending-decision]')).toHaveLength(1)
   })
 
-  it('attaches a correlated native approval to its exact provider card, not a generic codex tool', () => {
+  it('attaches a native approval only to its exact provider invocation', () => {
     const provider = {
       id: 'codex:outer',
       type: 'provider_invocation',
@@ -147,20 +157,39 @@ describe('ChatMessages permission decisions', () => {
       activities: [],
     } as ChatItem
     const genericCodexTool: ChatItem = {
-      id: 'generic-codex', type: 'tool_call', name: 'codex', status: 'running',
+      id: 'generic-codex', type: 'tool_call', name: 'codex', status: 'running', args: {},
     }
     const correlated: PendingApproval = {
       id: 'approval-codex',
       tool: 'codex',
-      arguments: { action: 'Run pytest' },
+      arguments: {},
       provider: 'codex',
       providerInvocationId: 'codex:outer',
       parentToolCallId: 'outer',
     }
 
     const { element } = render([genericCodexTool, provider], correlated)
-
-    expect(element.textContent).toContain('Allow Codex once')
+    const card = element.querySelector<HTMLElement>('[data-provider-card="codex:outer"]')!
+    expect(card.querySelector('[data-native-decision]')).not.toBeNull()
+    expect(buttonNamed(element, 'Inline allow once')).toBeUndefined()
     expect(element.querySelectorAll('[data-pending-decision]')).toHaveLength(1)
+  })
+
+  it('does not merge separate provider runs merely because their session is the same', () => {
+    const first = {
+      id: 'codex:first', type: 'provider_invocation', parentToolCallId: 'first',
+      provider: 'codex', providerDisplayName: 'Codex', status: 'completed',
+      sessionId: 'shared-native-session', activities: [],
+    } as ChatItem
+    const second = {
+      id: 'codex:second', type: 'provider_invocation', parentToolCallId: 'second',
+      provider: 'codex', providerDisplayName: 'Codex', status: 'running',
+      sessionId: 'shared-native-session', activities: [],
+    } as ChatItem
+
+    const { element } = render([first, second], approval)
+    expect(element.querySelectorAll('[data-provider-card]')).toHaveLength(2)
+    expect(element.querySelector('[data-provider-card="codex:first"]')).not.toBeNull()
+    expect(element.querySelector('[data-provider-card="codex:second"]')).not.toBeNull()
   })
 })

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -26,7 +26,7 @@ export function ChatMessages({
   ui = [],
   className,
   onStop,
-  onProviderMessage,
+  onProviderStop,
   pendingApproval,
   onApprovalResponse,
   pendingAskUser,
@@ -57,14 +57,6 @@ export function ChatMessages({
   // scroll back through at all.
   const pinnedTopRef = useRef(-1)
   const [showScrollDown, setShowScrollDown] = useState(false)
-  const [expandedInvocations, setExpandedInvocations] = useState<string[]>([])
-
-  const toggleInvocation = (id: string) => {
-    setExpandedInvocations(current => current.includes(id)
-      ? current.filter(value => value !== id)
-      : [...current, id].slice(-2))
-  }
-
   const handleScroll = () => {
     const el = scrollRef.current
     if (!el) return
@@ -190,7 +182,7 @@ export function ChatMessages({
         aria-label="Conversation"
         className="mx-auto max-w-3xl space-y-1"
       >
-        {ui.map((item, itemIndex) => {
+        {ui.map(item => {
           switch (item.type) {
             case 'user':
               return <User key={item.id} message={item} />
@@ -228,33 +220,19 @@ export function ChatMessages({
               )
             }
             case 'provider_invocation': {
-              const alreadyRenderedForSession = item.sessionId
-                && ui.slice(0, itemIndex).some(candidate =>
-                  candidate.type === 'provider_invocation'
-                  && candidate.provider === item.provider
-                  && candidate.sessionId === item.sessionId,
-                )
-              if (alreadyRenderedForSession) return null
-              const continuations = item.sessionId
-                ? ui.slice(itemIndex + 1).filter((candidate): candidate is typeof item =>
-                    candidate.type === 'provider_invocation'
-                    && candidate.provider === item.provider
-                    && candidate.sessionId === item.sessionId)
-                : []
-              const approvalForProvider = [item, ...continuations].some(candidate =>
-                approvalMatchesProvider(pendingApproval, candidate),
-              ) ? pendingApproval : undefined
+              // Session IDs are provider state, not a safe continuation key.
+              // Do not merge two outer invocations by array position or session:
+              // a future provider_continuation envelope supplies explicit IDs.
+              const approvalForProvider = approvalMatchesProvider(pendingApproval, item)
+                ? pendingApproval
+                : undefined
               return (
                 <div key={item.id} {...(approvalForProvider ? { 'data-pending-decision': '' } : {})}>
                   <CodingAgentCard
                     invocation={item}
-                    continuations={continuations}
-                    expanded={expandedInvocations.includes(item.id)}
-                    onToggle={() => toggleInvocation(item.id)}
-                    onStop={onStop}
-                    onMessageProvider={message => onProviderMessage?.(item, message)}
                     pendingApproval={approvalForProvider}
                     onApprovalResponse={approvalForProvider ? onApprovalResponse : undefined}
+                    onProviderStop={onProviderStop}
                   />
                 </div>
               )

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -25,7 +25,6 @@ function approvalMatchesProvider(
 export function ChatMessages({
   ui = [],
   className,
-  onStop,
   onProviderStop,
   pendingApproval,
   onApprovalResponse,

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -15,6 +15,7 @@ export function Chat({
   ui = [],
   onSend,
   onStop,
+  onProviderStop,
   isLoading = false,
   inputDisabled = false,
   placeholder = 'Send a message...',
@@ -198,9 +199,7 @@ export function Chat({
             ui={ui}
             isLoading={isLoading}
             onStop={onStop}
-            onProviderMessage={(invocation, message) => onSend(
-              `[Work Room → ${invocation.providerDisplayName}${invocation.sessionId ? ` session ${invocation.sessionId}` : ''}] ${message}`,
-            )}
+            onProviderStop={onProviderStop}
             pendingApproval={pendingApproval}
             onApprovalResponse={onApprovalResponse}
             pendingAskUser={pendingAskUser}

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -198,7 +198,6 @@ export function Chat({
           <ChatMessages
             ui={ui}
             isLoading={isLoading}
-            onStop={onStop}
             onProviderStop={onProviderStop}
             pendingApproval={pendingApproval}
             onApprovalResponse={onApprovalResponse}

--- a/components/chat/messages/coding-agent-activity.ts
+++ b/components/chat/messages/coding-agent-activity.ts
@@ -2,11 +2,40 @@ import type { ProviderInvocationUI } from '../types'
 
 export type ProviderActivity = ProviderInvocationUI['activities'][number]
 
+export function providerPermissionLabel(mode: ProviderInvocationUI['permissionMode']) {
+  return mode === 'auto_approve'
+    ? 'Auto (workspace)'
+    : mode === 'full_access'
+      ? 'Full access'
+      : 'Manual'
+}
+
+export function providerPermissionBoundary(mode: ProviderInvocationUI['permissionMode']) {
+  return mode === 'auto_approve'
+    ? 'Workspace actions are automatic; broader requests still need review.'
+    : mode === 'full_access'
+      ? 'This run has the Host-approved full-access boundary.'
+      : 'Each request needs your review.'
+}
+
 export function allProviderActivities(
   invocation: ProviderInvocationUI,
   continuations: ProviderInvocationUI[] = [],
 ) {
-  return [invocation, ...continuations].flatMap(item => item.activities)
+  const activities: ProviderActivity[] = []
+  for (const item of [invocation, ...continuations]) {
+    for (const activity of item.activities) {
+      const index = activities.findIndex(candidate => candidate.id === activity.id)
+      if (index < 0) {
+        activities.push(activity)
+      } else if (activity.legacy === false) {
+        // A typed OIP activity is the authoritative, redacted representation of
+        // the same native step. Never keep the generic raw compatibility item.
+        activities[index] = activity
+      }
+    }
+  }
+  return activities
 }
 
 export function latestProviderActivity(
@@ -23,9 +52,12 @@ export function latestProviderActivity(
  * falling back to a stable, provider-specific heading for everything else.
  */
 export function compactProviderTaskHeading(
+  taskTitle: string | undefined,
   taskSummary: string | undefined,
   providerDisplayName: string,
 ) {
+  const title = taskTitle?.replace(/\s+/g, ' ').trim()
+  if (title && title.length <= 96) return title
   const summary = taskSummary?.replace(/\s+/g, ' ').trim()
   if (!summary || summary.length > 80) return `${providerDisplayName} work room`
   return summary
@@ -35,23 +67,29 @@ export function compactProviderTaskHeading(
 export function providerSnapshotSummary(
   status: ProviderInvocationUI['status'],
   activity: ProviderActivity | undefined,
+  currentSummary?: string,
 ) {
-  if (status === 'awaiting_approval') return 'Waiting for your approval'
-  if (status === 'completed') return 'Completed the work'
-  if (status === 'failed') return 'Work stopped before completion'
-  if (status === 'cancelled') return 'Work stopped'
-  return activitySummary(activity, true)
+  if (status === 'completed') return currentSummary || 'Completed the work'
+  if (status === 'failed') return currentSummary || 'Work stopped before completion'
+  if (status === 'cancelled') return currentSummary || 'Work stopped'
+  if (status === 'awaiting_approval') return currentSummary || 'Waiting for your approval'
+  // Provider invocation fields are an initial state snapshot. Once a typed
+  // activity arrives, its finite semantic phase is fresher and more useful
+  // than a permanently repeated "Working in the selected workspace" label.
+  return activity ? activitySummary(activity, true) : currentSummary || 'Preparing the workroom'
 }
 
 /** A short human description; raw commands and outputs stay behind disclosure. */
 export function activitySummary(activity: ProviderActivity | undefined, running: boolean) {
   if (!activity) return running ? 'Preparing the workroom' : 'No provider activity recorded'
+  if (activity.summary) return activity.summary
+  if (activity.title) return activity.title
   const command = typeof activity.args?.command === 'string'
     ? activity.args.command.toLowerCase()
     : ''
   const path = typeof activity.args?.file_path === 'string'
     || typeof activity.args?.path === 'string'
-  const name = activity.name.toLowerCase()
+  const name = activity.name?.toLowerCase() || ''
   if (/pytest|vitest|jest|npm test|pnpm test/.test(command)) return 'Running tests'
   const compilesC = /(?:^|\s)(?:cc|gcc|clang)(?:\s|$)/.test(command)
   const runsCSortTests = /(?:^|\s)\.\/(?:test_?sort|sort_test)(?:\s|$)/.test(command)
@@ -68,14 +106,7 @@ export function activitySummary(activity: ProviderActivity | undefined, running:
 }
 
 export function activityRawDetails(activity: ProviderActivity) {
-  const data = {
-    ...(activity.args && { input: activity.args }),
-    ...(activity.result && { result: activity.result }),
-  }
-  return Object.keys(data).length > 0 ? JSON.stringify(data, null, 2) : 'No additional details.'
-}
-
-export function activityPath(activity: ProviderActivity): string | null {
-  const value = activity.args?.file_path ?? activity.args?.path
-  return typeof value === 'string' && value ? value : null
+  return activity.legacy
+    ? 'Legacy activity did not provide safe technical details.'
+    : 'No additional technical details were provided.'
 }

--- a/components/chat/messages/coding-agent-card.test.tsx
+++ b/components/chat/messages/coding-agent-card.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { CodingAgentCard } from './coding-agent-card'
-import type { ProviderInvocationUI } from '../types'
+import type { PendingApproval, ProviderInvocationUI } from '../types'
 
 beforeAll(() => {
   ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -20,259 +20,285 @@ afterEach(() => {
   container = null
 })
 
+const rawInstruction = 'Work inside /private/tmp/codex-workroom. Create sort.c and test_sort.c, compile with cc -std=c11 -Wall -Wextra -Werror, run every fixture, inspect command output, and report every internal command.'
+
+const activities: ProviderInvocationUI['activities'] = [
+  { id: 'inspect', name: 'Read', status: 'done', sequence: 1, kind: 'inspect', title: 'Inspect the task', summary: 'Reviewed the requested sorting behavior', legacy: false },
+  { id: 'create-sort', name: 'Edit', status: 'done', sequence: 2, kind: 'file_change', title: 'Create the sorting program', summary: 'Created the C sorting program', files: ['sort.c'], legacy: false },
+  { id: 'create-test', name: 'Edit', status: 'done', sequence: 3, kind: 'file_change', title: 'Add sorting tests', summary: 'Added focused test coverage', files: ['test_sort.c'], legacy: false },
+  { id: 'compile', name: 'Bash', status: 'done', sequence: 4, kind: 'command', title: 'Compile the program', summary: 'Compiled the C program with strict checks', legacy: false },
+  { id: 'fixture-one', name: 'Bash', status: 'done', sequence: 5, kind: 'command', title: 'Run sorting fixture', summary: 'Verified an unsorted input case', legacy: false },
+  { id: 'fixture-two', name: 'Bash', status: 'done', sequence: 6, kind: 'command', title: 'Run duplicate-value fixture', summary: 'Verified duplicate values', legacy: false },
+  { id: 'tests', name: 'Bash', status: 'done', sequence: 7, kind: 'command', title: 'Run the test suite', summary: 'All sorting tests passed', legacy: false },
+  { id: 'review', name: 'Read', status: 'running', sequence: 8, kind: 'inspect', title: 'Review the final result', summary: 'Checking the finished implementation', legacy: false },
+]
+
 const invocation: ProviderInvocationUI = {
-  id: 'codex:call-7', type: 'provider_invocation', parentToolCallId: 'call-7',
-  provider: 'codex', providerDisplayName: 'Codex', taskSummary: 'Fix Windows tests',
-  status: 'running', activities: [{
-    id: 'a', name: 'Bash', status: 'done', args: { command: 'pytest tests/unit' }, result: '89 passed',
-  }],
+  id: 'codex:call-7',
+  type: 'provider_invocation',
+  parentToolCallId: 'call-7',
+  provider: 'codex',
+  providerDisplayName: 'Codex',
+  taskTitle: 'Build and verify a C sorting program',
+  taskSummary: rawInstruction,
+  currentSummary: 'Checking the finished implementation',
+  status: 'running',
+  activities,
 }
 
 function render(overrides: Partial<Parameters<typeof CodingAgentCard>[0]> = {}) {
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
-  const props = { invocation, expanded: false, onToggle: vi.fn(), onStop: vi.fn(), ...overrides }
+  const props = { invocation, ...overrides }
   act(() => root!.render(<CodingAgentCard {...props} />))
   return { element: container, props }
 }
 
+function buttonNamed(element: ParentNode, label: string) {
+  return Array.from(element.querySelectorAll<HTMLButtonElement>('button'))
+    .find(button => button.textContent?.replace(/\s+/g, ' ').trim().startsWith(label))
+}
+
+function workroom() {
+  const room = document.querySelector<HTMLElement>('[role="dialog"]')
+  if (!room) throw new Error('Work Room was not opened')
+  return room
+}
+
 describe('CodingAgentCard', () => {
-  it('keeps the transcript compact while exposing status and stop', () => {
-    const { element, props } = render()
-    expect(element.textContent).toContain('Codex')
-    expect(element.textContent).toContain('Fix Windows tests')
-    expect(element.textContent).not.toContain('pytest tests/unit')
-    expect(element.querySelector('[aria-label="Live activity snapshot"]')).not.toBeNull()
-    act(() => element.querySelector<HTMLButtonElement>('[aria-label="Stop Codex"]')!.click())
-    expect(props.onStop).toHaveBeenCalledOnce()
+  it('keeps the transcript to task, status, semantic progress, and one action', () => {
+    const { element } = render()
+
+    expect(element.textContent).toContain('Codex · Working')
+    expect(element.textContent).toContain('Build and verify a C sorting program')
+    expect(element.textContent).toContain('Checking the finished implementation')
+    expect(element.textContent).not.toContain(rawInstruction)
+    expect(element.textContent).not.toContain('cc -std=c11')
+    expect(element.textContent).not.toContain('/private/tmp/codex-workroom')
+    expect(element.querySelector('pre')).toBeNull()
+    expect(element.querySelector('details')).toBeNull()
+    expect(buttonNamed(element, 'Open Work Room')).toBeDefined()
+    expect(element.querySelectorAll('button')).toHaveLength(1)
   })
 
-  it('keeps a long provider instruction out of the collapsed card and default Work Room view', () => {
-    const providerInstruction = 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
-    const { element } = render({ invocation: { ...invocation, taskSummary: providerInstruction } })
+  it('starts in a one-scroll overview with only the latest three semantic steps', () => {
+    const { element } = render()
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
 
-    expect(element.textContent).toContain('Codex work room')
-    expect(element.textContent).not.toContain(providerInstruction)
-    expect(element.querySelector('.line-clamp-2')).not.toBeNull()
-
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Codex Work Room"]')!
-    expect(workroom.textContent).not.toContain(providerInstruction)
-
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
-    expect(workroom.textContent).toContain(providerInstruction)
+    const room = workroom()
+    expect(room.textContent).toContain('Current progress')
+    expect(room.textContent).toContain('7 of 8 steps completed')
+    expect(room.textContent).toContain('Review the final result')
+    expect(room.textContent).toContain('Run the test suite')
+    expect(room.textContent).toContain('Run duplicate-value fixture')
+    expect(room.textContent).not.toContain('Inspect the task')
+    expect(room.textContent).not.toContain(rawInstruction)
+    expect(room.textContent).not.toContain('cc -std=c11')
+    expect(room.querySelector('pre')).toBeNull()
+    expect(room.querySelector('details')).toBeNull()
+    expect(room.querySelector('textarea')).toBeNull()
+    expect(buttonNamed(room, 'Chat')).toBeUndefined()
   })
 
-  it('shows semantic nested activity inline and keeps raw details behind disclosure', () => {
-    const { element } = render({ expanded: true })
-    expect(element.textContent).toContain('Running tests')
-    const details = element.querySelector('details')!
-    expect(details.open).toBe(false)
-    details.open = true
-    expect(element.textContent).toContain('pytest tests/unit')
-    expect(element.textContent).toContain('89 passed')
-    expect(element.querySelector('section')?.className).toContain('min-w-0')
-    expect(element.querySelector('section')?.className).toContain('overflow-hidden')
+  it('reveals earlier activity explicitly without creating a nested scroll region', () => {
+    const { element } = render()
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    const room = workroom()
+
+    act(() => buttonNamed(room, 'Activity')!.click())
+    const activitySection = room.querySelector<HTMLElement>('[aria-label="All provider activity"]')!
+    expect(activitySection.querySelectorAll('li')).toHaveLength(3)
+    expect(activitySection.querySelector('ol')?.className).not.toContain('overflow-y-auto')
+    expect(buttonNamed(room, 'Show 5 earlier')).toBeDefined()
+
+    act(() => buttonNamed(room, 'Show 5 earlier')!.click())
+    expect(activitySection.querySelectorAll('li')).toHaveLength(8)
+    expect(activitySection.textContent).toContain('Inspect the task')
+    expect(activitySection.textContent).not.toContain('/private/tmp/codex-workroom')
   })
 
-  it('describes C compile and test activity without exposing the command by default', () => {
+  it('uses the typed activity as the source of truth over a legacy raw duplicate', () => {
     const { element } = render({
-      expanded: true,
       invocation: {
         ...invocation,
         activities: [
-          {
-            id: 'compile-c', name: 'Bash', status: 'done',
-            args: { command: 'cc -std=c11 -Wall -Wextra -Werror sort.c test_sort.c -o test_sort && ./test_sort' },
-            result: '5 cases passed',
-          },
-          {
-            id: 'run-sort', name: 'Bash', status: 'done',
-            args: { command: './sort 9 1 5 1' }, result: '1 1 5 9',
-          },
+          { id: 'compile', name: 'Bash', status: 'done', args: { command: 'cc -std=c11 -Wall -Wextra -Werror sort.c' }, result: 'raw compiler output', legacy: true },
+          { id: 'compile', name: 'Bash', status: 'done', sequence: 4, kind: 'command', title: 'Compile the program', summary: 'Compiled the C program with strict checks', legacy: false },
         ],
       },
     })
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    const room = workroom()
+    act(() => buttonNamed(room, 'Activity')!.click())
 
-    expect(element.textContent).toContain('Compiling and running C tests')
-    expect(element.textContent).toContain('Running the sorting program')
-    const summaries = Array.from(element.querySelectorAll('details summary'))
-    expect(summaries.some(summary => summary.textContent?.includes('cc -std=c11'))).toBe(false)
-    expect(Array.from(element.querySelectorAll('details')).every(item => !item.open)).toBe(true)
+    expect(room.textContent).toContain('Compiled the C program with strict checks')
+    expect(room.textContent).not.toContain('cc -std=c11')
+    expect(room.textContent).not.toContain('raw compiler output')
+    expect(room.textContent).not.toContain('Legacy activity')
   })
 
-  it('removes Stop after a terminal event', () => {
-    const { element } = render({ invocation: { ...invocation, status: 'cancelled' } })
-    expect(element.querySelector('[aria-label="Stop Codex"]')).toBeNull()
+  it('shows only safe file evidence in the overview when it exists', () => {
+    const { element } = render()
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    const room = workroom()
+
+    expect(room.textContent).toContain('sort.c')
+    expect(room.textContent).toContain('test_sort.c')
+    expect(room.textContent).not.toContain('/private/tmp/codex-workroom')
+    expect(buttonNamed(room, 'Files')).toBeUndefined()
   })
 
-  it('does not present a failed provider as if it were still working', () => {
+  it('does not turn a legacy raw path into verified file evidence', () => {
     const { element } = render({
       invocation: {
         ...invocation,
-        status: 'failed',
-        activities: [{ ...invocation.activities[0], status: 'running' }],
+        activities: [{
+          id: 'legacy-path', name: 'Bash', status: 'done', legacy: true,
+          args: { path: '/private/tmp/codex-workroom/private.c' },
+        }],
       },
     })
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    const room = workroom()
 
-    const snapshot = element.querySelector('[aria-label="Live activity snapshot"]')!
-    expect(snapshot.textContent).toContain('Work stopped before completion')
-    expect(snapshot.textContent).not.toContain('Working on the next step')
+    expect(room.querySelector('[aria-label="Provider file evidence"]')).toBeNull()
+    expect(room.textContent).not.toContain('private.c')
   })
 
-  it('opens an interactive Work Room and targets messages to Codex', () => {
-    const onMessageProvider = vi.fn()
-    const { element } = render({ onMessageProvider })
-
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Codex Work Room"]')!
-    expect(workroom).not.toBeNull()
-    expect(workroom.textContent).toContain('Fix Windows tests')
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
-
-    const composer = workroom.querySelector<HTMLTextAreaElement>('textarea')!
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!
-      setter.call(composer, 'Also update the changelog')
-      composer.dispatchEvent(new Event('input', { bubbles: true }))
-    })
-    act(() => workroom.querySelector<HTMLButtonElement>('[aria-label="Send to Codex"]')!.click())
-
-    expect(onMessageProvider).toHaveBeenCalledWith('Also update the changelog')
-    expect(workroom.textContent).toContain('Queued #1 to Codex')
-  })
-
-  it('reconciles a queued message with a resumed provider result', () => {
-    const continuation: ProviderInvocationUI = {
-      ...invocation,
-      id: 'codex:call-8',
-      parentToolCallId: 'call-8',
-      sessionId: 'codex-session-1',
-      taskSummary: 'Also update the changelog',
-      status: 'completed',
-      result: 'Changelog updated.',
-    }
-    const { element } = render({
-      invocation: { ...invocation, sessionId: 'codex-session-1' },
-      continuations: [continuation],
-    })
-
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
-    expect(workroom.textContent).toContain('Completed #1 by Codex')
-    expect(workroom.textContent).toContain('Also update the changelog')
-    expect(workroom.textContent).toContain('Changelog updated.')
-  })
-
-  it('keeps the first result before resumed messages in chronological order', () => {
-    const continuation: ProviderInvocationUI = {
-      ...invocation,
-      id: 'codex:call-8',
-      parentToolCallId: 'call-8',
-      sessionId: 'codex-session-1',
-      taskSummary: 'Second request',
-      status: 'completed',
-      result: 'Second result',
-    }
-    const { element } = render({
-      invocation: {
-        ...invocation,
-        sessionId: 'codex-session-1',
-        status: 'completed',
-        result: 'First result',
-      },
-      continuations: [continuation],
-    })
-
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Chat'))!.click())
-    const text = workroom.textContent!
-    expect(text.indexOf('First result')).toBeLessThan(text.indexOf('Second request'))
-    expect(text.indexOf('Second request')).toBeLessThan(text.indexOf('Second result'))
-  })
-
-  it('tracks resumed status, activity and files across the provider session', () => {
-    const continuation: ProviderInvocationUI = {
-      ...invocation,
-      id: 'codex:call-8',
-      parentToolCallId: 'call-8',
-      sessionId: 'codex-session-1',
-      taskSummary: 'Continue',
-      status: 'running',
-      activities: [{
-        id: 'file-2', name: 'Edit', status: 'done',
-        args: { file_path: 'src/resumed.ts' }, result: 'updated',
-      }],
-    }
-    const { element } = render({
-      invocation: { ...invocation, sessionId: 'codex-session-1', status: 'completed' },
-      continuations: [continuation],
-    })
-
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
-    expect(workroom.querySelector('[aria-label="Stop Codex"]')).not.toBeNull()
-
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Activity'))!.click())
-    expect(workroom.textContent).toContain('pytest tests/unit')
-    expect(workroom.textContent).toContain('src/resumed.ts')
-
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Files'))!.click())
-    expect(workroom.textContent).toContain('src/resumed.ts')
-  })
-
-  it('exposes Activity and Files as full Work Room sections', () => {
-    const withFile = {
-      ...invocation,
-      activities: [...invocation.activities, {
-        id: 'file-1', name: 'File change', status: 'done' as const,
-        args: { file_path: 'src/app.tsx' }, result: 'updated',
-      }],
-    }
-    const { element } = render({ invocation: withFile })
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Open Work Room'))!.click())
-    const workroom = document.querySelector<HTMLElement>('[role="dialog"]')!
-
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Activity'))!.click())
-    expect(workroom.textContent).toContain('pytest tests/unit')
-    act(() => Array.from(workroom.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(button => button.textContent?.includes('Files'))!.click())
-    expect(workroom.textContent).toContain('src/app.tsx')
-  })
-
-  it('keeps a long activity history bounded and hides raw details until disclosure', () => {
-    const activities = Array.from({ length: 10 }, (_, index) => ({
-      id: `step-${index}`,
-      name: 'Bash',
-      status: index === 9 ? 'running' as const : 'done' as const,
-      args: { command: `python3 dijkstra.py --case ${index}` },
-      result: `case ${index} passed`,
-    }))
-    const { element } = render({ invocation: { ...invocation, activities }, expanded: true })
-
-    const activityList = element.querySelector<HTMLOListElement>('[aria-label="Codex activity"]')!
-    expect(activityList.className).toContain('max-h-56')
-    expect(activityList.className).toContain('overflow-y-auto')
-    expect(element.querySelectorAll('details')).toHaveLength(10)
-    expect(Array.from(element.querySelectorAll('details')).every(item => !item.open)).toBe(true)
-    expect(element.textContent).toContain('Running a Python check')
-  })
-
-  it('keeps a native approval visible on the collapsed provider card', () => {
+  it('puts a native approval in Work Room with a narrow primary action', () => {
     const onApprovalResponse = vi.fn()
+    const approval: PendingApproval = {
+      id: 'approval-1',
+      tool: 'codex',
+      arguments: { command: 'cc -std=c11 -Wall -Wextra -Werror /private/tmp/codex-workroom/sort.c' },
+      provider: 'codex',
+      providerInvocationId: invocation.id,
+      parentToolCallId: invocation.parentToolCallId,
+      providerApproval: {
+        action: 'Compile the requested C11 program',
+        scope: 'This Work Room only',
+        reason: 'Compile the requested workspace files before continuing',
+        scopeClassification: 'workroom',
+        allowOnce: true,
+        allowSession: false,
+        files: ['sort.c', 'test_sort.c'],
+      },
+    }
+    const { element } = render({ pendingApproval: approval, onApprovalResponse })
+
+    expect(element.textContent).toContain('Your decision is needed in the Work Room.')
+    expect(element.textContent).not.toContain('Compile the requested C11 program')
+    act(() => buttonNamed(element, 'Review decision')!.click())
+    const room = workroom()
+    expect(room.textContent).toContain('Compile the requested C11 program')
+    expect(room.textContent).toContain('This Work Room only')
+    expect(room.textContent).toContain('Compile the requested workspace files before continuing')
+    expect(room.textContent).toContain('sort.c, test_sort.c')
+    expect(room.textContent).not.toContain('cc -std=c11')
+    expect(room.textContent).not.toContain('/private/tmp/codex-workroom')
+    expect(buttonNamed(room, 'Allow once')).toBeDefined()
+    expect(buttonNamed(room, 'Reject this request')).toBeDefined()
+    expect(buttonNamed(room, 'Trust this Work Room for the session')).toBeUndefined()
+
+    act(() => buttonNamed(room, 'Allow once')!.click())
+    expect(onApprovalResponse).toHaveBeenCalledWith(true, 'once', undefined)
+  })
+
+  it('does not offer an allow action for approval outside the Work Room', () => {
     const { element } = render({
       pendingApproval: {
-        id: 'approval-1',
         tool: 'codex',
-        arguments: { action: 'Run pytest', cwd: '.workroom-e2e' },
+        arguments: { cwd: '/outside' },
+        provider: 'codex',
+        providerInvocationId: invocation.id,
+        parentToolCallId: invocation.parentToolCallId,
+        providerApproval: {
+          action: 'Run an external command',
+          scope: 'Outside this Work Room',
+          reason: 'The provider requested a broader scope',
+          scopeClassification: 'elevated',
+          allowOnce: false,
+          allowSession: false,
+        },
       },
-      onApprovalResponse,
+      onApprovalResponse: vi.fn(),
     })
 
-    expect(element.querySelector('[aria-label="Approval required for codex"]')).not.toBeNull()
-    act(() => Array.from(element.querySelectorAll('button')).find(button => button.textContent?.includes('Allow once'))!.click())
-    expect(onApprovalResponse).toHaveBeenCalledWith(true, 'once', undefined)
+    act(() => buttonNamed(element, 'Review decision')!.click())
+    const room = workroom()
+    expect(buttonNamed(room, 'Allow once')).toBeUndefined()
+    expect(room.textContent).toContain('cannot be allowed here')
+  })
+
+  it('fails closed when a native approval has no Core-verified presentation', () => {
+    const { element } = render({
+      pendingApproval: {
+        tool: 'codex',
+        arguments: { command: 'private command' },
+        provider: 'codex',
+        providerInvocationId: invocation.id,
+        parentToolCallId: invocation.parentToolCallId,
+      },
+      onApprovalResponse: vi.fn(),
+    })
+
+    act(() => buttonNamed(element, 'Review decision')!.click())
+    const room = workroom()
+    expect(room.textContent).toContain('Boundary could not be verified')
+    expect(buttonNamed(room, 'Allow once')).toBeUndefined()
+    expect(room.textContent).not.toContain('private command')
+  })
+
+  it('stops only this provider run from inside Work Room', () => {
+    const onProviderStop = vi.fn()
+    const { element } = render({ onProviderStop })
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    const room = workroom()
+
+    const stop = room.querySelector<HTMLButtonElement>('[aria-label="Stop Codex run"]')
+    act(() => stop!.click())
+    expect(onProviderStop).toHaveBeenCalledWith('codex:call-7')
+    expect(room.textContent).toContain('Stopping…')
+  })
+
+  it('uses a static stopped marker for a cancelled provider run', () => {
+    const { element } = render({
+      invocation: {
+        ...invocation,
+        status: 'cancelled',
+        resultSummary: 'The provider stopped',
+      },
+    })
+
+    expect(element.querySelector('[data-tool-status="stopped"]')).not.toBeNull()
+    act(() => buttonNamed(element, 'Open Work Room')!.click())
+    expect(workroom().querySelector('[data-tool-status="stopped"]')).not.toBeNull()
+  })
+
+  it('shows a terminal outcome instead of stale live progress', () => {
+    const { element } = render({
+      invocation: {
+        ...invocation,
+        status: 'completed',
+        currentSummary: 'Checking the finished implementation',
+        resultSummary: 'The provider completed its run',
+      },
+    })
+
+    expect(element.textContent).toContain('The provider completed its run')
+    expect(element.textContent).not.toContain('Checking the finished implementation')
+  })
+
+  it('returns focus to the card trigger when Escape closes Work Room', () => {
+    const { element } = render()
+    const trigger = buttonNamed(element, 'Open Work Room')!
+    trigger.focus()
+    act(() => trigger.click())
+    expect(workroom()).not.toBeNull()
+
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })))
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
   })
 })

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -1,18 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import {
-  HiOutlineChevronDown,
-  HiOutlineChevronRight,
-  HiOutlineClock,
-  HiOutlineEye,
-  HiOutlineStop,
-} from 'react-icons/hi'
+import { HiOutlineChevronRight } from 'react-icons/hi'
 import type { PendingApproval, ProviderInvocationUI } from '../types'
-import { ChatApproval } from '../chat-approval'
 import {
-  activityRawDetails,
-  activitySummary,
   allProviderActivities,
   compactProviderTaskHeading,
   latestProviderActivity,
@@ -24,163 +15,100 @@ import { CodingAgentWorkroom } from './coding-agent-workroom'
 interface CodingAgentCardProps {
   invocation: ProviderInvocationUI
   continuations?: ProviderInvocationUI[]
-  expanded: boolean
-  onToggle: () => void
-  onStop?: () => void
   pendingApproval?: PendingApproval | null
-  onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
-  onMessageProvider?: (message: string) => void
+  onApprovalResponse?: (
+    approved: boolean,
+    scope: 'once' | 'session',
+    mode?: 'reject_soft' | 'reject_hard' | 'reject_explain',
+    feedback?: string,
+  ) => void
+  onProviderStop?: (invocationId: string) => void
 }
 
 const terminal = new Set(['completed', 'failed', 'cancelled'])
 
-function elapsed(ms?: number) {
-  if (typeof ms !== 'number') return ''
-  if (ms < 1000) return `${ms}ms`
-  return `${Math.round(ms / 1000)}s`
+function statusLabel(status: ProviderInvocationUI['status']) {
+  return status === 'awaiting_approval'
+    ? 'Needs your decision'
+    : status === 'completed'
+      ? 'Completed'
+      : status === 'failed'
+        ? 'Needs attention'
+        : status === 'cancelled'
+          ? 'Stopped'
+          : 'Working'
 }
 
-function statusTone(status: ProviderInvocationUI['status']) {
-  if (status === 'failed') return 'bg-red-50 text-red-700'
-  if (status === 'cancelled') return 'bg-neutral-100 text-neutral-700'
-  if (status === 'completed') return 'bg-emerald-50 text-emerald-700'
-  if (status === 'awaiting_approval') return 'bg-neutral-100 text-neutral-700'
-  return 'bg-blue-50 text-blue-700'
-}
-
+/** A compact transcript summary. Decisions and evidence belong in the Work Room. */
 export function CodingAgentCard({
-  invocation, continuations = [], expanded, onToggle, onStop, pendingApproval, onApprovalResponse, onMessageProvider,
+  invocation,
+  continuations = [],
+  pendingApproval,
+  onApprovalResponse,
+  onProviderStop,
 }: CodingAgentCardProps) {
   const [workroomOpen, setWorkroomOpen] = useState(false)
   const current = continuations.at(-1) ?? invocation
-  const running = !terminal.has(current.status)
-  const summary = compactProviderTaskHeading(
+  const activities = allProviderActivities(invocation, continuations)
+  const latest = latestProviderActivity(invocation, continuations)
+  const taskTitle = compactProviderTaskHeading(
+    invocation.taskTitle || current.taskTitle,
     invocation.taskSummary || current.taskSummary,
     invocation.providerDisplayName,
   )
-  const genericSummary = summary === `${invocation.providerDisplayName} work room`
-  const status = current.status.replace('_', ' ')
-  const activities = allProviderActivities(invocation, continuations)
-  const latest = latestProviderActivity(invocation, continuations)
-  const latestSummary = providerSnapshotSummary(current.status, latest)
+  const state = statusLabel(current.status)
+  const summary = providerSnapshotSummary(
+    current.status,
+    latest,
+    terminal.has(current.status)
+      ? current.resultSummary || current.errorSummary
+      : current.currentSummary,
+  )
+  const reviewRequired = Boolean(pendingApproval && onApprovalResponse)
 
   return (
     <section
-      aria-label={`${invocation.providerDisplayName} ${status}`}
-      className="my-3 min-w-0 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
+      aria-label={`${invocation.providerDisplayName} ${state}`}
+      className="my-3 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
     >
-      <div className="border-b border-neutral-100 px-3 py-3 sm:px-4">
-        <div className="flex min-w-0 items-start gap-2">
-          <ToolStatus status={current.status === 'completed' ? 'done' : current.status === 'failed' ? 'error' : 'running'} className="mt-1" />
-          <button
-            type="button"
-            aria-expanded={expanded}
-            onClick={onToggle}
-            className="flex min-h-9 min-w-0 flex-1 items-start gap-2 text-left"
-          >
-            {expanded ? <HiOutlineChevronDown className="mt-0.5 h-4 w-4 shrink-0" /> : <HiOutlineChevronRight className="mt-0.5 h-4 w-4 shrink-0" />}
-            <span className="min-w-0">
-              <span className="block line-clamp-2 text-sm font-semibold text-neutral-950">{summary}</span>
-              <span className="mt-0.5 block text-xs text-neutral-500">{genericSummary ? 'Live activity' : `${invocation.providerDisplayName} work room`}</span>
-            </span>
-          </button>
-          {running && onStop && (
-            <button
-              type="button"
-              onClick={onStop}
-              className="flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-red-600"
-              aria-label={`Stop ${invocation.providerDisplayName}`}
-            >
-              <HiOutlineStop className="h-4 w-4" />
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => setWorkroomOpen(true)}
-            className="min-h-9 shrink-0 rounded-md border border-neutral-200 px-2.5 text-xs font-medium text-neutral-700 hover:bg-neutral-50"
-          >
-            Open Work Room
-          </button>
+      <div className="flex min-h-[92px] items-center gap-3 px-4 py-3">
+        <ToolStatus
+          status={terminal.has(current.status)
+            ? current.status === 'completed' ? 'done' : current.status === 'cancelled' ? 'stopped' : 'error'
+            : 'running'}
+          awaitingApproval={current.status === 'awaiting_approval'}
+          className="shrink-0"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium text-neutral-500">
+            {invocation.providerDisplayName} · {state}
+          </p>
+          <h3 className="mt-0.5 truncate text-sm font-semibold text-neutral-950">{taskTitle}</h3>
+          <p className="mt-1 line-clamp-1 text-sm text-neutral-600">{summary}</p>
         </div>
-
-        {/* This is a true activity snapshot, not a fabricated screenshot. */}
-        <div
-          aria-label="Live activity snapshot"
-          className="mt-3 grid min-h-24 grid-cols-[auto_1fr] gap-x-3 rounded-lg border border-neutral-200 bg-gradient-to-br from-neutral-50 to-white p-3"
+        <button
+          type="button"
+          onClick={() => setWorkroomOpen(true)}
+          className="flex min-h-11 shrink-0 items-center gap-1 rounded-lg bg-neutral-900 px-3 text-sm font-medium text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
         >
-          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-900 text-white">
-            <HiOutlineEye className="h-5 w-5" />
-          </span>
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-sm font-medium text-neutral-900">{latestSummary}</p>
-              <span
-                aria-label={`Status: ${status}`}
-                className={`rounded-full px-2 py-0.5 text-[11px] font-medium capitalize ${statusTone(current.status)}`}
-              >
-                {status}
-              </span>
-            </div>
-            <p className="mt-1 text-xs text-neutral-500">
-              {activities.length === 0 ? 'Live activity will appear here as Codex works.' : `${activities.length} recorded step${activities.length === 1 ? '' : 's'} · newest activity first in Work Room`}
-            </p>
-          </div>
-          <div className="col-span-2 mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-neutral-200 pt-2 text-xs text-neutral-500">
-            <span>{invocation.providerDisplayName}</span>
-            <span className="flex items-center gap-1"><HiOutlineClock className="h-3.5 w-3.5" />{current.elapsedMs != null ? elapsed(current.elapsedMs) : running ? 'Live' : 'Finished'}</span>
-            {current.sessionId && <span>Session connected</span>}
-          </div>
-        </div>
+          {reviewRequired ? 'Review decision' : 'Open Work Room'}
+          <HiOutlineChevronRight className="h-4 w-4" aria-hidden />
+        </button>
       </div>
-
-      {pendingApproval && onApprovalResponse && (
-        <div className="border-b border-neutral-200 bg-neutral-50 px-3 py-2 sm:px-4">
-          <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
-        </div>
-      )}
-
-      {expanded && (
-        <div className="px-3 py-3 sm:px-4">
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Recent activity</p>
-            <span className="text-xs text-neutral-400">Details stay collapsed by default</span>
-          </div>
-          <ol className="max-h-56 space-y-1 overflow-y-auto overscroll-contain pr-1" aria-label={`${invocation.providerDisplayName} activity`}>
-            {[...activities].reverse().map(activity => (
-              <li key={activity.id} className="rounded-lg border border-neutral-100 bg-neutral-50/70 px-2.5 py-2">
-                <details>
-                  <summary className="flex min-w-0 cursor-pointer list-none items-start gap-2 text-xs marker:hidden">
-                    <ToolStatus status={activity.status} className="mt-0.5" />
-                    <span className="min-w-0 flex-1">
-                      <span className="block font-medium text-neutral-800">{activitySummary(activity, running)}</span>
-                      <span className="mt-0.5 block capitalize text-neutral-500">{activity.status}</span>
-                    </span>
-                    <HiOutlineChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-neutral-400" />
-                  </summary>
-                  <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-neutral-900 p-2 text-[11px] leading-5 text-neutral-100">{activityRawDetails(activity)}</pre>
-                </details>
-              </li>
-            ))}
-          </ol>
-          {activities.length === 0 && (
-            <p className="py-2 text-xs text-neutral-500">{running ? 'Starting provider…' : 'No provider activity reported.'}</p>
-          )}
-          {(current.error || (current.result && terminal.has(current.status))) && (
-            <p className={`mt-3 break-words rounded-md px-2.5 py-2 text-xs ${current.error ? 'bg-red-50 text-red-700' : 'bg-neutral-50 text-neutral-600'}`}>
-              {current.error || current.result}
-            </p>
-          )}
-        </div>
+      {reviewRequired && (
+        <p className="border-t border-amber-100 bg-amber-50 px-4 py-2 text-sm text-amber-900">
+          Your decision is needed in the Work Room.
+        </p>
       )}
       {workroomOpen && (
         <CodingAgentWorkroom
           invocation={invocation}
           continuations={continuations}
           onClose={() => setWorkroomOpen(false)}
-          onStop={onStop}
-          onMessage={onMessageProvider}
           pendingApproval={pendingApproval}
           onApprovalResponse={onApprovalResponse}
+          onProviderStop={onProviderStop}
+          activityCount={activities.length}
         />
       )}
     </section>

--- a/components/chat/messages/coding-agent-card.tsx
+++ b/components/chat/messages/coding-agent-card.tsx
@@ -96,7 +96,7 @@ export function CodingAgentCard({
         </button>
       </div>
       {reviewRequired && (
-        <p className="border-t border-amber-100 bg-amber-50 px-4 py-2 text-sm text-amber-900">
+        <p className="border-t border-neutral-100 bg-neutral-50 px-4 py-2 text-sm text-neutral-700">
           Your decision is needed in the Work Room.
         </p>
       )}

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -99,7 +99,10 @@ export function CodingAgentWorkroom({
   const headingRef = useRef<HTMLHeadingElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const onCloseRef = useRef(onClose)
-  onCloseRef.current = onClose
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
 
   const current = continuations.at(-1) ?? invocation
   const running = !terminal.has(current.status)

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -302,7 +302,7 @@ export function CodingAgentWorkroom({
               </section>
 
               {hasDecision && (
-                <section aria-live="assertive" aria-label="Work Room decision" className="rounded-xl border border-amber-200 bg-amber-50 p-1">
+                <section aria-live="assertive" aria-label="Work Room decision" className="rounded-xl border border-neutral-300 bg-neutral-50 p-1">
                   <ChatApproval approval={pendingApproval!} onResponse={onApprovalResponse!} />
                 </section>
               )}

--- a/components/chat/messages/coding-agent-workroom.tsx
+++ b/components/chat/messages/coding-agent-workroom.tsx
@@ -1,258 +1,398 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   HiOutlineArrowLeft,
-  HiOutlineChatBubbleLeftRight,
-  HiOutlineDocument,
-  HiOutlineEye,
   HiOutlineListBullet,
-  HiOutlinePaperAirplane,
-  HiOutlineStop,
+  HiOutlineSparkles,
 } from 'react-icons/hi2'
 import type { PendingApproval, ProviderInvocationUI } from '../types'
 import { ChatApproval } from '../chat-approval'
 import {
-  activityPath,
-  activityRawDetails,
   activitySummary,
   allProviderActivities,
   compactProviderTaskHeading,
   latestProviderActivity,
+  type ProviderActivity,
+  providerPermissionBoundary,
+  providerPermissionLabel,
   providerSnapshotSummary,
 } from './coding-agent-activity'
 import { ToolStatus } from './tools/tool-status'
 
-type WorkroomTab = 'chat' | 'activity' | 'files'
+type WorkroomSection = 'overview' | 'activity'
 
 interface CodingAgentWorkroomProps {
   invocation: ProviderInvocationUI
   continuations?: ProviderInvocationUI[]
   onClose: () => void
-  onStop?: () => void
-  onMessage?: (message: string) => void
   pendingApproval?: PendingApproval | null
-  onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
+  onApprovalResponse?: (
+    approved: boolean,
+    scope: 'once' | 'session',
+    mode?: 'reject_soft' | 'reject_hard' | 'reject_explain',
+    feedback?: string,
+  ) => void
+  onProviderStop?: (invocationId: string) => void
+  activityCount?: number
 }
 
-interface QueuedMessage {
-  id: string
-  content: string
+const terminal = new Set(['completed', 'failed', 'cancelled'])
+const recentLimit = 3
+
+type DisplayActivity = ProviderActivity & { occurrences?: number }
+
+function recentActivityGroups(activities: ProviderActivity[]): DisplayActivity[] {
+  const groups: DisplayActivity[] = []
+  for (const activity of activities) {
+    const previous = groups.at(-1)
+    const repeat = previous
+      && previous.title === activity.title
+      && previous.summary === activity.summary
+      && previous.status === activity.status
+      && !previous.files?.length
+      && !activity.files?.length
+      && previous.legacy === false
+      && activity.legacy === false
+    if (repeat) {
+      previous.occurrences = (previous.occurrences || 1) + 1
+    } else {
+      groups.push({ ...activity, occurrences: 1 })
+    }
+  }
+  return groups.slice(-recentLimit).reverse()
 }
 
-export function CodingAgentWorkroom({ invocation, continuations = [], onClose, onStop, onMessage, pendingApproval, onApprovalResponse }: CodingAgentWorkroomProps) {
-  const [tab, setTab] = useState<WorkroomTab>('activity')
-  const [draft, setDraft] = useState('')
-  const [queued, setQueued] = useState<QueuedMessage[]>([])
+function displayStatus(status: ProviderInvocationUI['status']) {
+  return status === 'awaiting_approval'
+    ? 'Needs your decision'
+    : status === 'completed'
+      ? 'Completed'
+      : status === 'failed'
+        ? 'Needs attention'
+        : status === 'cancelled'
+          ? 'Stopped'
+          : 'Working'
+}
+
+function focusable(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>(
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  )).filter(element => !element.hasAttribute('hidden'))
+}
+
+/** One-scroll, keyboard-safe decision and evidence surface for a provider run. */
+export function CodingAgentWorkroom({
+  invocation,
+  continuations = [],
+  onClose,
+  pendingApproval,
+  onApprovalResponse,
+  onProviderStop,
+  activityCount,
+}: CodingAgentWorkroomProps) {
+  const [section, setSection] = useState<WorkroomSection>('overview')
+  const [showEarlier, setShowEarlier] = useState(false)
+  const [stopping, setStopping] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const headingRef = useRef<HTMLHeadingElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
   const current = continuations.at(-1) ?? invocation
-  const running = !['completed', 'failed', 'cancelled'].includes(current.status)
+  const running = !terminal.has(current.status)
   const taskHeading = compactProviderTaskHeading(
+    invocation.taskTitle || current.taskTitle,
     invocation.taskSummary || current.taskSummary,
     invocation.providerDisplayName,
   )
-  const genericTaskHeading = taskHeading === `${invocation.providerDisplayName} work room`
   const activities = useMemo(
     () => allProviderActivities(invocation, continuations),
     [invocation, continuations],
   )
   const latest = latestProviderActivity(invocation, continuations)
-  const files = useMemo(
-    () => activities.map(activity => ({ activity, path: activityPath(activity) })).filter(item => item.path),
-    [activities],
+  const summary = providerSnapshotSummary(
+    current.status,
+    latest,
+    terminal.has(current.status)
+      ? current.resultSummary || current.errorSummary
+      : current.currentSummary,
   )
+  const recentActivities = useMemo(() => recentActivityGroups(activities), [activities])
+  const allActivities = useMemo(() => [...activities].reverse(), [activities])
+  const visibleActivities = showEarlier ? allActivities : recentActivities
+  const files = useMemo(() => {
+    const items = new Map<string, { status: 'running' | 'done' | 'error' }>()
+    for (const activity of activities) {
+      // A generic compatibility event can mention a path in unverified raw
+      // arguments. It is useful only as legacy activity, never as file proof.
+      const names = activity.legacy === false ? activity.files || [] : []
+      for (const name of names) {
+        if (name) items.set(name, { status: activity.status })
+      }
+    }
+    return Array.from(items, ([name, value]) => ({ name, ...value }))
+  }, [activities])
 
   useEffect(() => {
-    const previous = document.body.style.overflow
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+    const root = rootRef.current
+    if (!root) return
+    const previousOverflow = document.body.style.overflow
+    const siblings = Array.from(document.body.children)
+      .filter((element): element is HTMLElement => element !== root)
+      .map(element => ({
+        element,
+        ariaHidden: element.getAttribute('aria-hidden'),
+        inert: element.hasAttribute('inert'),
+      }))
     document.body.style.overflow = 'hidden'
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+    siblings.forEach(({ element }) => {
+      element.setAttribute('aria-hidden', 'true')
+      element.setAttribute('inert', '')
+    })
+    requestAnimationFrame(() => headingRef.current?.focus())
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current()
+        return
+      }
+      if (event.key !== 'Tab') return
+      const elements = focusable(root)
+      if (!elements.length) return
+      const first = elements[0]
+      const last = elements[elements.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
     }
-    window.addEventListener('keydown', closeOnEscape)
+    window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = previous
-      window.removeEventListener('keydown', closeOnEscape)
+      document.body.style.overflow = previousOverflow
+      siblings.forEach(({ element, ariaHidden, inert }) => {
+        if (ariaHidden === null) element.removeAttribute('aria-hidden')
+        else element.setAttribute('aria-hidden', ariaHidden)
+        if (!inert) element.removeAttribute('inert')
+      })
+      window.removeEventListener('keydown', onKeyDown)
+      previousFocusRef.current?.focus()
     }
-  }, [onClose])
+  }, [])
 
-  const submit = () => {
-    const message = draft.trim()
-    if (!message || !onMessage) return
-    setQueued(items => [...items, { id: crypto.randomUUID(), content: message }])
-    setDraft('')
-    onMessage(message)
-  }
+  const stepCount = activityCount ?? activities.length
+  const completedSteps = activities.filter(activity => activity.status === 'done').length
+  const failedSteps = activities.filter(activity => activity.status === 'error').length
+  const hasDecision = Boolean(pendingApproval && onApprovalResponse)
+  const canStop = (current.status === 'starting' || current.status === 'running')
+    && Boolean(onProviderStop)
+  const progressDetail = current.status === 'awaiting_approval'
+    ? `${completedSteps} of ${stepCount} steps completed · 1 decision needed`
+    : current.status === 'failed'
+      ? `${completedSteps} of ${stepCount} steps completed${failedSteps ? ` · ${failedSteps} need attention` : ''}`
+      : current.status === 'completed'
+        ? `${completedSteps || stepCount} of ${stepCount} steps completed`
+        : `${completedSteps} of ${stepCount} steps completed`
 
   return createPortal(
-    <div className="fixed inset-0 z-[100] flex min-h-0 flex-col bg-neutral-50" role="dialog" aria-modal="true" aria-label={`${invocation.providerDisplayName} Work Room`}>
-      <header className="flex min-h-16 shrink-0 items-center gap-2 border-b border-neutral-200 bg-white px-3 sm:gap-3 sm:px-5">
-        <button type="button" onClick={onClose} className="flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100">
-          <HiOutlineArrowLeft className="h-5 w-5" />
-          <span className="hidden sm:inline">Back</span>
-        </button>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <ToolStatus status={current.status === 'failed' ? 'error' : current.status === 'completed' ? 'done' : 'running'} />
-            <h1 className="whitespace-nowrap text-sm font-semibold text-neutral-950">{invocation.providerDisplayName} Work Room</h1>
+    <div
+      ref={rootRef}
+      className="fixed inset-0 z-[100] flex min-h-0 flex-col bg-neutral-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="workroom-heading"
+    >
+      <header className="shrink-0 border-b border-neutral-200 bg-white">
+        <div className="mx-auto flex min-h-16 max-w-3xl items-center gap-3 px-4 sm:px-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex min-h-11 shrink-0 items-center gap-1 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
+          >
+            <HiOutlineArrowLeft className="h-5 w-5" aria-hidden />
+            <span className="hidden sm:inline">Back</span>
+          </button>
+          <div className="min-w-0 flex-1">
+            <h1 id="workroom-heading" ref={headingRef} tabIndex={-1} className="truncate text-sm font-semibold text-neutral-950 focus:outline-none">
+              {taskHeading}
+            </h1>
+            <p className="mt-0.5 text-xs text-neutral-500">
+              {invocation.providerDisplayName} · {displayStatus(current.status)}
+            </p>
           </div>
-          <p className="truncate text-xs text-neutral-500">{genericTaskHeading ? 'Live activity and approvals' : taskHeading}</p>
+          {canStop ? (
+            <button
+              type="button"
+              aria-label={`Stop ${current.providerDisplayName} run`}
+              disabled={stopping}
+              onClick={() => {
+                if (stopping) return
+                setStopping(true)
+                onProviderStop?.(current.id)
+              }}
+              className="min-h-11 shrink-0 rounded-lg px-3 text-sm font-medium text-red-700 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-700 disabled:cursor-not-allowed disabled:text-neutral-400"
+            >
+              {stopping ? 'Stopping…' : <>
+                <span className="sm:hidden">Stop</span>
+                <span className="hidden sm:inline">Stop {current.providerDisplayName} run</span>
+              </>}
+            </button>
+          ) : null}
         </div>
-        <span className="hidden rounded-full bg-neutral-100 px-2.5 py-1 text-xs capitalize text-neutral-600 sm:inline">{current.status.replace('_', ' ')}</span>
-        {running && onStop && (
-          <button type="button" onClick={onStop} aria-label={`Stop ${invocation.providerDisplayName}`} className="flex min-h-11 items-center gap-2 rounded-lg border border-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-50">
-            <HiOutlineStop className="h-4 w-4" /> Stop
-          </button>
-        )}
-        {!running && (
-          <button type="button" onClick={onClose} aria-label="Return to conversation" className="min-h-11 shrink-0 rounded-lg bg-neutral-900 px-3 text-sm font-medium text-white hover:bg-neutral-800">
-            <span className="sm:hidden">Return</span>
-            <span className="hidden sm:inline">Return to conversation</span>
-          </button>
-        )}
       </header>
 
-      <nav className="grid shrink-0 grid-cols-3 border-b border-neutral-200 bg-white" aria-label="Work Room sections">
-        {([
-          ['chat', 'Chat', HiOutlineChatBubbleLeftRight],
-          ['activity', 'Activity', HiOutlineListBullet],
-          ['files', 'Files', HiOutlineDocument],
-        ] as const).map(([value, label, Icon]) => (
-          <button
-            key={value}
-            type="button"
-            role="tab"
-            aria-selected={tab === value}
-            onClick={() => setTab(value)}
-            className={`flex min-h-12 items-center justify-center gap-2 border-b-2 text-sm font-medium ${tab === value ? 'border-neutral-900 text-neutral-950' : 'border-transparent text-neutral-500 hover:text-neutral-800'}`}
-          >
-            <Icon className="h-4 w-4" /> {label}
-            {value === 'files' && files.length > 0 && <span className="rounded-full bg-neutral-100 px-1.5 text-[11px]">{files.length}</span>}
-          </button>
-        ))}
-      </nav>
+      <div className="shrink-0 border-b border-neutral-200 bg-white">
+        <nav className="mx-auto flex max-w-3xl gap-1 px-4 py-2 sm:px-6" aria-label="Work Room sections">
+          {([
+            ['overview', 'Overview', HiOutlineSparkles],
+            ['activity', 'Activity', HiOutlineListBullet],
+          ] as const).map(([value, label, Icon]) => (
+            <button
+              key={value}
+              type="button"
+              aria-current={section === value ? 'page' : undefined}
+              onClick={() => setSection(value)}
+              className={`flex min-h-11 items-center gap-2 rounded-lg px-3 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 ${section === value ? 'bg-neutral-900 text-white' : 'text-neutral-600 hover:bg-neutral-100'}`}
+            >
+              <Icon className="h-4 w-4" aria-hidden />
+              {label}
+            </button>
+          ))}
+        </nav>
+      </div>
 
       <main className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
-        <div className="mx-auto max-w-4xl">
-          <section aria-label="Work Room live summary" className="mb-4 rounded-xl border border-neutral-200 bg-white p-4">
-            <div className="flex min-w-0 items-start gap-3">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-neutral-900 text-white"><HiOutlineEye className="h-5 w-5" /></span>
-              <div className="min-w-0 flex-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Live work</p>
-                <p className="mt-1 text-sm font-semibold text-neutral-950">{providerSnapshotSummary(current.status, latest)}</p>
-                <p className="mt-1 text-xs text-neutral-500">{activities.length} recorded step{activities.length === 1 ? '' : 's'} · raw commands and outputs are available only when you expand a step.</p>
-              </div>
-            </div>
-            {pendingApproval && onApprovalResponse && (
-              <div className="mt-4 border-t border-neutral-200 pt-3">
-                <ChatApproval approval={pendingApproval} onResponse={onApprovalResponse} />
-              </div>
-            )}
-          </section>
-          {tab === 'chat' && (
-            <div className="space-y-3">
-              <div className="rounded-xl border border-neutral-200 bg-white p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Target</p>
-                <p className="mt-1 text-sm font-medium text-neutral-900">{invocation.providerDisplayName}{invocation.sessionId ? ` · ${invocation.sessionId.slice(0, 12)}…` : ''}</p>
-                <p className="mt-2 text-sm text-neutral-600">{invocation.taskSummary || 'Coding task'}</p>
-              </div>
-              {invocation.result && (
-                <div className="max-w-[90%] rounded-xl border border-neutral-200 bg-white px-4 py-3 text-sm text-neutral-700">
-                  {invocation.result}
-                </div>
-              )}
-              {invocation.error && <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{invocation.error}</div>}
-              {Array.from({ length: Math.max(queued.length, continuations.length) }, (_, index) => {
-                const message = queued[index]
-                const continuation = continuations[index]
-                const status = continuation?.status === 'completed'
-                  ? 'Completed'
-                  : continuation?.status === 'failed'
-                    ? 'Failed'
-                    : continuation
-                      ? 'Working'
-                      : 'Queued'
-                return (
-                  <div key={message?.id || continuation.id} className="space-y-3">
-                    <div className="ml-auto max-w-[85%] rounded-xl bg-neutral-900 px-4 py-3 text-sm text-white">
-                      <p>{message?.content || continuation.taskSummary || 'Continuation'}</p>
-                      <p className="mt-1 text-[11px] text-neutral-400">{status} #{index + 1} {status === 'Queued' ? 'to' : 'by'} {invocation.providerDisplayName}</p>
-                    </div>
-                    {(continuation?.result || continuation?.error) && (
-                      <div className={`max-w-[90%] rounded-xl px-4 py-3 text-sm ${continuation.error ? 'bg-red-50 text-red-700' : 'border border-neutral-200 bg-white text-neutral-700'}`}>
-                        {continuation.error || continuation.result}
-                      </div>
-                    )}
+        <div className="mx-auto max-w-3xl space-y-4">
+          {section === 'overview' && (
+            <>
+              <section aria-label="Work Room progress" className="rounded-xl border border-neutral-200 bg-white p-4 sm:p-5">
+                <div className="flex items-start gap-3">
+                  <ToolStatus
+                    status={current.status === 'completed'
+                      ? 'done'
+                      : current.status === 'cancelled'
+                        ? 'stopped'
+                        : current.status === 'failed'
+                          ? 'error'
+                          : 'running'}
+                    awaitingApproval={current.status === 'awaiting_approval'}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Current progress</p>
+                    <p className="mt-1 text-base font-semibold text-neutral-950">{summary}</p>
+                    <p className="mt-1 text-sm text-neutral-600">{progressDetail}</p>
+                    <p className="mt-3 text-xs leading-5 text-neutral-500">
+                      Access: <span className="font-medium text-neutral-700">{providerPermissionLabel(current.permissionMode)}</span>
+                      {' · '}{providerPermissionBoundary(current.permissionMode)}
+                    </p>
                   </div>
-                )
-              })}
-            </div>
-          )}
-
-          {tab === 'activity' && (
-            <ol className="max-h-[calc(100dvh-16rem)] space-y-2 overflow-y-auto overscroll-contain pr-1" aria-label={`${invocation.providerDisplayName} Work Room activity`}>
-              {[...activities].reverse().map(activity => (
-                <li key={activity.id} className="rounded-xl border border-neutral-200 bg-white p-3 sm:p-4">
-                  <details>
-                    <summary className="flex min-w-0 cursor-pointer list-none gap-3 marker:hidden">
-                      <ToolStatus status={activity.status} className="mt-0.5" />
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-neutral-900">{activitySummary(activity, running)}</p>
-                        <p className="mt-1 text-xs capitalize text-neutral-500">{activity.status}</p>
-                      </div>
-                    </summary>
-                    <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-neutral-900 p-3 text-xs leading-5 text-neutral-100">{activityRawDetails(activity)}</pre>
-                  </details>
-                </li>
-              ))}
-              {activities.length === 0 && (
-                <li className="py-12 text-center text-sm text-neutral-500">
-                  {running ? 'Waiting for provider activity…' : 'No provider activity reported.'}
-                </li>
-              )}
-            </ol>
-          )}
-
-          {tab === 'files' && (
-            <div className="space-y-2">
-              {files.map(({ activity, path }) => (
-                <div key={activity.id} className="rounded-xl border border-neutral-200 bg-white p-4">
-                  <p className="break-all font-mono text-sm text-neutral-800">{path}</p>
-                  <p className="mt-1 text-xs capitalize text-neutral-500">{activity.status}</p>
                 </div>
-              ))}
-              {files.length === 0 && <p className="py-12 text-center text-sm text-neutral-500">No file changes reported yet.</p>}
-            </div>
+              </section>
+
+              {hasDecision && (
+                <section aria-live="assertive" aria-label="Work Room decision" className="rounded-xl border border-amber-200 bg-amber-50 p-1">
+                  <ChatApproval approval={pendingApproval!} onResponse={onApprovalResponse!} />
+                </section>
+              )}
+
+              <section aria-label="Recent activity" className="rounded-xl border border-neutral-200 bg-white p-4 sm:p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="text-sm font-semibold text-neutral-950">Recent activity</h2>
+                  {activities.length > recentLimit && (
+                    <button
+                      type="button"
+                      onClick={() => setSection('activity')}
+                      className="min-h-11 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
+                    >
+                      View all
+                    </button>
+                  )}
+                </div>
+                <ActivityList activities={recentActivities} running={running} empty={running ? 'Waiting for provider activity…' : 'No provider activity reported.'} />
+              </section>
+
+              {files.length > 0 && (
+                <section aria-label="Provider file evidence" className="rounded-xl border border-neutral-200 bg-white p-4 sm:p-5">
+                  <h2 className="text-sm font-semibold text-neutral-950">Files changed</h2>
+                  <ul className="mt-3 divide-y divide-neutral-100">
+                    {files.map(file => (
+                      <li key={file.name} className="flex min-h-11 items-center justify-between gap-3 py-2 text-sm">
+                        <span className="min-w-0 truncate font-medium text-neutral-800">{file.name}</span>
+                        <span className="shrink-0 text-xs capitalize text-neutral-500">{file.status}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+            </>
           )}
+
+          {section === 'activity' && (
+            <section aria-label="All provider activity" className="rounded-xl border border-neutral-200 bg-white p-4 sm:p-5">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold text-neutral-950">Activity</h2>
+                {activities.length > recentLimit && (
+                  <button
+                    type="button"
+                    onClick={() => setShowEarlier(value => !value)}
+                    aria-expanded={showEarlier}
+                    className="min-h-11 rounded-lg px-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
+                  >
+                    {showEarlier ? 'Show recent' : `Show ${activities.length - recentLimit} earlier`}
+                  </button>
+                )}
+              </div>
+              <ActivityList activities={visibleActivities} running={running} empty={running ? 'Waiting for provider activity…' : 'No provider activity reported.'} />
+            </section>
+          )}
+
         </div>
       </main>
-
-      {tab === 'chat' && (
-        <footer className="shrink-0 border-t border-neutral-200 bg-white p-3 sm:p-4">
-          <div className="mx-auto flex max-w-4xl items-end gap-2">
-            <label className="min-w-0 flex-1">
-              <span className="sr-only">Message {invocation.providerDisplayName}</span>
-              <textarea
-                value={draft}
-                onChange={event => setDraft(event.target.value)}
-                onKeyDown={event => {
-                  if (event.key === 'Enter' && !event.shiftKey) {
-                    event.preventDefault()
-                    submit()
-                  }
-                }}
-                disabled={!onMessage}
-                rows={2}
-                placeholder={`Message ${invocation.providerDisplayName}…`}
-                className="max-h-32 min-h-12 w-full resize-none rounded-xl border border-neutral-300 px-3 py-2.5 text-sm outline-none focus:border-neutral-500 disabled:bg-neutral-100"
-              />
-            </label>
-            <button type="button" onClick={submit} disabled={!draft.trim() || !onMessage} aria-label={`Send to ${invocation.providerDisplayName}`} className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-neutral-900 text-white hover:bg-neutral-800 disabled:bg-neutral-300">
-              <HiOutlinePaperAirplane className="h-5 w-5" />
-            </button>
-          </div>
-        </footer>
-      )}
     </div>,
     document.body,
+  )
+}
+
+function ActivityList({
+  activities,
+  running,
+  empty,
+}: {
+  activities: DisplayActivity[]
+  running: boolean
+  empty: string
+}) {
+  if (!activities.length) return <p className="mt-3 text-sm text-neutral-600">{empty}</p>
+  return (
+    <ol className="mt-3 divide-y divide-neutral-100">
+      {activities.map(activity => (
+        <li key={activity.id} className="flex min-h-14 items-start gap-3 py-3">
+          <ToolStatus status={activity.status} className="mt-0.5 shrink-0" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-neutral-900">{activity.title || activitySummary(activity, running)}</p>
+            <p className="mt-0.5 text-sm text-neutral-600">
+              {activity.summary || activitySummary(activity, running)}
+              {activity.occurrences && activity.occurrences > 1
+                ? ` · ${activity.occurrences} recorded checks`
+                : ''}
+            </p>
+            {activity.files?.length ? (
+              <p className="mt-1 text-xs text-neutral-500">{activity.files.join(', ')}</p>
+            ) : activity.legacy ? (
+              <p className="mt-1 text-xs text-neutral-500">Legacy activity</p>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ol>
   )
 }

--- a/components/chat/messages/tools/approval-buttons.tsx
+++ b/components/chat/messages/tools/approval-buttons.tsx
@@ -91,19 +91,19 @@ export function ApprovalButtons({
             <button
               type="button"
               onClick={() => setConfirmSession(true)}
-              className="flex min-h-11 w-full items-center gap-2 rounded-lg border border-amber-300 px-3 text-left text-sm font-medium text-amber-900 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-700"
+              className="flex min-h-11 w-full items-center gap-2 rounded-lg border border-neutral-300 px-3 text-left text-sm font-medium text-neutral-800 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
             >
               <HiOutlineShieldCheck className="h-5 w-5 shrink-0" aria-hidden />
               Trust this Work Room for the session
             </button>
           )}
           {allowSession && confirmSession && (
-            <div className="rounded-lg border border-amber-300 bg-amber-50 p-3">
-              <p className="text-sm font-medium text-amber-950">Trust future matching requests in this Work Room?</p>
-              <p className="mt-1 text-sm text-amber-900">You can end the session to remove this trust.</p>
+            <div className="rounded-lg border border-neutral-300 bg-neutral-50 p-3">
+              <p className="text-sm font-medium text-neutral-950">Trust future matching requests in this Work Room?</p>
+              <p className="mt-1 text-sm text-neutral-700">You can end the session to remove this trust.</p>
               <div className="mt-3 flex flex-wrap gap-2">
-                <button type="button" onClick={() => setConfirmSession(false)} className="min-h-11 rounded-lg border border-amber-300 px-3 text-sm font-medium text-amber-900 hover:bg-white">Cancel</button>
-                <button type="button" onClick={() => onApproval(true, 'session')} className="min-h-11 rounded-lg bg-amber-800 px-3 text-sm font-semibold text-white hover:bg-amber-900">Confirm trust</button>
+                <button type="button" onClick={() => setConfirmSession(false)} className="min-h-11 rounded-lg border border-neutral-300 px-3 text-sm font-medium text-neutral-700 hover:bg-white">Cancel</button>
+                <button type="button" onClick={() => onApproval(true, 'session')} className="min-h-11 rounded-lg bg-neutral-900 px-3 text-sm font-semibold text-white hover:bg-neutral-800">Confirm trust</button>
               </div>
             </div>
           )}

--- a/components/chat/messages/tools/approval-buttons.tsx
+++ b/components/chat/messages/tools/approval-buttons.tsx
@@ -1,11 +1,11 @@
 'use client'
 
+import { useState } from 'react'
 import {
   HiOutlineCheck,
+  HiOutlineQuestionMarkCircle,
   HiOutlineShieldCheck,
   HiOutlineX,
-  HiOutlineStop,
-  HiOutlineQuestionMarkCircle
 } from 'react-icons/hi'
 
 export type ApprovalState = 'approved' | 'approved_session' | 'skipped' | 'stopped' | null
@@ -17,134 +17,113 @@ interface BatchTool {
 
 interface ApprovalButtonsProps {
   approvalSent: ApprovalState
-  onApproval: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain') => void
-  toolName?: string
+  onApproval: (
+    approved: boolean,
+    scope: 'once' | 'session',
+    mode?: 'reject_soft' | 'reject_hard' | 'reject_explain',
+  ) => void
   description?: string
+  /** Kept for generic tool-card compatibility; native approval copy comes from Core. */
+  toolName?: string
   batchRemaining?: BatchTool[]
+  allowOnce?: boolean
+  allowSession?: boolean
+  /** Specific safe reason a native request has no approve control. */
+  blockedMessage?: string
 }
 
-function getToolSummary(tool: string, args: string): string {
-  const baseTool = tool.split(':')[0]
-  try {
-    const parsed = JSON.parse(args)
-    if (baseTool === 'bash' || baseTool === 'shell' || baseTool === 'run' || baseTool === 'run_background') return parsed.command || ''
-    if (baseTool === 'write' || baseTool === 'edit' || baseTool === 'read') return parsed.file_path || parsed.path || ''
-    if (baseTool === 'send_email') return parsed.to || ''
-    // fallback: show first string value
-    const first = Object.values(parsed).find(v => typeof v === 'string')
-    return (first as string) || ''
-  } catch {
-    return args
-  }
-}
-
-export function ApprovalButtons({ approvalSent, onApproval, toolName, description, batchRemaining }: ApprovalButtonsProps) {
+/** Deliberate approval hierarchy: one primary action; broader trust is confirmed. */
+export function ApprovalButtons({
+  approvalSent,
+  onApproval,
+  description,
+  batchRemaining,
+  allowOnce = true,
+  allowSession = false,
+  blockedMessage,
+}: ApprovalButtonsProps) {
+  const [confirmSession, setConfirmSession] = useState(false)
   if (approvalSent) {
-    return (
-      <div className="py-2 px-1 border-t border-neutral-100 mt-1 animate-in fade-in duration-300">
-        <div className="flex items-center gap-2 text-[11px] text-neutral-500 font-medium italic">
-          {approvalSent === 'skipped' ? (
-            <span className="flex items-center gap-1.5"><HiOutlineX className="w-3.5 h-3.5 shrink-0" /> Tool rejected</span>
-          ) : approvalSent === 'stopped' ? (
-            <span className="flex items-center gap-1.5 text-red-500"><HiOutlineStop className="w-3.5 h-3.5 shrink-0" /> Execution stopped</span>
-          ) : (
-            <span className="flex items-center gap-1.5 text-brand-600">
-              <HiOutlineCheck className="w-3.5 h-3.5" />
-              {approvalSent === 'approved_session' ? 'Session authorized' : 'Approved'} — running...
-            </span>
-          )}
-        </div>
-      </div>
-    )
+    const copy = approvalSent === 'approved_session'
+      ? 'Session trust confirmed — continuing…'
+      : approvalSent === 'approved'
+        ? 'Allowed once — continuing…'
+        : approvalSent === 'skipped'
+          ? 'This request was rejected'
+          : 'This request was stopped'
+    return <p className="px-1 py-3 text-sm font-medium text-neutral-700" role="status">{copy}</p>
   }
 
   return (
-    <div className="mt-2 border-l-2 border-neutral-200 bg-neutral-50/50 rounded-r-lg overflow-hidden animate-in fade-in slide-in-from-top-1 duration-200">
-      <div className="p-1">
-        {/* Main Approve Action */}
+    <div className="mt-4 space-y-3">
+      <div className={`grid gap-2 ${allowOnce ? 'grid-cols-2' : 'grid-cols-1'}`}>
+        {allowOnce ? (
+          <button
+            type="button"
+            onClick={() => onApproval(true, 'once')}
+            className="flex min-h-12 w-full items-center justify-center gap-2 rounded-lg bg-neutral-900 px-3 text-sm font-semibold text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
+          >
+            <HiOutlineCheck className="h-5 w-5 shrink-0" aria-hidden />
+            Allow once
+          </button>
+        ) : (
+          <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-sm text-red-800">
+            {blockedMessage || 'This request is outside the selected Work Room and cannot be allowed here.'}
+          </p>
+        )}
         <button
-          onClick={() => onApproval(true, 'once')}
-          className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white transition-colors group"
+          type="button"
+          onClick={() => onApproval(false, 'once', 'reject_soft')}
+          className="flex min-h-12 w-full items-center justify-center gap-2 rounded-lg border border-neutral-300 bg-white px-3 text-sm font-semibold text-neutral-700 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
         >
-          <HiOutlineCheck className="w-4 h-4 text-neutral-400 group-hover:text-brand-600" />
-          <div className="flex-1">
-            <span className="text-sm font-semibold text-neutral-800">Allow once</span>
-            <span className="text-xs text-neutral-500 ml-2 font-normal">{description || 'Only this command'}</span>
-          </div>
+          <HiOutlineX className="h-5 w-5 shrink-0" aria-hidden />
+          Reject this request
         </button>
-
-        {/* Session Approval */}
-        <button
-          onClick={() => onApproval(true, 'session')}
-          className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-white transition-colors group"
-        >
-          <HiOutlineShieldCheck className="w-4 h-4 text-neutral-400 group-hover:text-neutral-600" />
-          <div className="flex-1 min-w-0">
-            {/* Same weight as "Allow once": this grant is the broader of the two,
-                and rendering it lighter made the wider permission read as the
-                more casual choice. The consequence is spelled out rather than
-                implied by the words "for this session". */}
-            <span className="text-sm font-semibold text-neutral-800">Trust {toolName || 'this tool'}</span>
-            <span className="text-xs text-neutral-500 ml-2">for this session</span>
-            <span className="block text-xs text-neutral-500">Won&apos;t ask again this conversation</span>
-          </div>
-        </button>
-
-        <div className="mx-3 my-1 border-t border-neutral-100" />
-
-        {/* Reject/Stop actions */}
-        <div className="flex flex-wrap items-center">
-          <button
-            onClick={() => onApproval(false, 'once', 'reject_soft')}
-            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
-          >
-            <HiOutlineX className="w-3.5 h-3.5 shrink-0" />
-            <span>Reject</span>
-            <span className="text-neutral-500">this tool</span>
-          </button>
-          <div className="w-px h-4 bg-neutral-100" />
-          <button
-            onClick={() => onApproval(false, 'once', 'reject_hard')}
-            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-red-600 hover:bg-white transition-colors"
-          >
-            <HiOutlineStop className="w-3.5 h-3.5 shrink-0" />
-            <span>Stop</span>
-            <span className="text-neutral-500">all & redirect</span>
-          </button>
-          <div className="w-px h-4 bg-neutral-100" />
-          <button
-            onClick={() => onApproval(false, 'once', 'reject_explain')}
-            className="flex-1 min-w-[7.5rem] flex items-center justify-center gap-1.5 py-2.5 text-xs text-neutral-500 hover:text-neutral-800 hover:bg-white transition-colors"
-            title="I don't understand - please explain this action"
-          >
-            <HiOutlineQuestionMarkCircle className="w-3.5 h-3.5 shrink-0" />
-            <span>Explain</span>
-            <span className="text-neutral-500">why?</span>
-          </button>
-        </div>
       </div>
+      {description && <p className="text-sm text-neutral-600">{description}</p>}
 
-      {batchRemaining && batchRemaining.length > 0 && (
-        <div className="px-3 py-2.5 bg-neutral-100/50 border-t border-neutral-100">
-          <div className="flex items-center gap-1.5 mb-2 px-0.5">
-            <span className="text-[11px] font-bold text-neutral-400 uppercase tracking-wide">Up Next ({batchRemaining.length})</span>
-          </div>
-          <div className="space-y-1.5">
-            {batchRemaining.map((t, i) => {
-              const summary = getToolSummary(t.tool, t.arguments)
-              return (
-                <div key={i} className="flex items-start gap-2 text-[11px] font-mono leading-tight">
-                  <span className="text-neutral-300 mt-0.5">$</span>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-neutral-800 font-semibold mr-2">{t.tool}</span>
-                    <span className="text-neutral-500 truncate inline-block w-full">{summary}</span>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
+      <details className="rounded-lg border border-neutral-200 bg-white">
+        <summary className="flex min-h-11 cursor-pointer list-none items-center px-3 text-sm font-medium text-neutral-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900">
+          Other review options
+        </summary>
+        <div className="space-y-3 border-t border-neutral-100 p-3">
+          {allowSession && !confirmSession && (
+            <button
+              type="button"
+              onClick={() => setConfirmSession(true)}
+              className="flex min-h-11 w-full items-center gap-2 rounded-lg border border-amber-300 px-3 text-left text-sm font-medium text-amber-900 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-700"
+            >
+              <HiOutlineShieldCheck className="h-5 w-5 shrink-0" aria-hidden />
+              Trust this Work Room for the session
+            </button>
+          )}
+          {allowSession && confirmSession && (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-3">
+              <p className="text-sm font-medium text-amber-950">Trust future matching requests in this Work Room?</p>
+              <p className="mt-1 text-sm text-amber-900">You can end the session to remove this trust.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button type="button" onClick={() => setConfirmSession(false)} className="min-h-11 rounded-lg border border-amber-300 px-3 text-sm font-medium text-amber-900 hover:bg-white">Cancel</button>
+                <button type="button" onClick={() => onApproval(true, 'session')} className="min-h-11 rounded-lg bg-amber-800 px-3 text-sm font-semibold text-white hover:bg-amber-900">Confirm trust</button>
+              </div>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => onApproval(false, 'once', 'reject_explain')}
+            className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3 text-left text-sm font-medium text-neutral-700 hover:bg-neutral-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900"
+          >
+            <HiOutlineQuestionMarkCircle className="h-5 w-5" aria-hidden />
+            Reject and ask for an explanation
+          </button>
+          <p className="px-1 text-xs leading-5 text-neutral-500">
+            Raw provider commands and output are not shown here. This decision
+            uses the verified action and Work Room boundary above.
+          </p>
         </div>
-      )}
+      </details>
+      {batchRemaining?.length ? (
+        <p className="text-xs text-neutral-500">Additional approval requests may follow.</p>
+      ) : null}
     </div>
   )
 }

--- a/components/chat/messages/tools/tool-status.tsx
+++ b/components/chat/messages/tools/tool-status.tsx
@@ -18,19 +18,23 @@ export function ToolStatus({
   awaitingApproval = false,
   className,
 }: {
-  status: 'running' | 'done' | 'error' | string
+  status: 'running' | 'done' | 'error' | 'stopped' | string
   /** Neutral rather than brand while the run is parked on the reader. */
   awaitingApproval?: boolean
   className?: string
 }) {
   return (
-    <span className={cn('flex h-4 w-4 shrink-0 items-center justify-center', className)}>
+    <span data-tool-status={status} className={cn('flex h-4 w-4 shrink-0 items-center justify-center', className)}>
       {status === 'done' ? (
         <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-neutral-100">
           <HiOutlineCheck className="h-2.5 w-2.5 text-neutral-600" />
         </span>
       ) : status === 'error' ? (
         <HiOutlineX className="h-3.5 w-3.5 text-red-600" />
+      ) : status === 'stopped' ? (
+        <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-neutral-100">
+          <HiOutlineX className="h-2.5 w-2.5 text-neutral-600" />
+        </span>
       ) : status === 'running' ? (
         <span
           className={cn(

--- a/components/chat/mode-policy.test.ts
+++ b/components/chat/mode-policy.test.ts
@@ -6,7 +6,16 @@ import {
   selectablePermissionProfiles,
 } from './mode-policy'
 
-const profile = (id: HostPermissionOption['id']): HostPermissionOption => ({ id, name: id })
+const profile = (id: HostPermissionOption['id']): HostPermissionOption => ({
+  id,
+  wireId: id,
+  profile: id === ':read-only'
+    ? 'safe'
+    : id === ':workspace'
+      ? 'default'
+      : 'full_access',
+  name: id,
+})
 
 describe('O Chat Codex-style mode policy', () => {
   test('keeps collaboration independent from permission authority', () => {

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -254,7 +254,6 @@ export interface ChatMessagesProps {
   ui?: Array<UI | ProviderInvocationUI>
   className?: string
   isLoading?: boolean
-  onStop?: () => void
   /** Stop only the native coding-provider invocation selected in a Work Room. */
   onProviderStop?: (invocationId: string) => void
   pendingApproval?: PendingApproval | null

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -82,6 +82,16 @@ export interface PendingApproval {
   providerInvocationId?: string
   parentToolCallId?: string
   activityId?: string
+  /** Core-verified presentation for a native provider approval. */
+  providerApproval?: {
+    action: string
+    scope: string
+    reason: string
+    scopeClassification: 'workroom' | 'elevated' | 'unknown'
+    allowOnce: boolean
+    allowSession: boolean
+    files?: string[]
+  }
 }
 
 export interface PendingOnboard {
@@ -116,18 +126,28 @@ export interface ProviderInvocationUI {
   parentToolCallId: string
   provider: 'codex' | 'claude_code'
   providerDisplayName: string
+  taskTitle?: string
   taskSummary?: string
+  currentSummary?: string
   permissionMode?: 'manual' | 'auto_approve' | 'full_access'
   status: 'starting' | 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled'
   activities: Array<{
     id: string
-    name: string
+    name?: string
     args?: Record<string, unknown>
     status: 'running' | 'done' | 'error'
     result?: string
+    sequence?: number
+    kind?: 'command' | 'file_change' | 'inspect' | 'search' | 'tool'
+    title?: string
+    summary?: string
+    files?: string[]
+    legacy?: boolean
   }>
   sessionId?: string
   elapsedMs?: number
+  resultSummary?: string
+  errorSummary?: string
   result?: string
   error?: string
 }
@@ -161,6 +181,8 @@ export interface ChatProps {
   onSend: (message: string, images?: string[], files?: FileAttachment[]) => void
   /** Gracefully stop the running agent (shown as a stop button while isLoading) */
   onStop?: () => void
+  /** Stop only the native coding-provider invocation selected in a Work Room. */
+  onProviderStop?: (invocationId: string) => void
   isLoading?: boolean
   /** Disable every message entry point while a Host policy write is pending. */
   inputDisabled?: boolean
@@ -233,7 +255,8 @@ export interface ChatMessagesProps {
   className?: string
   isLoading?: boolean
   onStop?: () => void
-  onProviderMessage?: (invocation: ProviderInvocationUI, message: string) => void
+  /** Stop only the native coding-provider invocation selected in a Work Room. */
+  onProviderStop?: (invocationId: string) => void
   pendingApproval?: PendingApproval | null
   onApprovalResponse?: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
   pendingAskUser?: PendingAskUser | null

--- a/components/chat/use-agent-sdk.ts
+++ b/components/chat/use-agent-sdk.ts
@@ -44,6 +44,34 @@ export type UI = ChatItem
 
 type ApprovalItem = Extract<ChatItem, { type: 'approval_needed' }>
 
+const SAFE_PROVIDER_APPROVAL_ACTIONS = new Set([
+  'Run a workspace command',
+  'Compile the requested C11 program',
+  'Compile the requested C program',
+  'Compile and run the requested tests',
+  'Run the requested tests',
+  'Run the requested program',
+  'Inspect the workspace',
+  'Make workspace file changes',
+  'Expand provider permissions',
+  'Perform a provider action',
+])
+const SAFE_PROVIDER_APPROVAL_REASONS = new Set([
+  'Codex requested approval to continue',
+  'Claude Code requested approval to continue',
+  'Compile the requested workspace files before continuing',
+  'Verify the requested workspace changes before continuing',
+  'Verify the requested program before continuing',
+  'Check the requested workspace result before continuing',
+  'Apply the requested workspace file changes',
+  'Review the requested permission expansion',
+])
+const PROVIDER_APPROVAL_SCOPES = {
+  workroom: 'This Work Room only',
+  elevated: 'Outside this Work Room',
+  unknown: 'Boundary could not be verified',
+} as const
+
 function nativeProviderApproval(item: ApprovalItem): Pick<PendingApproval, 'provider' | 'providerInvocationId' | 'parentToolCallId' | 'activityId'> | null {
   const candidate = item as ApprovalItem & {
     provider?: PendingApproval['provider']
@@ -61,6 +89,36 @@ function nativeProviderApproval(item: ApprovalItem): Pick<PendingApproval, 'prov
     providerInvocationId: candidate.providerInvocationId,
     parentToolCallId: candidate.parentToolCallId,
     ...(candidate.activityId && { activityId: candidate.activityId }),
+  }
+}
+
+function nativeProviderApprovalPresentation(
+  item: ApprovalItem,
+): Pick<PendingApproval, 'providerApproval'> | null {
+  const candidate = item as ApprovalItem & { providerApproval?: PendingApproval['providerApproval'] }
+  const value = candidate.providerApproval
+  if (
+    !value
+    || (value.scopeClassification !== 'workroom'
+      && value.scopeClassification !== 'elevated'
+      && value.scopeClassification !== 'unknown')
+    || typeof value.action !== 'string'
+    || !SAFE_PROVIDER_APPROVAL_ACTIONS.has(value.action)
+    || typeof value.scope !== 'string'
+    || value.scope !== PROVIDER_APPROVAL_SCOPES[value.scopeClassification]
+    || typeof value.reason !== 'string'
+    || !SAFE_PROVIDER_APPROVAL_REASONS.has(value.reason)
+    || typeof value.allowOnce !== 'boolean'
+    || typeof value.allowSession !== 'boolean'
+  ) return null
+  return {
+    providerApproval: {
+      ...value,
+      // A rolling deployment can receive an older React package's native
+      // envelope directly. Apply the same fail-closed authority rule here.
+      allowOnce: value.scopeClassification === 'workroom' ? value.allowOnce : false,
+      allowSession: value.scopeClassification === 'workroom' ? value.allowSession : false,
+    },
   }
 }
 
@@ -141,6 +199,8 @@ interface UseAgentSDKReturn {
   retry: (content: string, images?: string[], files?: import('./types').FileAttachment[]) => void
   /** Gracefully stop a running agent: it finishes the current step and returns a closing message */
   interrupt: () => void
+  /** Stop one native coding-provider invocation without interrupting the whole agent turn. */
+  interruptProvider: (invocationId: string) => void
   respondToAskUser: (answer: string | string[]) => void
   respondToApproval: (approved: boolean, scope: 'once' | 'session', mode?: 'reject_soft' | 'reject_hard' | 'reject_explain', feedback?: string) => void
   respondToPlanReview: (message: string) => void
@@ -239,6 +299,7 @@ export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingA
 
   if (pendingApprovalItem) {
     const providerApproval = nativeProviderApproval(pendingApprovalItem)
+    const providerPresentation = nativeProviderApprovalPresentation(pendingApprovalItem)
     const providerStatus = providerApproval
       ? providerStatuses.get(providerApproval.providerInvocationId!)
       : undefined
@@ -254,6 +315,7 @@ export function extractPendingStates(ui: ChatItem[]): { pendingAskUser: PendingA
         ...(pendingApprovalItem.description && { description: pendingApprovalItem.description }),
         ...(pendingApprovalItem.batch_remaining && { batch_remaining: pendingApprovalItem.batch_remaining }),
         ...(providerApproval || {}),
+        ...(providerPresentation || {}),
       }
     }
   }
@@ -333,6 +395,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     sendMessage,
     respondToApproval: sdkRespondToApproval,
     interrupt: sdkInterrupt,
+    interruptProvider: sdkInterruptProvider,
     signOnboard,
     setCollaborationMode: setSDKCollaborationMode,
     setPermissionProfile: setSDKPermissionProfile,
@@ -587,6 +650,7 @@ export function useAgentSDK(options: UseAgentSDKOptions): UseAgentSDKReturn {
     send,
     retry,
     interrupt,
+    interruptProvider: sdkInterruptProvider,
     respondToAskUser,
     respondToApproval,
     respondToPlanReview,

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -2,19 +2,19 @@
  * Which answer actually reaches the agent.
  *
  * The approval prompt is the one place a reader tells an agent whether it may
- * run something. Existing coverage checks that the prompt appears, that all five
- * answers are on screen, and that they are big enough to tap — not one of them
- * checks what pressing them *sends*.
+ * run something. Existing coverage checks that the prompt appears, that its
+ * primary choices are on screen, and that they are big enough to tap — not one
+ * of them checks what pressing them *sends*.
  *
- * That gap is the highest-severity one in this app. The five buttons differ only
- * in the frame they produce; on screen they are five rounded rectangles. Cross
- * two `onClick` handlers in a refactor and the UI looks perfect while an agent
- * runs a command the reader rejected. Nothing would catch it, and on an agent
- * with `bash` the first symptom is the damage.
+ * That gap is the highest-severity one in this app. The compact first layer has
+ * exactly two choices: allow this request once, or reject it. Cross two
+ * `onClick` handlers in a refactor and the UI looks perfect while an agent runs
+ * a command the reader rejected. Nothing would catch it, and on an agent with
+ * `bash` the first symptom is the damage.
  *
- * So these assert the wire, not the pixels. The frame shapes were read off a
- * live run rather than off the source, so this is a record of what the agent is
- * actually told.
+ * The explanation path is deliberately behind "Other review options" so it
+ * remains available without turning an urgent decision into a crowded menu.
+ * These assert the wire, not the pixels.
  */
 
 import { test, expect } from './fixtures'
@@ -31,20 +31,17 @@ async function atAnApproval(
   return agent
 }
 
-/** Label → the exact OIP approval decision the Host must receive. */
-const DECISIONS: [RegExp, Record<string, unknown>][] = [
+/** Primary label → the exact OIP approval decision the Host must receive. */
+const PRIMARY_DECISIONS: [RegExp, Record<string, unknown>][] = [
   [/allow once/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'once' }],
-  [/trust/i, { type: 'APPROVAL_RESPONSE', approved: true, scope: 'session' }],
-  [/reject/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_soft' }],
-  [/stop/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_hard' }],
-  [/explain/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_explain' }],
+  [/reject this request/i, { type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_soft' }],
 ]
 
 test.describe('phone', () => {
   test.describe.configure({ timeout: 120_000 })
   test.use({ viewport: { width: 375, height: 667 } })
 
-  for (const [label, response] of DECISIONS) {
+  for (const [label, response] of PRIMARY_DECISIONS) {
     test(`"${label.source}" sends exactly what it promises`, async ({ page }) => {
       const agent = await atAnApproval(page)
 
@@ -55,6 +52,17 @@ test.describe('phone', () => {
         .toEqual([response])
     })
   }
+
+  test('the optional explanation path sends exactly what it promises', async ({ page }) => {
+    const agent = await atAnApproval(page)
+
+    await page.getByText('Other review options', { exact: true }).click()
+    await page.getByRole('button', { name: /reject and ask for an explanation/i }).click()
+
+    await expect
+      .poll(() => agent.sent('APPROVAL_RESPONSE'), { timeout: 10_000 })
+      .toEqual([{ type: 'APPROVAL_RESPONSE', approved: false, scope: 'once', mode: 'reject_explain' }])
+  })
 
   test('nothing is answered until the reader answers it', async ({ page, shot }) => {
     const agent = await atAnApproval(page)

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -86,16 +86,19 @@ test.describe('a full exchange', () => {
     await expect(page.getByText('uname -a')).toBeVisible()
   })
 
-  test('an approval prompt blocks the run and offers all four answers', async ({ page }) => {
+  test('an approval prompt blocks the run with a simple first decision layer', async ({ page }) => {
     await landing(page, 'approval')
     await page.getByRole('button', { name: 'What can you do?' }).click()
 
     await expect(page.getByRole('button', { name: /allow once/i })).toBeVisible({ timeout: 15_000 })
-    // Each qualifier has to be readable, not just present — this row is the only
-    // thing separating "reject one call" from "kill the whole run".
-    for (const label of [/trust/i, /reject/i, /stop/i, /explain/i]) {
-      await expect(page.getByRole('button', { name: label })).toBeVisible()
-    }
+    await expect(page.getByRole('button', { name: /reject this request/i })).toBeVisible()
+    await expect(page.getByText('Other review options', { exact: true })).toBeVisible()
+    // A parked approval is already waiting on the reader. "Stop" here used to
+    // mean two different things, so only a specific rejection is offered.
+    await expect(page.getByRole('button', { name: /^stop/i })).toHaveCount(0)
+
+    await page.getByText('Other review options', { exact: true }).click()
+    await expect(page.getByRole('button', { name: /reject and ask for an explanation/i })).toBeVisible()
   })
 
   test('an agent error is surfaced, not swallowed', async ({ page }) => {

--- a/e2e/coding-agent-card.spec.ts
+++ b/e2e/coding-agent-card.spec.ts
@@ -1,13 +1,16 @@
-/** Exact React package events render as one usable nested coding-agent card. */
+/** Native provider OIP events render as one calm, evidence-based Work Room. */
 
 import { type Page } from '@playwright/test'
 import { test, expect, pane } from './fixtures'
 import { mockAgent, AGENT_ADDRESS, PROFILE, type Scenario } from './mock-agent'
 
+const taskTitle = 'Build and verify the requested C program'
+const rawInstruction = 'Work inside /private/tmp/codex-workroom. Create sort.c and test_sort.c, compile with cc -std=c11 -Wall -Wextra -Werror, run sorting fixtures, inspect the output, and report the raw command transcript.'
+
 async function openCodingRun(
   page: Page,
   scenario: Extract<Scenario, 'coding-agent' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval'> = 'coding-agent',
-  status: 'running' | 'completed' | 'failed' | 'awaiting approval' = 'running',
+  status: 'Working' | 'Completed' | 'Needs attention' | 'Needs your decision' = 'Working',
 ) {
   await page.addInitScript(() => {
     localStorage.setItem(
@@ -15,162 +18,179 @@ async function openCodingRun(
       JSON.stringify({ state: { conversations: [], agents: [] }, version: 0 }),
     )
   })
-  await mockAgent(page, scenario)
+  const agent = await mockAgent(page, scenario)
   await page.goto(`/${AGENT_ADDRESS}`)
   await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
   await page.getByRole('button', { name: 'What can you do?' }).click()
   await expect(pane(page).getByRole('region', { name: `Codex ${status}` })).toBeVisible({
     timeout: 15_000,
   })
+  return agent
 }
 
-test('running Codex activity stays nested under one expandable card', async ({ page, shot }) => {
+function workroom(page: Page) {
+  return page.getByRole('dialog', { name: taskTitle })
+}
+
+test('a long native Codex run stays calm in the transcript and defaults to a three-step overview', async ({ page, shot }) => {
   await openCodingRun(page)
 
-  const card = pane(page).getByRole('region', { name: 'Codex running' })
-  await expect(card).toContainText('Fix Windows tests')
-  await expect(card).toContainText('running')
-  await expect(card.getByRole('button', { name: 'Stop Codex' })).toBeVisible()
-  await card.getByRole('button', { expanded: false }).click()
-  const activity = card.getByRole('list', { name: 'Codex activity' })
-  await expect(activity).toContainText('Running tests')
-  await expect(activity.locator('details:not([open])')).toHaveCount(1)
-  await activity.locator('summary').click()
-  await expect(activity).toContainText('pytest -q')
-  await expect(activity).toContainText('89 passed')
-  await expect(pane(page).getByRole('region', { name: 'Codex running' })).toHaveCount(1)
-  await shot('codex-running-expanded')
-})
+  const card = pane(page).getByRole('region', { name: 'Codex Working' })
+  await expect(card).toContainText(taskTitle)
+  await expect(card).toContainText('Inspecting workspace context')
+  await expect(card).not.toContainText(rawInstruction)
+  await expect(card).not.toContainText('/private/tmp/codex-workroom')
+  await expect(card).not.toContainText('cc -std=c11')
+  await expect(card.locator('pre, details')).toHaveCount(0)
+  await expect(card.getByRole('button')).toHaveCount(1)
+  await expect(card.getByRole('button', { name: 'Open Work Room' })).toBeVisible()
+  await shot('codex-c-sort-card-desktop')
 
-test('Codex card opens an interactive Work Room with target, queue, activity and files', async ({ page, shot }) => {
-  await openCodingRun(page)
-
-  const card = pane(page).getByRole('region', { name: 'Codex running' })
   await card.getByRole('button', { name: 'Open Work Room' }).click()
-  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
+  const room = workroom(page)
   await expect(room).toBeVisible()
-  await expect(room).toContainText('Fix Windows tests')
-
-  await room.getByRole('tab', { name: /Chat/ }).click()
-  await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
-  await room.getByRole('button', { name: 'Send to Codex' }).click()
-  await expect(room).toContainText('Completed #1 by Codex')
-  await expect(room).toContainText('Changelog updated.')
-  await shot('codex-workroom-chat-desktop')
-  await room.getByRole('tab', { name: /Activity/ }).click()
-  await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('pytest -q')
-  await expect(room.getByRole('list', { name: 'Codex Work Room activity' })).toContainText('src/changelog.md')
-  await room.getByRole('tab', { name: /Files/ }).click()
-  await expect(room).toContainText('src/changelog.md')
-  await shot('codex-workroom-desktop')
+  await expect(room.getByLabel('Work Room progress')).toContainText('7 of 8 steps completed')
+  const recent = room.getByLabel('Recent activity')
+  await expect(recent).toContainText('Inspect the workspace')
+  await expect(recent).toContainText('Run the requested tests')
+  await expect(recent).not.toContainText('Update workspace files')
+  await expect(room.getByLabel('Provider file evidence')).toContainText('sort.c')
+  await expect(room.getByLabel('Provider file evidence')).toContainText('test_sort.c')
+  await expect(room).not.toContainText(rawInstruction)
+  await expect(room.locator('pre, details, textarea')).toHaveCount(0)
+  await shot('codex-c-sort-workroom-overview-desktop')
 })
 
-test('Work Room keeps the first result before the resumed request and result', async ({ page }) => {
-  await openCodingRun(page, 'coding-agent-completed', 'completed')
+test('activity history uses one page scroll and reveals older semantic evidence intentionally', async ({ page, shot }) => {
+  await openCodingRun(page)
+  await pane(page).getByRole('region', { name: 'Codex Working' }).getByRole('button', { name: 'Open Work Room' }).click()
+  const room = workroom(page)
 
-  const card = pane(page).getByRole('region', { name: 'Codex completed' })
-  await card.getByRole('button', { name: 'Open Work Room' }).click()
-  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
-  await room.getByRole('tab', { name: /Chat/ }).click()
-  await room.getByPlaceholder('Message Codex…').fill('Also update the changelog')
-  await room.getByRole('button', { name: 'Send to Codex' }).click()
-  await expect(room).toContainText('Changelog updated.')
+  await room.getByRole('button', { name: 'Activity' }).click()
+  const activity = room.getByLabel('All provider activity')
+  await expect(activity.locator('li')).toHaveCount(3)
+  await expect(activity).toContainText('Run the requested tests')
+  await expect(activity).not.toContainText('Update workspace files')
+  await expect(activity.locator('ol')).not.toHaveClass(/overflow-y-auto/)
 
-  const text = await room.textContent()
-  expect(text!.indexOf('Codex fixed the Windows tests.')).toBeLessThan(text!.indexOf('Also update the changelog'))
-  expect(text!.indexOf('Also update the changelog')).toBeLessThan(text!.indexOf('Changelog updated.'))
-})
-
-test('completed Codex card shows the result and no Stop action', async ({ page, shot }) => {
-  await openCodingRun(page, 'coding-agent-completed', 'completed')
-
-  const card = pane(page).getByRole('region', { name: 'Codex completed' })
-  await expect(card).toContainText('1s')
-  expect(
-    await card.getByLabel('Status: completed').evaluate(element => getComputedStyle(element).backgroundColor),
-    'terminal status should be visually separated from the provider label',
-  ).not.toBe('rgba(0, 0, 0, 0)')
-  await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
-  await card.getByRole('button', { expanded: false }).click()
-  await expect(card).toContainText('Codex fixed the Windows tests.')
-  await shot('codex-completed-expanded')
-})
-
-test('failed Codex card exposes the error and no Stop action', async ({ page, shot }) => {
-  await openCodingRun(page, 'coding-agent-failed', 'failed')
-
-  const card = pane(page).getByRole('region', { name: 'Codex failed' })
-  await expect(card.getByLabel('Live activity snapshot')).toContainText('Work stopped before completion')
-  await expect(card.getByRole('button', { name: 'Stop Codex' })).toHaveCount(0)
-  await card.getByRole('button', { expanded: false }).click()
-  await expect(card).toContainText('Codex exited before applying the patch.')
-  await shot('codex-failed-expanded')
-})
-
-test('long native work keeps one actionable card, bounded history, and the approval on that card', async ({ page, shot }) => {
-  await openCodingRun(page, 'coding-agent-long-approval', 'awaiting approval')
-
-  const card = pane(page).getByRole('region', { name: 'Codex awaiting approval' })
-  const providerInstruction = 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
-  await expect(card).toContainText('Waiting for your approval')
-  await expect(card).toContainText('Codex work room')
-  await expect(card).not.toContainText(providerInstruction)
-  await expect(card.locator('.line-clamp-2')).toHaveCount(1)
-  await expect(card.getByLabel('Live activity snapshot')).toBeVisible()
-  await expect(card.getByRole('button', { name: /Allow once/ })).toBeVisible()
-  await card.getByRole('button', { expanded: false }).click()
-  const activity = card.getByRole('list', { name: 'Codex activity' })
+  await room.getByRole('button', { name: 'Show 5 earlier' }).click()
   await expect(activity.locator('li')).toHaveCount(8)
-  await expect(activity).toHaveCSS('overflow-y', 'auto')
-  await shot('codex-long-approval-card')
+  await expect(activity).toContainText('Update workspace files')
+  await expect(activity).not.toContainText('/private/tmp/codex-workroom')
+  await expect(activity).not.toContainText('cc -std=c11')
+  await shot('codex-c-sort-workroom-activity-desktop')
+})
 
+test('a native approval is inside Work Room and exposes only a narrow decision', async ({ page, shot }) => {
+  await openCodingRun(page, 'coding-agent-long-approval', 'Needs your decision')
+
+  const card = pane(page).getByRole('region', { name: 'Codex Needs your decision' })
+  await expect(card).toContainText('Your decision is needed in the Work Room.')
+  await expect(card).not.toContainText('Run the final sorting verification')
+  await expect(card).not.toContainText(rawInstruction)
+  await expect(card.getByRole('button', { name: 'Review decision' })).toBeVisible()
+  await shot('codex-c-sort-approval-card-desktop')
+
+  await card.getByRole('button', { name: 'Review decision' }).click()
+  const room = workroom(page)
+  const approval = room.getByLabel('Approval required')
+  await expect(approval).toContainText('Inspect the workspace')
+  await expect(approval).toContainText('This Work Room only')
+  await expect(approval).toContainText('Check the requested workspace result before continuing')
+  await expect(approval).toContainText('sort.c, test_sort.c')
+  await expect(approval).not.toContainText(rawInstruction)
+  await expect(approval).not.toContainText('cc -std=c11')
+  await expect(approval.getByRole('button', { name: 'Allow once' })).toBeVisible()
+  await expect(approval.getByText('Trust this Work Room for the session')).toHaveCount(0)
+  await shot('codex-c-sort-approval-workroom-desktop')
+})
+
+test('a completed run receives an honest terminal summary', async ({ page }) => {
+  await openCodingRun(page, 'coding-agent-completed', 'Completed')
+  const completed = pane(page).getByRole('region', { name: 'Codex Completed' })
+  await expect(completed).toContainText('Completed the provider run after the recorded compilation and test checks')
+  await completed.getByRole('button', { name: 'Open Work Room' }).click()
+  await expect(workroom(page).getByLabel('Work Room progress')).toContainText('Completed the provider run after the recorded compilation and test checks')
+})
+
+test('Stop targets the current Codex invocation and leaves the outer turn alone', async ({ page }) => {
+  const agent = await openCodingRun(page)
+  const card = pane(page).getByRole('region', { name: 'Codex Working' })
   await card.getByRole('button', { name: 'Open Work Room' }).click()
-  const room = page.getByRole('dialog', { name: 'Codex Work Room' })
-  await expect(room.getByLabel('Work Room live summary')).toContainText('Waiting for your approval')
-  await expect(room).not.toContainText(providerInstruction)
-  await expect(room.getByRole('button', { name: /Allow once/ })).toBeVisible()
-  await expect(room.getByRole('list', { name: 'Codex Work Room activity' }).locator('li')).toHaveCount(8)
-  await room.getByRole('tab', { name: /Chat/ }).click()
-  await expect(room).toContainText(providerInstruction)
-  await shot('codex-long-approval-workroom')
+  const room = workroom(page)
+
+  await room.getByRole('button', { name: 'Stop Codex run' }).click()
+  await expect(room).toContainText('The provider stopped')
+  await expect(room.locator('[data-tool-status="stopped"]')).toBeVisible()
+  expect(agent.sent('PROVIDER_INTERRUPT')).toContainEqual(expect.objectContaining({
+    invocationId: 'codex:call-7',
+  }))
+  expect(agent.sent('INTERRUPT')).toHaveLength(0)
+})
+
+test('a failed run receives an honest terminal summary', async ({ page }) => {
+  await openCodingRun(page, 'coding-agent-failed', 'Needs attention')
+  const failed = pane(page).getByRole('region', { name: 'Codex Needs attention' })
+  await expect(failed).toContainText('The provider reported an error')
 })
 
 test.describe('phone', () => {
   test.use({ viewport: { width: 375, height: 667 } })
 
-  test('expanded provider activity does not overflow the viewport', async ({ page, shot }) => {
+  test('the compact card and one-scroll Work Room do not overflow horizontally', async ({ page, shot }) => {
     await openCodingRun(page)
-    const card = pane(page).getByRole('region', { name: 'Codex running' })
-    await card.getByRole('button', { expanded: false }).click()
-
-    const overflow = await page.evaluate(
-      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
-    )
-    expect(overflow, 'provider card scrolls sideways on a phone').toBeLessThanOrEqual(0)
+    const card = pane(page).getByRole('region', { name: 'Codex Working' })
     await expect(card).toBeInViewport()
-    await shot('codex-phone-expanded')
+    await expect(card).not.toContainText(rawInstruction)
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth),
+      'provider card scrolls sideways on a phone',
+    ).toBeLessThanOrEqual(0)
+    await shot('codex-c-sort-card-phone')
+
+    await card.getByRole('button', { name: 'Open Work Room' }).click()
+    const room = workroom(page)
+    await expect(room).toBeVisible()
+    await expect(room.getByRole('heading', { name: taskTitle })).toBeVisible()
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth),
+      'Work Room scrolls sideways on a phone',
+    ).toBeLessThanOrEqual(0)
+    await shot('codex-c-sort-workroom-phone')
   })
 
-  test('Work Room is usable without horizontal overflow on a phone', async ({ page, shot }) => {
-    await openCodingRun(page, 'coding-agent-completed', 'completed')
-    await pane(page).getByRole('region', { name: 'Codex completed' }).getByRole('button', { name: 'Open Work Room' }).click()
-    const room = page.getByRole('dialog', { name: 'Codex Work Room' })
-    await expect(room).toBeVisible()
-    await room.getByRole('tab', { name: /Chat/ }).click()
-    await expect(room.getByPlaceholder('Message Codex…')).toBeVisible()
+  test('the native approval remains readable and reachable at 375px', async ({ page, shot }) => {
+    await openCodingRun(page, 'coding-agent-long-approval', 'Needs your decision')
+    const card = pane(page).getByRole('region', { name: 'Codex Needs your decision' })
+    await card.getByRole('button', { name: 'Review decision' }).click()
+    const approval = workroom(page).getByLabel('Approval required')
+    const allow = approval.getByRole('button', { name: 'Allow once' })
 
-    const heading = room.getByRole('heading', { name: 'Codex Work Room' })
-    await expect(heading).toBeVisible()
+    await expect(allow).toBeVisible()
+    const reject = approval.getByRole('button', { name: 'Reject this request' })
+    await expect(reject).toBeVisible()
+    const bounds = await allow.boundingBox()
+    expect(bounds?.height, 'approval action is too small to tap').toBeGreaterThanOrEqual(44)
+    const rejectBounds = await reject.boundingBox()
+    expect(rejectBounds?.height, 'rejection action is too small to tap').toBeGreaterThanOrEqual(44)
     expect(
-      await heading.evaluate(element => element.scrollWidth <= element.clientWidth),
-      'Work Room title is visually truncated on a phone',
-    ).toBe(true)
-    await expect(room.getByRole('button', { name: 'Return to conversation' })).toContainText('Return')
+      await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth),
+      'approval scrolls sideways on a phone',
+    ).toBeLessThanOrEqual(0)
+    await shot('codex-c-sort-approval-workroom-phone')
+  })
 
-    const overflow = await page.evaluate(
-      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
-    )
-    expect(overflow, 'Work Room scrolls sideways on a phone').toBeLessThanOrEqual(0)
-    await shot('codex-workroom-phone')
+  test('the native approval does not overflow at 320px', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 640 })
+    await openCodingRun(page, 'coding-agent-long-approval', 'Needs your decision')
+    await pane(page).getByRole('region', { name: 'Codex Needs your decision' })
+      .getByRole('button', { name: 'Review decision' }).click()
+    const approval = workroom(page).getByLabel('Approval required')
+
+    await expect(approval.getByRole('button', { name: 'Allow once' })).toBeVisible()
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth),
+      '320px approval scrolls sideways',
+    ).toBeLessThanOrEqual(0)
   })
 })

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -69,7 +69,7 @@ test.describe('a conversation on a phone', () => {
     await shot('reply')
   })
 
-  test('an approval is answerable — all four buttons on screen and hittable', async ({ page, shot }) => {
+  test('an approval is answerable — primary choices are on screen and hittable', async ({ page, shot }) => {
     await mockAgent(page, 'approval')
     await page.goto(`/${AGENT_ADDRESS}`)
     await page.getByRole('button', { name: 'What can you do?' }).click()
@@ -78,13 +78,20 @@ test.describe('a conversation on a phone', () => {
     await expect(allow).toBeVisible({ timeout: 15_000 })
     await expectNoSideScroll(page)
 
-    for (const name of [/allow once/i, /trust/i, /reject/i, /stop/i, /explain/i]) {
+    for (const name of [/allow once/i, /reject this request/i]) {
       const button = page.getByRole('button', { name }).first()
       await expect(button).toBeInViewport()
       const box = await button.boundingBox()
       expect(box!.height, `${name} is too short to tap`).toBeGreaterThanOrEqual(24)
     }
-    await shot('approval')
+    const reviewOptions = page.locator('summary').filter({ hasText: 'Other review options' })
+    await expect(reviewOptions).toBeInViewport()
+    const reviewBox = await reviewOptions.boundingBox()
+    expect(reviewBox!.height, 'Other review options is too short to tap').toBeGreaterThanOrEqual(24)
+    await shot('approval-primary')
+    await reviewOptions.click()
+    await expect(page.getByRole('button', { name: /reject and ask for an explanation/i })).toBeInViewport()
+    await shot('approval-explanation')
   })
 })
 

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -103,6 +103,7 @@ export async function mockAgent(
         prompt?: string
         session_id?: string
         mode?: string
+        invocationId?: string
       }
       sent.push(msg)
 
@@ -195,6 +196,28 @@ export async function mockAgent(
           result: 'Full access run ended.',
           session: { session_id: connectedSessionId },
         })
+        return
+      }
+
+      if (msg.type === 'PROVIDER_INTERRUPT') {
+        if (
+          msg.invocationId === 'codex:call-7'
+          && codingAgentInputs > 0
+          && (
+            scenario === 'coding-agent'
+            || scenario === 'coding-agent-completed'
+            || scenario === 'coding-agent-failed'
+            || scenario === 'coding-agent-long-approval'
+          )
+        ) {
+          send(ws, {
+            type: 'provider_invocation', invocationId: 'codex:call-7',
+            parentToolCallId: 'call-7', provider: 'codex',
+            providerDisplayName: 'Codex', status: 'cancelled',
+            currentSummary: 'The provider stopped',
+            resultSummary: 'The provider stopped',
+          })
+        }
         return
       }
 
@@ -306,24 +329,22 @@ export async function mockAgent(
           send(ws, {
             type: 'provider_invocation', invocationId: 'codex:call-8',
             parentToolCallId: 'call-8', provider: 'codex',
-            providerDisplayName: 'Codex', taskSummary: 'Also update the changelog',
+            providerDisplayName: 'Codex', taskTitle: 'Implement and verify the requested change',
+            currentSummary: 'Working in the selected workspace',
             sessionId: 'codex-session-1', status: 'running',
           })
           send(ws, {
-            type: 'tool_call', tool_id: 'child-2', name: 'Edit',
-            args: { file_path: 'src/changelog.md' }, status: 'in_progress',
-            parentToolCallId: 'call-8', invocationId: 'codex:call-8',
-          })
-          send(ws, {
-            type: 'tool_result', tool_id: 'child-2', status: 'completed', result: 'updated',
+            type: 'provider_activity', provider: 'codex', activityId: 'changelog', sequence: 1,
+            kind: 'file_change', status: 'completed', title: 'Update workspace files',
+            summary: 'Workspace files updated', files: ['changelog.md'],
             parentToolCallId: 'call-8', invocationId: 'codex:call-8',
           })
           send(ws, {
             type: 'provider_invocation', invocationId: 'codex:call-8',
             parentToolCallId: 'call-8', provider: 'codex',
-            providerDisplayName: 'Codex', taskSummary: 'Also update the changelog',
+            providerDisplayName: 'Codex', taskTitle: 'Implement and verify the requested change',
             sessionId: 'codex-session-1', status: 'completed', elapsedMs: 900,
-            result: 'Changelog updated.',
+            resultSummary: 'The provider completed its run',
           })
           send(ws, {
             type: 'OUTPUT', result: 'Changelog updated.',
@@ -331,9 +352,7 @@ export async function mockAgent(
           })
           return
         }
-        const taskSummary = scenario === 'coding-agent-long-approval'
-          ? 'Please work entirely inside the directory .workroom-e2e. Create a deterministic Python Dijkstra implementation, inspect it, run three command-line cases, add focused pytest tests, run pytest, inspect output, and report the final acceptance marker.'
-          : 'Fix Windows tests'
+        const taskSummary = 'Work inside /private/tmp/codex-workroom. Create sort.c and test_sort.c, compile with cc -std=c11 -Wall -Wextra -Werror, run sorting fixtures, inspect the output, and report the raw command transcript.'
         send(ws, {
           type: 'tool_call', id: 'call-7', name: 'codex',
           args: { prompt: taskSummary }, status: 'running',
@@ -341,63 +360,64 @@ export async function mockAgent(
         send(ws, {
           type: 'provider_invocation', invocationId: 'codex:call-7',
           parentToolCallId: 'call-7', provider: 'codex',
-          providerDisplayName: 'Codex', taskSummary,
-          permissionMode: 'workspace_write', sessionId: 'codex-session-1', status: 'running',
+          providerDisplayName: 'Codex', taskTitle: 'Build and verify the requested C program',
+          taskSummary, currentSummary: 'Working in the selected workspace',
+          permissionMode: 'manual', sessionId: 'codex-session-1', status: 'running',
         })
-        if (scenario === 'coding-agent-long-approval') {
-          const steps = [
-            ['Read', { path: 'dijkstra.py' }],
-            ['Bash', { command: 'python3 dijkstra.py --case 1' }],
-            ['Bash', { command: 'python3 dijkstra.py --case 2' }],
-            ['File change', { file_path: 'test_dijkstra.py' }],
-            ['Bash', { command: 'pytest -q' }],
-            ['Read', { path: 'test_dijkstra.py' }],
-            ['Bash', { command: 'python3 -m py_compile dijkstra.py' }],
-          ] as const
-          for (const [index, [name, args]] of steps.entries()) {
-            const toolId = `long-child-${index}`
-            send(ws, {
-              type: 'tool_call', tool_id: toolId, name, args, status: 'in_progress',
-              parentToolCallId: 'call-7', invocationId: 'codex:call-7',
-            })
-            send(ws, {
-              type: 'tool_result', tool_id: toolId, status: 'completed', result: 'Completed',
-              parentToolCallId: 'call-7', invocationId: 'codex:call-7',
-            })
-          }
+        const steps = [
+          ['inspect-task', 'inspect', 'Inspect the workspace', 'Workspace inspection completed'],
+          ['create-sort', 'file_change', 'Update workspace files', 'Workspace files updated', ['sort.c']],
+          ['create-tests', 'file_change', 'Update workspace files', 'Workspace files updated', ['test_sort.c']],
+          ['compile', 'command', 'Compile the requested C11 program', 'Compiled the requested C11 program'],
+          ['fixture-one', 'command', 'Run the requested tests', 'Completed the requested tests'],
+          ['fixture-two', 'command', 'Run the requested tests', 'Completed the requested tests'],
+          ['test-suite', 'command', 'Run the requested tests', 'Completed the requested tests'],
+          ['review', 'inspect', 'Inspect the workspace', 'Inspecting workspace context'],
+        ] as const
+        for (const [index, [activityId, kind, title, summary, files]] of steps.entries()) {
+          const activityStatus = scenario === 'coding-agent-completed'
+            ? 'completed'
+            : scenario === 'coding-agent-failed'
+              ? index === steps.length - 1 ? 'failed' : 'completed'
+              : index === steps.length - 1 ? 'running' : 'completed'
           send(ws, {
-            type: 'tool_call', tool_id: 'long-child-7', name: 'Bash',
-            args: { command: 'pytest -q' }, status: 'in_progress',
+            type: 'provider_activity', provider: 'codex', activityId, sequence: index + 1,
+            kind, status: activityStatus, title, summary,
+            ...(files && { files }),
             parentToolCallId: 'call-7', invocationId: 'codex:call-7',
           })
+        }
+        if (scenario === 'coding-agent-long-approval') {
           send(ws, {
             type: 'provider_invocation', invocationId: 'codex:call-7',
             parentToolCallId: 'call-7', provider: 'codex',
             providerDisplayName: 'Codex', status: 'awaiting_approval',
+            currentSummary: 'Waiting for your decision',
           })
           send(ws, {
             type: 'approval_needed', id: 'approval-codex-long', tool: 'codex',
-            arguments: { action: 'Run pytest -q', cwd: '.workroom-e2e' },
+            arguments: {},
             provider: 'codex', invocationId: 'codex:call-7',
-            parentToolCallId: 'call-7', activityId: 'long-child-7',
+            parentToolCallId: 'call-7', activityId: 'review',
+            providerApproval: {
+              action: 'Inspect the workspace',
+              scope: 'This Work Room only',
+              reason: 'Check the requested workspace result before continuing',
+              scopeClassification: 'workroom',
+              allowOnce: true,
+              allowSession: false,
+              files: ['sort.c', 'test_sort.c'],
+            },
           })
           return
         }
-        send(ws, {
-          type: 'tool_call', tool_id: 'child-1', name: 'Bash',
-          args: { command: 'pytest -q' }, status: 'in_progress',
-          parentToolCallId: 'call-7', invocationId: 'codex:call-7',
-        })
-        send(ws, {
-          type: 'tool_result', tool_id: 'child-1', status: 'completed', result: '89 passed',
-          parentToolCallId: 'call-7', invocationId: 'codex:call-7',
-        })
         if (scenario === 'coding-agent-completed') {
           send(ws, {
             type: 'provider_invocation', invocationId: 'codex:call-7',
             parentToolCallId: 'call-7', provider: 'codex',
             providerDisplayName: 'Codex', status: 'completed', elapsedMs: 1_250,
-            result: 'Codex fixed the Windows tests.',
+            currentSummary: 'Completed the provider run after the recorded compilation and test checks',
+            resultSummary: 'Completed the provider run after the recorded compilation and test checks',
           })
         }
         if (scenario === 'coding-agent-failed') {
@@ -405,7 +425,7 @@ export async function mockAgent(
             type: 'provider_invocation', invocationId: 'codex:call-7',
             parentToolCallId: 'call-7', provider: 'codex',
             providerDisplayName: 'Codex', status: 'failed', elapsedMs: 800,
-            error: 'Codex exited before applying the patch.',
+            errorSummary: 'The provider reported an error',
           })
         }
         return

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-alpha.12",
+        "@connectonion/react": "0.4.2-alpha.13",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-alpha.12",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.12.tgz",
-      "integrity": "sha512-ZjgW6XeJfoJwlAWxUn7Rr9o6Mt9B0E98LwDbaYxypxhH2fv2SF8qm8wCLDD8nePa2606tx/V0mF5Eqxp8hmmOw==",
+      "version": "0.4.2-alpha.13",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-alpha.13.tgz",
+      "integrity": "sha512-T4PHDJV3kR7X8bw6Gvzj9Sl+t3537cVvCOeYnfoLh7A8II9M+kG/CV2cZatZfQ34KOJzTb6297zm/ySkit556w==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-alpha.12",
+    "@connectonion/react": "0.4.2-alpha.13",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Replaces the dense native provider card with a compact semantic summary and a one-scroll Overview/Activity Work Room. Native approvals stay inside the Work Room, Stop targets the exact provider invocation, and the app pins the published @connectonion/react 0.4.2-alpha.13 protocol. Verified with TypeScript, 119 unit tests, production build, and 9 Chromium Codex Work Room screenshot/interaction scenarios.