### PR TITLE
fix: reconnect without resending the last instruction

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -359,6 +359,7 @@ export default function ChatSessionPage() {
           }
           connectionError={connectionError}
           onRetry={!agentOffline && lastUserMessage ? handleRetry : undefined}
+          onReconnect={!agentOffline ? handleReconnect : undefined}
           onDismissError={() => setConnectionError(null)}
           skills={skills}
           acceptsAttachments={acceptsAttachments(

--- a/components/chat/chat-error.test.tsx
+++ b/components/chat/chat-error.test.tsx
@@ -1,0 +1,52 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { ChatError } from './chat-error'
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+let container: HTMLDivElement | null = null
+let root: ReturnType<typeof createRoot> | null = null
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+function render(error: string, onRetry = vi.fn(), onReconnect = vi.fn()) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(
+    <ChatError error={error} onRetry={onRetry} onReconnect={onReconnect} />,
+  ))
+  return { container, onRetry, onReconnect }
+}
+
+describe('ChatError recovery action', () => {
+  it('reconnects without resending after a reconnect timeout', () => {
+    const view = render('Reconnect timed out')
+    const action = view.container.querySelector<HTMLButtonElement>('button')!
+
+    expect(action.textContent).toBe('Reconnect')
+    act(() => action.click())
+    expect(view.onReconnect).toHaveBeenCalledOnce()
+    expect(view.onRetry).not.toHaveBeenCalled()
+  })
+
+  it('keeps Retry for a failed turn', () => {
+    const view = render('Provider rejected the turn')
+    const action = view.container.querySelector<HTMLButtonElement>('button')!
+
+    expect(action.textContent).toBe('Retry')
+    act(() => action.click())
+    expect(view.onRetry).toHaveBeenCalledOnce()
+    expect(view.onReconnect).not.toHaveBeenCalled()
+  })
+})

--- a/components/chat/chat-error.tsx
+++ b/components/chat/chat-error.tsx
@@ -3,10 +3,23 @@ import { HiOutlineExclamationCircle, HiOutlineX } from 'react-icons/hi'
 interface ChatErrorProps {
   error: string
   onRetry?: () => void
+  onReconnect?: () => void
   onDismiss?: () => void
 }
 
