### PR TITLE
test: wait for the live run lifecycle

### DIFF
--- a/e2e/live/README.md
+++ b/e2e/live/README.md
@@ -28,6 +28,9 @@ bash e2e/live/run-production-acceptance.sh
 The gate creates and tests a Rust CLI through the real agent, checks its exact
 JSON output, proves the workspace boundary, exercises Full access, Read only,
 and Auto, and saves desktop/mobile evidence under `e2e-screenshots/`.
+It observes the production run lifecycle through the Stop control and the
+composer's restored Send control; completion never depends on the model
+repeating a particular phrase.
 
 Host and frontend logs should be captured by the outer release runner. Sanitize
 them before attaching release evidence, and verify that the invite value is not

--- a/e2e/live/query-run-state.js
+++ b/e2e/live/query-run-state.js
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+() => {
+  const isVisible = (element) =>
+    element instanceof HTMLElement &&
+    (element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0)
+
+  const stop = [...document.querySelectorAll('button')].find(
+    (candidate) =>
+      isVisible(candidate) &&
+      !candidate.disabled &&
+      candidate.getAttribute('aria-label')?.trim() === 'Stop agent',
+  )
+  const send = [...document.querySelectorAll('button')].find(
+    (candidate) =>
+      isVisible(candidate) &&
+      candidate.getAttribute('aria-label')?.trim() === 'Send message',
+  )
+  const composer = document.querySelector(
+    '[placeholder="Message this agent..."], [placeholder="Send a message..."]',
+  )
+
+  return {
+    ok: true,
+    running: Boolean(stop),
+    sendReady: Boolean(send),
+    composerPresent:
+      (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) &&
+      !composer.disabled,
+  }
+}

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -15,7 +15,45 @@ live_output_dir="${LIVE_E2E_OUTPUT_DIR:-$repo_dir/e2e-screenshots}"
 project_dir="$LIVE_E2E_WORKSPACE/rust-release-agent"
 click_helper="$script_dir/click-button.js"
 submit_helper="$script_dir/submit-prompt.js"
+run_state_helper="$script_dir/query-run-state.js"
 tab_opened=false
+
+run_state() {
+  CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$run_state_helper" '{}'
+}
+
+wait_for_run_state() {
+  local expected="$1"
+  local timeout="$2"
+  local deadline=$((SECONDS + timeout))
+  local state=''
+  while (( SECONDS < deadline )); do
+    state="$(run_state)"
+    if printf '%s' "$state" | grep -Eq "\"$expected\":[[:space:]]*true"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for run state $expected=true; last state: $state" >&2
+  return 1
+}
+
+wait_for_run_complete() {
+  local timeout="$1"
+  local deadline=$((SECONDS + timeout))
+  local state=''
+  while (( SECONDS < deadline )); do
+    state="$(run_state)"
+    if printf '%s' "$state" | grep -Eq '"running":[[:space:]]*false' && \
+      printf '%s' "$state" | grep -Eq '"sendReady":[[:space:]]*true'; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for the run to complete; last state: $state" >&2
+  return 1
+}
 
 if [[ ! -d "$LIVE_E2E_WORKSPACE" ]]; then
   echo "LIVE_E2E_WORKSPACE must already exist" >&2
@@ -60,8 +98,8 @@ CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
   "$submit_helper" \
   '{"prompt":"Create a Rust CLI project in the current workspace at rust-release-agent. Include Cargo.toml, src/main.rs, a unit test, and README.md. The CLI must print one JSON object with name release-beta-agent and status ready. Run cargo test, fix failures, report the exact result, and do not modify anything outside rust-release-agent."}' >/dev/null
 CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" wait_for_text \
-  'test result: ok' 180 >/dev/null
+wait_for_run_state running 30
+wait_for_run_complete 180
 
 test -f "$project_dir/Cargo.toml"
 test -f "$project_dir/src/main.rs"


### PR DESCRIPTION
## Summary

- replace the live release gate's model-prose completion condition with production UI lifecycle signals
- require the `Stop agent` control to appear before accepting completion
- require the Stop control to disappear and the Send control to return before artifact validation
- keep both waits bounded with the last observed state in timeout errors

Closes #198
Release control: openonion/connectonion#792

## User-visible change

- UI impact: no
- Changed surfaces/routes: none
- Related issue/design decision: https://github.com/openonion/oo-chat/issues/198
- Core version: 1.7.0b2
- React version: 0.4.2-beta.0
- O Chat commit: 12f5757a4ef406a6bf796beb22aaa407da40df86
- Evidence commit: 12f5757a4ef406a6bf796beb22aaa407da40df86
- No-visual-change reason: Only the shell and page-query scripts used by the live release gate change; no application component, route, style, or rendered state changes.

## Why

The public ConnectOnion `1.7.0b2` run created and tested the required Rust project successfully, but the model's final summary omitted the literal `test result: ok`. The old gate timed out even though independent Cargo validation passed. Model wording is not a lifecycle API.

## Evidence

- first public-artifact run reproduced the false timeout while independent `cargo test` and exact JSON output passed
- a first lifecycle probe exposed the real accessible name (`Stop agent`) instead of the visible title (`Stop`)
- final run from a third empty workspace passed the complete production gate:
  - public PyPI `connectonion==1.7.0b2`
  - registry `@connectonion/react@0.4.2-beta.0`
  - O Chat production build
  - observed start and completion lifecycle
  - independent Cargo tests: 2 passed, 0 failed
  - exact output: `{"name":"release-beta-agent","status":"ready"}`
  - Full access, Read only, and Auto mode changes
  - desktop 1440×900 and mobile 390×844 screenshots inspected
- `bash -n e2e/live/run-production-acceptance.sh`
- lint: 0 errors, 7 existing warnings
- unit tests: 145/145
- production build: passed