-export function ChatError({ error, onRetry, onDismiss }: ChatErrorProps) {
+export function isReconnectError(error: string): boolean {
+  const message = error.toLowerCase()
+  return message.includes('reconnect')
+    || message.includes('connection')
+    || message.includes('disconnected')
+    || message.includes('socket')
+    || message.includes('closed')
+    || message.includes('health check')
+}
+
+export function ChatError({ error, onRetry, onReconnect, onDismiss }: ChatErrorProps) {
+  const reconnect = isReconnectError(error)
+  const action = reconnect ? onReconnect : onRetry
   const getErrorMessage = (error: string) => {
     if (error.includes('timeout')) return 'Connection timed out'
     if (error.includes('closed')) return 'Connection lost'
@@ -25,12 +38,12 @@ export function ChatError({ error, onRetry, onDismiss }: ChatErrorProps) {
         </span>
       </div>
       <div className="flex items-center gap-2">
-        {onRetry && (
+        {action && (
           <button
-            onClick={onRetry}
+            onClick={action}
             className="min-h-11 px-2 text-sm font-medium text-red-600 hover:text-red-700"
           >
-            Retry
+            {reconnect ? 'Reconnect' : 'Retry'}
           </button>
         )}
         {onDismiss && (

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -40,6 +40,7 @@ export function Chat({
   sessionState,
   connectionError,
   onRetry,
+  onReconnect,
   onDismissError,
   skills,
   acceptsAttachments,
@@ -195,6 +196,7 @@ export function Chat({
               <ChatError
                 error={connectionError}
                 onRetry={onRetry}
+                onReconnect={onReconnect}
                 onDismiss={onDismissError}
               />
             </div>

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -238,6 +238,8 @@ export interface ChatProps {
   /** Connection error for retry functionality */
   connectionError?: string | null
   onRetry?: () => void
+  /** Reconnect the existing session without resubmitting the last instruction. */
+  onReconnect?: () => void
   /** Dismiss the error banner without resending anything */
   onDismissError?: () => void
   skills?: SkillInfo[]

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -5,7 +5,7 @@
  * cellular, the screen locking long enough for the socket to be reaped. The
  * agent stops being reachable and the reader is left looking at a status line.
  *
- * The recovery surface reports `Connection lost` with a `Retry` action, and it was
+ * The recovery surface reports `Connection lost` with a `Reconnect` action, and it was
  * effectively never shown: the state was derived from an HTTP poll that only
  * reports true while the *server* still has a run in flight, so a socket that
  * dropped while the agent was idle fell through to "connected". The reader is
@@ -54,13 +54,13 @@ test.describe('phone', () => {
   test('and offers a way back, at a size a thumb can hit', async ({ page }) => {
     await dropMidRun(page)
 
-    const retry = page.getByRole('button', { name: /^retry$/i }).first()
-    await expect(retry, 'no way back from a dead connection').toBeVisible({ timeout: 15_000 })
+    const reconnect = page.getByRole('button', { name: /^reconnect$/i }).first()
+    await expect(reconnect, 'no way back from a dead connection').toBeVisible({ timeout: 15_000 })
 
     // It was an 11px underlined word. This is the control someone reaches for
     // one-handed, on a train, having just come out of a tunnel.
-    const box = await retry.boundingBox()
-    expect(box!.height, `retry is ${Math.round(box!.width)}x${Math.round(box!.height)}`).toBeGreaterThanOrEqual(44)
+    const box = await reconnect.boundingBox()
+    expect(box!.height, `reconnect is ${Math.round(box!.width)}x${Math.round(box!.height)}`).toBeGreaterThanOrEqual(44)
   })
 
   test('a fresh landing page is not accused of being disconnected', async ({ page }) => {
@@ -71,7 +71,7 @@ test.describe('phone', () => {
     // Before anything is sent the transport is legitimately not connected yet.
     // Saying so would put an error state on every first impression.
     await expect(page.getByText('Connection lost', { exact: true })).toHaveCount(0)
-    await expect(page.getByRole('button', { name: /^retry$/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^(retry|reconnect)$/i })).toHaveCount(0)
   })
 
   test('a healthy conversation still reads as live', async ({ page }) => {
@@ -92,14 +92,14 @@ test.describe('coming back', () => {
   test('the reconnect link actually restores the session', async ({ page, shot }) => {
     await dropMidRun(page)
 
-    const retry = page.getByRole('button', { name: /^retry$/i }).first()
-    await expect(retry).toBeVisible({ timeout: 15_000 })
-    await retry.click()
+    const reconnect = page.getByRole('button', { name: /^reconnect$/i }).first()
+    await expect(reconnect).toBeVisible({ timeout: 15_000 })
+    await reconnect.click()
 
     // Not just a status flipping back — the session has to carry a message again,
     // which is the only thing the reader actually wanted.
     await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
-    await expect(retry).toHaveCount(0)
+    await expect(reconnect).toHaveCount(0)
 
     await page.getByPlaceholder(/message/i).fill('are you back?')
     await page.keyboard.press('Enter')
@@ -118,7 +118,7 @@ test.describe('coming back', () => {
     await page.evaluate(() => window.dispatchEvent(new Event('online')))
 
     await expect(page.getByText('live', { exact: true })).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByRole('button', { name: /^retry$/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^(retry|reconnect)$/i })).toHaveCount(0)
   })
 
   test('returning to the tab reconnects without being asked', async ({ page }) => {


### PR DESCRIPTION
## Public artifact finding

During the exact public ConnectOnion 1.7.0b8 Claude Work Room run, browser reattach ended with `Reconnect timed out`. The inline `Retry` action then submitted the previous 180-second Claude instruction as a new Host INPUT. The duplicated call was rejected before Claude launched.

## Change

- give the error surface separate reconnect and turn-retry callbacks
- show the action-first `Reconnect` label for reconnect/connection/socket/closed/health-check failures
- keep `Retry` for ordinary failed turns
- prove a reconnect timeout invokes reconnect and never invokes retry/resend

## Verification

- focused 22 tests
- full 157 tests
- lint: 0 errors, 7 existing warnings
- production build and TypeScript pass

## User-visible change

- UI impact: yes
- Changed surfaces/routes: active chat connection error banner
- Related issue/design decision: https://github.com/openonion/oo-chat/issues/205
- Core version: 1.7.0b8
- React version: 0.4.2-beta.2
- O Chat commit: c9cbbee51c955f4507a704757047062b98926b6f
- Evidence commit: c9cbbee51c955f4507a704757047062b98926b6f
- No-visual-change reason: not applicable; the recovery action changes visibly

<!-- e2e-screenshots:start -->
### Before

![Before — reconnect timeout incorrectly offers Retry](https://raw.githubusercontent.com/openonion/oo-chat/evidence/pr-206/docs/evidence/pr-206/before-retry.png)

### After — desktop

![After desktop — reconnect timeout offers Reconnect](https://raw.githubusercontent.com/openonion/oo-chat/evidence/pr-206/docs/evidence/pr-206/after-reconnect-desktop.png)

### After — narrow/mobile

![After 390px — reconnect timeout offers Reconnect](https://raw.githubusercontent.com/openonion/oo-chat/evidence/pr-206/docs/evidence/pr-206/after-reconnect-mobile.png)

### Critical states

The reconnect-timeout error keeps one compact recovery action; clicking it reconnects the existing session and cannot submit another turn. Ordinary failed turns retain Retry.

- [x] I inspected every image at the final PR head.
- [x] Images contain no secret, invite code, identity material, private path, customer data, raw reasoning, or sensitive prompt.
<!-- e2e-screenshots:end -->

Closes #205. Tracks openonion/connectonion#792 and openonion/connectonion#1109.