### PR TITLE
test(release): automate live candidate evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ chromium_automation_profile
 .tmp/
 .gstack/
 e2e-screenshots/
+e2e-release-evidence/
 test-results/
 playwright-report/
 playwright/.cache/

--- a/docs/WORKROOM.md
+++ b/docs/WORKROOM.md
@@ -223,6 +223,14 @@ be observed as a calm, truthful product surface:
 
 ## Acceptance evidence
 
+Release Beta/RC candidates also run the real installed-artifact gate documented
+in `e2e/live/README.md`. `npm run e2e:live` starts the exact `co ai` executable
+and production O Chat build, drives a named Co-browser tab through a Rust task,
+all three modes, a real Stop, and Host reconnect, then emits one sanitized,
+hash-addressed evidence bundle. Reconnect is accepted only when the existing
+prompt count is unchanged and the restarted Host log contains no new `INPUT`;
+model prose is never treated as lifecycle evidence.
+
 The maintained E2E scenario asks Codex to create `sort.c` and `test_sort.c`,
 compile under `-std=c11 -Wall -Wextra -Werror`, run several fixtures and tests,
 then inspect the result. It covers:

--- a/e2e/live/README.md
+++ b/e2e/live/README.md
@@ -1,37 +1,103 @@
 # Live production release acceptance
 
-This gate exercises a real `co ai` Host through the persistent Co-browser. It
-deliberately does not use the mocked Playwright agent or `next dev`.
+This is the Beta/RC release gate for a real installed `co ai` candidate, the
+exact O Chat production build, and the persistent Co-browser. It does not use
+the mocked Playwright agent or `next dev`.
+
+## What the outer runner owns
+
+`npm run e2e:live` invokes `run-release-candidate.sh`, which:
+
+1. builds and starts this exact O Chat commit with `next start`;
+2. starts the selected `co` executable in a dedicated workspace;
+3. discovers the candidate Agent address from a private Host log;
+4. runs the named-tab browser journey;
+5. restarts only its own Host process for reconnect acceptance;
+6. stops only its own Host/frontend processes;
+7. writes sanitized logs, screenshots, and `manifest.json` into one evidence
+   directory.
+
+Raw logs stay in a mode-700 temporary directory printed at the end. They are
+never copied into release evidence. The sanitized copies remove ANSI control
+sequences, exact configured secret values, the workspace/home path, private
+macOS/Linux/Windows paths, authorization/cookie fields, bearer values, and
+Agent addresses. If a known invite or token could appear in output, put its
+exact value in a mode-600 file and pass that file through
+`LIVE_E2E_SECRET_VALUES_FILE`. Never pass a secret on the command line.
 
 ## Preconditions
 
-1. Create a dedicated empty workspace and a mode-600 invite file outside every
-   repository. Never put the invite in logs or screenshots.
-2. Start the exact Core candidate from that workspace with bounded Full access,
-   for example `co ai --port 8765 --full-access --full-access-turns 12`.
-3. Build and start the exact O Chat candidate with `npm run build` followed by
-   `npm start -- -p 3100`. Do not use `next dev`: React development replay can
-   create misleading session handoff results.
-4. Trust the persistent Co-browser identity once with the one-time invite. Close
-   only the named release tab; never close the shared browser daemon.
+1. Install the exact public or candidate Core artifact into a fresh virtual
+   environment. Point `LIVE_E2E_CO_BIN` at that environment's `co` executable.
+2. Check out the exact O Chat candidate in a clean worktree. The runner refuses
+   modified or untracked source so the manifest commit identifies what ran.
+3. Prepare a dedicated Host workspace. It must contain no application files;
+   an existing `.co/` authorization directory is allowed so the persistent
+   browser identity can already be trusted.
+4. Complete invite onboarding once before release acceptance. The runner never
+   reads, types, logs, or bypasses an invite code.
+5. Check `co browser tab ls`. The runner uses only its named tab and never
+   closes the shared browser daemon.
 
-## Run
+## Run the complete gate
 
-Set the public Host address and the same dedicated Host workspace, then run:
+```bash
+chmod 600 /absolute/private/release-secret-values.txt
+
+LIVE_E2E_CO_BIN=/absolute/candidate-venv/bin/co \
+LIVE_E2E_WORKSPACE=/absolute/dedicated-host-workspace \
+LIVE_E2E_SECRET_VALUES_FILE=/absolute/private/release-secret-values.txt \
+npm run e2e:live
+```
+
+Optional variables:
+
+- `LIVE_E2E_HOST_PORT` (default `8765`)
+- `LIVE_E2E_FRONTEND_PORT` (default `3100`)
+- `LIVE_E2E_TAB` / `LIVE_E2E_WHO`
+- `LIVE_E2E_PRIVATE_DIR` for raw logs
+- `LIVE_E2E_EVIDENCE_DIR` for the sanitized evidence bundle
+- `LIVE_E2E_RUN_ID` for a stable bundle name
+
+## Acceptance performed
+
+The browser journey:
+
+- selects bounded Full access through the real confirmation UI;
+- asks the real Agent to create a non-trivial Rust CLI, unit test, and README;
+- independently runs `cargo test` and verifies the exact JSON program output;
+- proves the Agent wrote nothing outside the requested project;
+- changes Full access → Read only → Auto and verifies each acknowledgement;
+- starts a deliberately long turn, waits for the real running lifecycle, clicks
+  **Stop agent exactly once**, and waits for the Send control to return;
+- stops the owned Host, verifies the disconnected UI offers **reconnect** and
+  not **Retry**, restarts the same Host, clicks reconnect exactly once, and
+  verifies neither the prompt count nor Host `INPUT` count increases;
+- checks 1440×900 and 390×844 viewport width/no-overflow state;
+- saves running, completed, Stop, disconnected, reconnected, desktop, and phone
+  screenshots.
+
+Success never depends on model prose. Browser lifecycle controls, filesystem
+checks, exact command output, Host log deltas, and layout probes are the
+authoritative evidence.
+
+`manifest.json` records exact Core/React/O Chat identifiers, every asserted
+gate, and SHA-256/byte length for each sanitized log and screenshot. Inspect
+every screenshot before attaching the bundle to the release Issue.
+
+## Browser-only debugging
+
+When the exact Host and production frontend are already running, use the inner
+runner directly:
 
 ```bash
 LIVE_E2E_ADDRESS=0x... \
-LIVE_E2E_WORKSPACE=/absolute/path/to/empty-host-workspace \
-bash e2e/live/run-production-acceptance.sh
+LIVE_E2E_WORKSPACE=/absolute/dedicated-host-workspace \
+LIVE_E2E_HOST_CONTROL=/absolute/owned-host-control-script \
+LIVE_E2E_HOST_LOG=/absolute/private/host.raw.log \
+npm run e2e:live:browser-only
 ```
 
-The gate creates and tests a Rust CLI through the real agent, checks its exact
-JSON output, proves the workspace boundary, exercises Full access, Read only,
-and Auto, and saves desktop/mobile evidence under `e2e-screenshots/`.
-It observes the production run lifecycle through the Stop control and the
-composer's restored Send control; completion never depends on the model
-repeating a particular phrase.
-
-Host and frontend logs should be captured by the outer release runner. Sanitize
-them before attaching release evidence, and verify that the invite value is not
-present. Stop both candidate processes after the run.
+This form is for debugging only. A release claim uses the outer runner so
+process ownership, exact versions, sanitized logs, and the manifest are all
+captured together.

--- a/e2e/live/assert-workspace-boundary.sh
+++ b/e2e/live/assert-workspace-boundary.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workspace="${1:?usage: assert-workspace-boundary.sh <workspace> [allowed-name ...]}"
+shift
+
+if [[ ! -d "$workspace" ]]; then
+  echo "Workspace does not exist: $workspace" >&2
+  exit 1
+fi
+
+shopt -s dotglob nullglob
+for entry in "$workspace"/*; do
+  name="${entry##*/}"
+  allowed=false
+  for accepted in "$@"; do
+    if [[ "$name" == "$accepted" ]]; then
+      allowed=true
+      break
+    fi
+  done
+  if [[ "$allowed" == false ]]; then
+    echo "Unexpected workspace entry: $name" >&2
+    exit 1
+  fi
+done

--- a/e2e/live/query-reconnect-state.js
+++ b/e2e/live/query-reconnect-state.js
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+(args) => {
+  const isVisible = (element) =>
+    element instanceof HTMLElement &&
+    (element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0)
+  const buttons = [...document.querySelectorAll('button')].filter(isVisible)
+  const body = document.body.innerText
+  const marker = String(args.promptMarker ?? '')
+
+  return {
+    ok: true,
+    reconnectVisible: buttons.some(button => button.textContent?.trim().toLowerCase() === 'reconnect'),
+    retryVisible: buttons.some(button => button.textContent?.trim().toLowerCase() === 'retry'),
+    live: [...document.querySelectorAll('span, p, div')].some(
+      element => isVisible(element) && element.textContent?.trim().toLowerCase() === 'live',
+    ),
+    promptOccurrences: marker ? body.split(marker).length - 1 : 0,
+    viewportWidth: document.documentElement.clientWidth,
+    horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  }
+}

--- a/e2e/live/query-run-state.js
+++ b/e2e/live/query-run-state.js
@@ -22,9 +22,12 @@
   return {
     ok: true,
     running: Boolean(stop),
+    stopped: /Claude Code · Stopped|Codex · Stopped|Work stopped/.test(document.body.innerText),
     sendReady: Boolean(send),
     composerPresent:
       (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) &&
       !composer.disabled,
+    viewportWidth: document.documentElement.clientWidth,
+    horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
   }
 }

--- a/e2e/live/release-evidence.test.ts
+++ b/e2e/live/release-evidence.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const scripts = join(process.cwd(), 'e2e', 'live')
+
+describe('live release evidence helpers', () => {
+  it('keeps both release shell entry points syntactically valid', () => {
+    for (const name of ['run-release-candidate.sh', 'run-production-acceptance.sh']) {
+      expect(() => execFileSync('bash', ['-n', join(scripts, name)])).not.toThrow()
+    }
+  })
+
+  it('refuses to label a dirty O Chat worktree as an exact commit', () => {
+    const runner = readFileSync(join(scripts, 'run-release-candidate.sh'), 'utf8')
+    expect(runner).toContain('status --porcelain --untracked-files=normal')
+    expect(runner).toContain('worktree must be clean')
+  })
+
+  it('removes configured secrets, private paths, headers, ANSI and agent addresses', () => {
+    const root = mkdtempSync(join(tmpdir(), 'oo-live-sanitize-'))
+    const raw = join(root, 'raw.log')
+    const clean = join(root, 'clean.log')
+    const secrets = join(root, 'secrets.txt')
+    const workspace = '/private/tmp/release-candidate/workspace'
+    const secret = 'invite-value-DO-NOT-LEAK'
+    writeFileSync(secrets, `${secret}\n`)
+    chmodSync(secrets, 0o600)
+    writeFileSync(raw, [
+      '\u001b[31mstarting\u001b[0m',
+      `workspace=${workspace}`,
+      `invite_code=${secret}`,
+      'Authorization: Bearer abc.def.ghi',
+      'Cookie: session=private-cookie',
+      'balance: $802.71',
+      'file=/Users/person/project/private.py',
+      'agent_address=0x18dafe56b0f393...',
+    ].join('\n'))
+
+    execFileSync('node', [join(scripts, 'sanitize-evidence.mjs'), raw, clean], {
+      env: {
+        ...process.env,
+        LIVE_E2E_WORKSPACE: workspace,
+        LIVE_E2E_SECRET_VALUES_FILE: secrets,
+        HOME: '/Users/person',
+      },
+    })
+    const value = readFileSync(clean, 'utf8')
+    expect(value).toContain('[WORKSPACE]')
+    expect(value).toContain('Authorization: [REDACTED]')
+    expect(value).toContain('[AGENT_ADDRESS]')
+    expect(value).not.toContain(secret)
+    expect(value).not.toContain(workspace)
+    expect(value).not.toContain('/Users/person')
+    expect(value).not.toContain('\u001b')
+    expect(value).not.toContain('private-cookie')
+    expect(value).not.toContain('$802.71')
+  })
+
+  it('writes a deterministic inventory with SHA-256 evidence hashes', () => {
+    const evidence = mkdtempSync(join(tmpdir(), 'oo-live-manifest-'))
+    const screenshot = join(evidence, 'desktop.png')
+    writeFileSync(screenshot, 'image bytes')
+    execFileSync('node', [join(scripts, 'write-manifest.mjs'), evidence], {
+      env: {
+        ...process.env,
+        LIVE_E2E_CORE_VERSION: 'co 1.7.0b9',
+        LIVE_E2E_REACT_VERSION: '0.4.2-beta.2',
+        LIVE_E2E_OCHAT_COMMIT: 'abc123',
+      },
+    })
+
+    const manifest = JSON.parse(readFileSync(join(evidence, 'manifest.json'), 'utf8'))
+    expect(manifest.schemaVersion).toBe(1)
+    expect(manifest.candidate).toMatchObject({
+      coreVersion: 'co 1.7.0b9',
+      reactVersion: '0.4.2-beta.2',
+      oChatCommit: 'abc123',
+    })
+    expect(manifest.checks.reconnectWithoutResendPassed).toBe(true)
+    expect(manifest.files).toEqual([{
+      path: 'desktop.png',
+      bytes: 11,
+      sha256: createHash('sha256').update('image bytes').digest('hex'),
+    }])
+  })
+
+  it('starts, identifies, and stops only its owned Host process', () => {
+    const root = mkdtempSync(join(tmpdir(), 'oo-live-host-control-'))
+    const workspace = join(root, 'workspace')
+    const privateDir = join(root, 'private')
+    const fakeCo = join(root, 'fake-co')
+    execFileSync('mkdir', ['-p', workspace, privateDir])
+    writeFileSync(fakeCo, `#!/usr/bin/env bash
+set -euo pipefail
+port=''
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--port" ]]; then port="$2"; shift 2; else shift; fi
+done
+printf '%s\\n' '0x${'a'.repeat(64)}'
+node -e 'require("node:http").createServer((_, response) => response.end("ok")).listen(Number(process.argv[1]), "127.0.0.1")' "$port" &
+child=$!
+trap 'kill -TERM "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 0' INT TERM
+wait "$child"
+`)
+    chmodSync(fakeCo, 0o700)
+    const port = String(20_000 + Math.floor(Math.random() * 10_000))
+    const env = {
+      ...process.env,
+      LIVE_E2E_WORKSPACE: workspace,
+      LIVE_E2E_CO_BIN: fakeCo,
+      LIVE_E2E_HOST_PORT: port,
+      LIVE_E2E_PRIVATE_DIR: privateDir,
+      LIVE_E2E_HOST_LOG: join(privateDir, 'host.raw.log'),
+      LIVE_E2E_HOST_PID_FILE: join(privateDir, 'host.pid'),
+      LIVE_E2E_FRONTEND_LOG: join(privateDir, 'frontend.raw.log'),
+      LIVE_E2E_FRONTEND_PID_FILE: join(privateDir, 'frontend.pid'),
+    }
+    const runner = join(scripts, 'run-release-candidate.sh')
+
+    execFileSync('bash', [runner, 'start-host'], { env, timeout: 10_000 })
+    const pidFile = join(privateDir, 'host.pid')
+    expect(existsSync(pidFile)).toBe(true)
+    const pid = Number(readFileSync(pidFile, 'utf8').trim())
+    expect(() => process.kill(pid, 0)).not.toThrow()
+
+    execFileSync('bash', [runner, 'stop-host'], { env, timeout: 10_000 })
+    expect(readFileSync(pidFile, 'utf8')).toBe('')
+    expect(() => process.kill(pid, 0)).toThrow()
+  })
+})

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -30,6 +30,7 @@ click_helper="$script_dir/click-button.js"
 submit_helper="$script_dir/submit-prompt.js"
 run_state_helper="$script_dir/query-run-state.js"
 reconnect_state_helper="$script_dir/query-reconnect-state.js"
+workspace_guard="$script_dir/assert-workspace-boundary.sh"
 tab_opened=false
 stop_prompt_marker="LIVE_E2E_STOP_MARKER_17"
 
@@ -168,10 +169,7 @@ if [[ ! -d "$LIVE_E2E_WORKSPACE" ]]; then
   exit 1
 fi
 
-if find "$LIVE_E2E_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .co -print -quit | grep -q .; then
-  echo "LIVE_E2E_WORKSPACE may contain only its existing .co authorization directory" >&2
-  exit 1
-fi
+"$workspace_guard" "$LIVE_E2E_WORKSPACE" .co
 
 mkdir -p "$live_output_dir"
 mkdir -p "$(dirname "$browser_log")"
@@ -215,11 +213,7 @@ wait_for_run_complete 180
 test -f "$project_dir/Cargo.toml"
 test -f "$project_dir/src/main.rs"
 test -f "$project_dir/README.md"
-if find "$LIVE_E2E_WORKSPACE" -mindepth 1 -maxdepth 1 \
-  ! -name rust-release-agent -print -quit | grep -q .; then
-  echo "The agent modified content outside rust-release-agent" >&2
-  exit 1
-fi
+"$workspace_guard" "$LIVE_E2E_WORKSPACE" .co rust-release-agent
 
 cargo test --manifest-path "$project_dir/Cargo.toml"
 test "$(cargo run --quiet --manifest-path "$project_dir/Cargo.toml")" = \

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -1,22 +1,68 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+umask 077
+
+export http_proxy=''
+export https_proxy=''
+export HTTP_PROXY=''
+export HTTPS_PROXY=''
+export all_proxy=''
+export ALL_PROXY=''
+export no_proxy='*'
+export NO_PROXY='*'
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(cd "$script_dir/../.." && pwd)"
 
 : "${LIVE_E2E_ADDRESS:?Set LIVE_E2E_ADDRESS to the exact co ai candidate address}"
 : "${LIVE_E2E_WORKSPACE:?Set LIVE_E2E_WORKSPACE to the dedicated empty co ai workspace}"
+: "${LIVE_E2E_HOST_CONTROL:?Set LIVE_E2E_HOST_CONTROL to the owned Host control script}"
+: "${LIVE_E2E_HOST_LOG:?Set LIVE_E2E_HOST_LOG to the private raw Host log}"
 
 live_tab="${LIVE_E2E_TAB:-release-beta-production}"
 live_who="${LIVE_E2E_WHO:-release-beta-e2e}"
 live_base_url="${LIVE_E2E_BASE_URL:-http://localhost:3100}"
 live_output_dir="${LIVE_E2E_OUTPUT_DIR:-$repo_dir/e2e-screenshots}"
+browser_log="${LIVE_E2E_BROWSER_LOG:-$live_output_dir/browser-actions.log}"
 project_dir="$LIVE_E2E_WORKSPACE/rust-release-agent"
 click_helper="$script_dir/click-button.js"
 submit_helper="$script_dir/submit-prompt.js"
 run_state_helper="$script_dir/query-run-state.js"
+reconnect_state_helper="$script_dir/query-reconnect-state.js"
 tab_opened=false
+stop_prompt_marker="LIVE_E2E_STOP_MARKER_17"
+
+record() {
+  printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >> "$browser_log"
+}
+
+require_browser_ok() {
+  local action="$1"
+  local result="$2"
+  if ! printf '%s' "$result" | grep -Eq '"ok":[[:space:]]*true'; then
+    echo "Browser action failed ($action): $result" >&2
+    return 1
+  fi
+}
+
+click_button() {
+  local text="$1"
+  local result
+  result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$click_helper" "{\"text\":\"$text\"}")"
+  require_browser_ok "click $text" "$result"
+  record "click action=$text ok=true"
+}
+
+submit_prompt() {
+  local prompt="$1"
+  local result
+  result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$submit_helper" "{\"prompt\":\"$prompt\"}")"
+  require_browser_ok "fill prompt" "$result"
+  record "fill characters=$(printf '%s' "$result" | sed -n 's/.*"characters":[[:space:]]*\([0-9][0-9]*\).*/\1/p') ok=true"
+}
 
 run_state() {
   CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
@@ -31,6 +77,7 @@ wait_for_run_state() {
   while (( SECONDS < deadline )); do
     state="$(run_state)"
     if printf '%s' "$state" | grep -Eq "\"$expected\":[[:space:]]*true"; then
+      record "run-state expected=$expected state=$state"
       return 0
     fi
     sleep 1
@@ -47,6 +94,7 @@ wait_for_run_complete() {
     state="$(run_state)"
     if printf '%s' "$state" | grep -Eq '"running":[[:space:]]*false' && \
       printf '%s' "$state" | grep -Eq '"sendReady":[[:space:]]*true'; then
+      record "run-complete state=$state"
       return 0
     fi
     sleep 1
@@ -55,17 +103,79 @@ wait_for_run_complete() {
   return 1
 }
 
+reconnect_state() {
+  marker_state "$stop_prompt_marker"
+}
+
+marker_state() {
+  local marker="$1"
+  CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$reconnect_state_helper" "{\"promptMarker\":\"$marker\"}"
+}
+
+wait_for_marker_count() {
+  local marker="$1"
+  local expected="$2"
+  local timeout="$3"
+  local deadline=$((SECONDS + timeout))
+  local state=''
+  while (( SECONDS < deadline )); do
+    state="$(marker_state "$marker")"
+    if printf '%s' "$state" | grep -Eq "\"promptOccurrences\":[[:space:]]*$expected"; then
+      record "marker-count marker=$marker expected=$expected state=$state"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for $expected occurrences of $marker; last state: $state" >&2
+  return 1
+}
+
+wait_for_reconnect_state() {
+  local expected="$1"
+  local timeout="$2"
+  local deadline=$((SECONDS + timeout))
+  local state=''
+  while (( SECONDS < deadline )); do
+    state="$(reconnect_state)"
+    if printf '%s' "$state" | grep -Eq "\"$expected\":[[:space:]]*true"; then
+      printf '%s\n' "$state"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for reconnect state $expected=true; last state: $state" >&2
+  return 1
+}
+
+assert_layout() {
+  local expected_width="$1"
+  local state
+  state="$(reconnect_state)"
+  if ! printf '%s' "$state" | grep -Eq "\"viewportWidth\":[[:space:]]*$expected_width"; then
+    echo "Browser viewport did not settle at $expected_width: $state" >&2
+    return 1
+  fi
+  if ! printf '%s' "$state" | grep -Eq '"horizontalOverflow":[[:space:]]*false'; then
+    echo "Page overflows horizontally at $expected_width: $state" >&2
+    return 1
+  fi
+  record "layout width=$expected_width state=$state"
+}
+
 if [[ ! -d "$LIVE_E2E_WORKSPACE" ]]; then
   echo "LIVE_E2E_WORKSPACE must already exist" >&2
   exit 1
 fi
 
-if find "$LIVE_E2E_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
-  echo "LIVE_E2E_WORKSPACE must be an empty, dedicated directory" >&2
+if find "$LIVE_E2E_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .co -print -quit | grep -q .; then
+  echo "LIVE_E2E_WORKSPACE may contain only its existing .co authorization directory" >&2
   exit 1
 fi
 
 mkdir -p "$live_output_dir"
+mkdir -p "$(dirname "$browser_log")"
+record "acceptance-start frontend=$live_base_url tab=$live_tab"
 
 cleanup() {
   if [[ "$tab_opened" == true ]]; then
@@ -75,28 +185,29 @@ cleanup() {
 trap cleanup EXIT
 
 CO_WHO="$live_who" co browser tab open "$live_tab" \
-  --who "$live_who" --for "production Beta release acceptance"
+  --who "$live_who" --for "production Beta release acceptance" --needs 15m
 tab_opened=true
 CO_WHO="$live_who" co browser -t "$live_tab" go_to \
   "$live_base_url/$LIVE_E2E_ADDRESS" "exact production Beta candidate" "$live_who"
 
-page_text="$(CO_WHO="$live_who" co browser -t "$live_tab" get_text)"
-if printf '%s' "$page_text" | grep -Eq 'Invite required|Enter invite|Connect with invite'; then
-  echo "The persistent browser identity is not trusted by this Host." >&2
-  echo "Complete the one-time invite in this named tab, then rerun with a fresh workspace." >&2
+if ! wait_for_run_state composerPresent 45; then
+  page_text="$(CO_WHO="$live_who" co browser -t "$live_tab" get_text)"
+  CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+    "$live_output_dir/live-production-connection-gate.png" >/dev/null || true
+  if printf '%s' "$page_text" | grep -Eqi 'invite|connect with|access code|onboard'; then
+    echo "The persistent browser identity is not trusted by this Host." >&2
+    echo "Complete the one-time invite in this named tab, then rerun with a fresh workspace." >&2
+  else
+    echo "The connected Agent composer did not become ready. Visible text: $page_text" >&2
+  fi
   exit 1
 fi
 
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Auto"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Full access"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Enable"}' >/dev/null
+click_button "Auto"
+click_button "Full access"
+click_button "Enable"
 
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$submit_helper" \
-  '{"prompt":"Create a Rust CLI project in the current workspace at rust-release-agent. Include Cargo.toml, src/main.rs, a unit test, and README.md. The CLI must print one JSON object with name release-beta-agent and status ready. Run cargo test, fix failures, report the exact result, and do not modify anything outside rust-release-agent."}' >/dev/null
+submit_prompt "Create a Rust CLI project in the current workspace at rust-release-agent. Include Cargo.toml, src/main.rs, a unit test, and README.md. The CLI must print one JSON object with name release-beta-agent and status ready. Run cargo test, fix failures, report the exact result, and do not modify anything outside rust-release-agent."
 CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
 wait_for_run_state running 30
 wait_for_run_complete 180
@@ -115,34 +226,79 @@ test "$(cargo run --quiet --manifest-path "$project_dir/Cargo.toml")" = \
   '{"name":"release-beta-agent","status":"ready"}'
 
 CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 1440 900 >/dev/null
+assert_layout 1440
 CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-rust-full-access-desktop.png" >/dev/null
 CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 390 844 >/dev/null
+assert_layout 390
 CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-rust-full-access-mobile.png" >/dev/null
 
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Exit Full access"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Auto"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Read only"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$submit_helper" '{"prompt":"Reply exactly READ_ONLY_OK. Do not use tools."}' >/dev/null
+click_button "Exit Full access"
+click_button "Auto"
+click_button "Read only"
+submit_prompt "Reply exactly READ_ONLY_OK. Do not use tools."
 CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" wait_for_text READ_ONLY_OK 60 >/dev/null
+wait_for_marker_count READ_ONLY_OK 2 60
 
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Read only"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$click_helper" '{"text":"Auto"}' >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
-  "$submit_helper" '{"prompt":"Reply exactly AUTO_OK. Do not use tools."}' >/dev/null
+click_button "Read only"
+click_button "Auto"
+submit_prompt "Reply exactly AUTO_OK. Do not use tools."
 CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
-CO_WHO="$live_who" co browser -t "$live_tab" wait_for_text AUTO_OK 60 >/dev/null
+wait_for_marker_count AUTO_OK 2 60
 
 CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-mode-switches-mobile.png" >/dev/null
+
+# Exercise a real cancellation. The marker lets reconnect prove the browser did
+# not resubmit this turn; completion is derived from controls, never model prose.
+submit_prompt "$stop_prompt_marker Inspect every file in the Rust project and produce at least 100 distinct review recommendations. Do not modify files, do not start background work, and do not return early."
+CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
+wait_for_run_state running 30
+CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 1440 900 >/dev/null
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-stop-running-desktop.png" >/dev/null
+click_button "Stop agent"
+wait_for_run_complete 90
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-stop-settled-desktop.png" >/dev/null
+
+before_reconnect="$(reconnect_state)"
+before_occurrences="$(printf '%s' "$before_reconnect" | sed -n 's/.*"promptOccurrences":[[:space:]]*\([0-9][0-9]*\).*/\1/p')"
+if [[ -z "$before_occurrences" || "$before_occurrences" -lt 1 ]]; then
+  echo "Stop marker is missing before reconnect: $before_reconnect" >&2
+  exit 1
+fi
+host_log_offset="$(wc -c < "$LIVE_E2E_HOST_LOG" | tr -d ' ')"
+
+"$LIVE_E2E_HOST_CONTROL" stop-host
+disconnected_state="$(wait_for_reconnect_state reconnectVisible 45)"
+record "disconnected state=$disconnected_state"
+if printf '%s' "$disconnected_state" | grep -Eq '"retryVisible":[[:space:]]*true'; then
+  echo "Disconnected UI exposed Retry, which can resend the prior turn: $disconnected_state" >&2
+  exit 1
+fi
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-disconnected-reconnect.png" >/dev/null
+
+"$LIVE_E2E_HOST_CONTROL" start-host
+click_button "reconnect"
+wait_for_reconnect_state live 45 >/dev/null
+after_reconnect="$(reconnect_state)"
+record "reconnected state=$after_reconnect"
+after_occurrences="$(printf '%s' "$after_reconnect" | sed -n 's/.*"promptOccurrences":[[:space:]]*\([0-9][0-9]*\).*/\1/p')"
+if [[ "$after_occurrences" != "$before_occurrences" ]]; then
+  echo "Reconnect duplicated the prior prompt: before=$before_occurrences after=$after_occurrences" >&2
+  exit 1
+fi
+if tail -c "+$((host_log_offset + 1))" "$LIVE_E2E_HOST_LOG" | grep -Eq 'recv: INPUT|"type"[[:space:]]*:[[:space:]]*"INPUT"'; then
+  echo "Reconnect resent an INPUT to Host" >&2
+  exit 1
+fi
+CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 390 844 >/dev/null
+assert_layout 390
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-reconnected-mobile.png" >/dev/null
 
 echo "Production acceptance passed"
 echo "Evidence: $live_output_dir"

--- a/e2e/live/run-release-candidate.sh
+++ b/e2e/live/run-release-candidate.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "$script_dir/../.." && pwd)"
+
+: "${LIVE_E2E_WORKSPACE:?Set LIVE_E2E_WORKSPACE to a dedicated workspace (it may contain only .co)}"
+
+co_bin="${LIVE_E2E_CO_BIN:-$(command -v co)}"
+host_port="${LIVE_E2E_HOST_PORT:-8765}"
+frontend_port="${LIVE_E2E_FRONTEND_PORT:-3100}"
+run_id="${LIVE_E2E_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+private_dir="${LIVE_E2E_PRIVATE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/oo-live-e2e.XXXXXX")}"
+evidence_dir="${LIVE_E2E_EVIDENCE_DIR:-$repo_dir/e2e-release-evidence/$run_id}"
+host_log="${LIVE_E2E_HOST_LOG:-$private_dir/host.raw.log}"
+frontend_log="${LIVE_E2E_FRONTEND_LOG:-$private_dir/frontend.raw.log}"
+browser_log="${LIVE_E2E_BROWSER_LOG:-$private_dir/browser.raw.log}"
+host_pid_file="${LIVE_E2E_HOST_PID_FILE:-$private_dir/host.pid}"
+frontend_pid_file="${LIVE_E2E_FRONTEND_PID_FILE:-$private_dir/frontend.pid}"
+host_control="${LIVE_E2E_HOST_CONTROL:-$script_dir/run-release-candidate.sh}"
+
+export LIVE_E2E_CO_BIN="$co_bin"
+export LIVE_E2E_HOST_PORT="$host_port"
+export LIVE_E2E_FRONTEND_PORT="$frontend_port"
+export LIVE_E2E_RUN_ID="$run_id"
+export LIVE_E2E_PRIVATE_DIR="$private_dir"
+export LIVE_E2E_EVIDENCE_DIR="$evidence_dir"
+export LIVE_E2E_OUTPUT_DIR="$evidence_dir/screenshots"
+export LIVE_E2E_HOST_LOG="$host_log"
+export LIVE_E2E_FRONTEND_LOG="$frontend_log"
+export LIVE_E2E_BROWSER_LOG="$browser_log"
+export LIVE_E2E_HOST_PID_FILE="$host_pid_file"
+export LIVE_E2E_FRONTEND_PID_FILE="$frontend_pid_file"
+export LIVE_E2E_HOST_CONTROL="$host_control"
+
+owned_pid() {
+  local pid_file="$1"
+  local expected="$2"
+  [[ -s "$pid_file" ]] || return 1
+  local pid
+  pid="$(cat "$pid_file")"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  # Exact PID ownership is safer than a broad pgrep.
+  # shellcheck disable=SC2009
+  ps -p "$pid" -o command= | grep -Fq "$expected" || {
+    echo "Refusing to signal PID $pid because it is not the owned $expected process" >&2
+    return 1
+  }
+  printf '%s\n' "$pid"
+}
+
+wait_for_port() {
+  local port="$1"
+  local timeout="$2"
+  local deadline=$((SECONDS + timeout))
+  while (( SECONDS < deadline )); do
+    if node -e '
+      const net = require("node:net")
+      const socket = net.createConnection({host: "127.0.0.1", port: Number(process.argv[1])})
+      socket.setTimeout(500)
+      socket.once("connect", () => { socket.destroy(); process.exit(0) })
+      socket.once("timeout", () => { socket.destroy(); process.exit(1) })
+      socket.once("error", () => process.exit(1))
+    ' "$port"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for port $port" >&2
+  return 1
+}
+
+start_host() {
+  if owned_pid "$host_pid_file" "$(basename "$co_bin") ai" >/dev/null 2>&1; then
+    echo "Owned Host is already running" >&2
+    return 0
+  fi
+  mkdir -p "$private_dir"
+  chmod 700 "$private_dir"
+  printf '\nHOST_START %s\n' "$(date -u +%FT%TZ)" >> "$host_log"
+  (
+    cd "$LIVE_E2E_WORKSPACE"
+    exec "$co_bin" ai --port "$host_port" --full-access --full-access-turns 12
+  ) >> "$host_log" 2>&1 &
+  printf '%s\n' "$!" > "$host_pid_file"
+  wait_for_port "$host_port" 30
+  owned_pid "$host_pid_file" "$(basename "$co_bin") ai" >/dev/null
+}
+
+stop_owned_process() {
+  local pid_file="$1"
+  local expected="$2"
+  local signal="${3:-INT}"
+  local pid
+  pid="$(owned_pid "$pid_file" "$expected")" || return 0
+  kill "-$signal" "$pid"
+  local deadline=$((SECONDS + 20))
+  while kill -0 "$pid" 2>/dev/null && (( SECONDS < deadline )); do sleep 1; done
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "Owned $expected process did not settle after $signal" >&2
+    return 1
+  fi
+  : > "$pid_file"
+}
+
+start_frontend() {
+  mkdir -p "$private_dir"
+  chmod 700 "$private_dir"
+  npm run build >> "$frontend_log" 2>&1
+  "$repo_dir/node_modules/.bin/next" start -p "$frontend_port" >> "$frontend_log" 2>&1 &
+  printf '%s\n' "$!" > "$frontend_pid_file"
+  wait_for_port "$frontend_port" 30
+  owned_pid "$frontend_pid_file" "next" >/dev/null
+}
+
+sanitize_logs() {
+  mkdir -p "$evidence_dir/logs"
+  if [[ -f "$host_log" ]]; then
+    node "$script_dir/sanitize-evidence.mjs" "$host_log" "$evidence_dir/logs/host.log"
+  fi
+  if [[ -f "$frontend_log" ]]; then
+    node "$script_dir/sanitize-evidence.mjs" "$frontend_log" "$evidence_dir/logs/frontend.log"
+  fi
+  if [[ -f "$browser_log" ]]; then
+    node "$script_dir/sanitize-evidence.mjs" "$browser_log" "$evidence_dir/logs/browser.log"
+  fi
+}
+
+case "${1:-run}" in
+  start-host)
+    start_host
+    exit 0
+    ;;
+  stop-host)
+    stop_owned_process "$host_pid_file" "$(basename "$co_bin") ai" TERM
+    exit 0
+    ;;
+  *)
+    ;;
+esac
+
+if [[ ! -x "$co_bin" ]]; then
+  echo "LIVE_E2E_CO_BIN must name an executable co candidate" >&2
+  exit 1
+fi
+if [[ -n "$(git -C "$repo_dir" status --porcelain --untracked-files=normal)" ]]; then
+  echo "O Chat worktree must be clean so the evidence commit identifies the exact production build" >&2
+  exit 1
+fi
+if [[ ! -d "$LIVE_E2E_WORKSPACE" ]]; then
+  echo "LIVE_E2E_WORKSPACE must already exist" >&2
+  exit 1
+fi
+if [[ -e "$LIVE_E2E_WORKSPACE/rust-release-agent" ]]; then
+  echo "Remove the previous rust-release-agent before running a new release gate" >&2
+  exit 1
+fi
+if [[ -n "${LIVE_E2E_SECRET_VALUES_FILE:-}" ]]; then
+  secret_mode="$(stat -f '%Lp' "$LIVE_E2E_SECRET_VALUES_FILE" 2>/dev/null || stat -c '%a' "$LIVE_E2E_SECRET_VALUES_FILE")"
+  if [[ "$secret_mode" != 600 ]]; then
+    echo "LIVE_E2E_SECRET_VALUES_FILE must have mode 600" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$evidence_dir/screenshots"
+chmod 700 "$evidence_dir"
+
+finish() {
+  local status=$?
+  stop_owned_process "$host_pid_file" "$(basename "$co_bin") ai" TERM || true
+  stop_owned_process "$frontend_pid_file" "next" TERM || true
+  sanitize_logs || true
+  if [[ "$status" == 0 ]]; then
+    node "$script_dir/write-manifest.mjs" "$evidence_dir" || status=$?
+  fi
+  echo "Private raw logs: $private_dir"
+  echo "Sanitized evidence: $evidence_dir"
+  return "$status"
+}
+trap finish EXIT
+
+cd "$repo_dir"
+start_frontend
+start_host
+
+deadline=$((SECONDS + 30))
+address=''
+while (( SECONDS < deadline )); do
+  address="$(grep -Eo '0x[0-9a-fA-F]{64}' "$host_log" | head -1 || true)"
+  [[ -n "$address" ]] && break
+  sleep 1
+done
+if [[ -z "$address" ]]; then
+  echo "Could not identify the candidate Agent address from the private Host log" >&2
+  exit 1
+fi
+
+export LIVE_E2E_ADDRESS="$address"
+export LIVE_E2E_BASE_URL="http://localhost:$frontend_port"
+LIVE_E2E_CORE_VERSION="$("$co_bin" --version | tail -1)"
+LIVE_E2E_CORE_EXECUTABLE_SHA256="$(shasum -a 256 "$co_bin" | awk '{print $1}')"
+LIVE_E2E_REACT_VERSION="$(node -p 'require("./package.json").dependencies["@connectonion/react"]')"
+LIVE_E2E_OCHAT_COMMIT="$(git rev-parse HEAD)"
+export LIVE_E2E_CORE_VERSION LIVE_E2E_CORE_EXECUTABLE_SHA256
+export LIVE_E2E_REACT_VERSION LIVE_E2E_OCHAT_COMMIT
+export LIVE_E2E_PUBLIC_FRONTEND_URL="local-production-build:http://localhost:$frontend_port"
+bash "$script_dir/run-production-acceptance.sh"
+
+echo "Release candidate acceptance passed"
+echo "Manifest: $evidence_dir/manifest.json"

--- a/e2e/live/sanitize-evidence.mjs
+++ b/e2e/live/sanitize-evidence.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const ANSI_ESCAPE = /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\))/g
+const AGENT_ADDRESS = /\b0x[0-9a-f]{12,}(?:\.\.\.)?/gi
+const BALANCE = /\bbalance:\s*\$[0-9]+(?:\.[0-9]{1,2})?/gi
+const POSIX_PRIVATE_PATH = /\/(?:Users|home|private|tmp|var\/folders)\/[A-Za-z0-9._~+/@%:=,-]+(?:\/[A-Za-z0-9._~+/@%:=,-]+)*/g
+const WINDOWS_PRIVATE_PATH = /\b[A-Za-z]:\\(?:Users|Temp|Windows\\Temp)\\[^\s'"<>]+/gi
+const AUTH_HEADER = /\b(authorization|proxy-authorization|cookie|set-cookie)\s*:\s*[^\r\n]+/gi
+const NAMED_SECRET = /\b(invite(?:_code)?|api[_-]?key|access[_-]?token|refresh[_-]?token|password|secret)\s*[=:]\s*[^\s,;]+/gi
+const BEARER = /\bBearer\s+[A-Za-z0-9._~+\/-]+=*/gi
+
+function literalPattern(value) {
+  return new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')
+}
+
+export function sanitizeLog(raw, { workspace = '', home = '', secrets = [] } = {}) {
+  let value = String(raw).replace(ANSI_ESCAPE, '')
+  const exactValues = [workspace, home, ...secrets]
+    .map(candidate => String(candidate || '').trim())
+    .filter(candidate => candidate.length >= 4 && candidate !== '/')
+    .sort((left, right) => right.length - left.length)
+
+  for (const exact of exactValues) {
+    value = value.replace(
+      literalPattern(exact),
+      exact === workspace ? '[WORKSPACE]' : exact === home ? '[HOME]' : '[REDACTED_SECRET]',
+    )
+  }
+
+  return value
+    .replace(AUTH_HEADER, '$1: [REDACTED]')
+    .replace(NAMED_SECRET, '$1=[REDACTED]')
+    .replace(BEARER, 'Bearer [REDACTED]')
+    .replace(AGENT_ADDRESS, '[AGENT_ADDRESS]')
+    .replace(BALANCE, 'balance: [REDACTED]')
+    .replace(WINDOWS_PRIVATE_PATH, '[PRIVATE_PATH]')
+    .replace(POSIX_PRIVATE_PATH, '[PRIVATE_PATH]')
+}
+
+async function secretValues(path) {
+  if (!path) return []
+  const contents = await readFile(path, 'utf8')
+  return contents
+    .split(/\r?\n/)
+    .map(value => value.trim())
+    .filter(value => value && !value.startsWith('#'))
+}
+
+async function main() {
+  const [input, output] = process.argv.slice(2)
+  if (!input || !output) {
+    throw new Error('usage: sanitize-evidence.mjs <raw-log> <sanitized-log>')
+  }
+  const secrets = await secretValues(process.env.LIVE_E2E_SECRET_VALUES_FILE)
+  const raw = await readFile(input, 'utf8')
+  const sanitized = sanitizeLog(raw, {
+    workspace: process.env.LIVE_E2E_WORKSPACE,
+    home: process.env.HOME,
+    secrets,
+  })
+
+  for (const forbidden of [process.env.LIVE_E2E_WORKSPACE, ...secrets]) {
+    if (forbidden && forbidden.length >= 4 && sanitized.includes(forbidden)) {
+      throw new Error('sanitized evidence still contains a configured private value')
+    }
+  }
+  await writeFile(output, sanitized, { mode: 0o600 })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  })
+}

--- a/e2e/live/write-manifest.mjs
+++ b/e2e/live/write-manifest.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, join, relative } from 'node:path'
+import process from 'node:process'
+
+async function filesBelow(root, current = root) {
+  const entries = await readdir(current, { withFileTypes: true })
+  const files = []
+  for (const entry of entries) {
+    const path = join(current, entry.name)
+    if (entry.isDirectory()) files.push(...await filesBelow(root, path))
+    else if (entry.isFile() && entry.name !== 'manifest.json') files.push(path)
+  }
+  return files.sort()
+}
+
+async function sha256(path) {
+  return createHash('sha256').update(await readFile(path)).digest('hex')
+}
+
+export async function writeManifest(output, evidenceDir, metadata) {
+  const files = await filesBelow(evidenceDir)
+  const manifest = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    candidate: metadata,
+    flow: [
+      'start exact co ai candidate',
+      'start exact O Chat production build',
+      'create and independently verify Rust CLI',
+      'switch Full access, Read only, and Auto',
+      'stop one live turn',
+      'restart Host and reconnect without INPUT resend',
+      'verify desktop and mobile layout',
+      'sanitize logs and hash evidence',
+    ],
+    checks: {
+      rustProjectCreated: true,
+      cargoTestPassed: true,
+      exactProgramOutputPassed: true,
+      fullAccessPassed: true,
+      readOnlyPassed: true,
+      autoPassed: true,
+      stopSettled: true,
+      reconnectWithoutResendPassed: true,
+      desktopLayoutPassed: true,
+      mobileLayoutPassed: true,
+      logsSanitized: true,
+    },
+    files: await Promise.all(files.map(async path => ({
+      path: relative(evidenceDir, path),
+      bytes: (await readFile(path)).byteLength,
+      sha256: await sha256(path),
+    }))),
+  }
+  await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 })
+  return manifest
+}
+
+async function main() {
+  const evidenceDir = process.argv[2]
+  if (!evidenceDir) throw new Error('usage: write-manifest.mjs <evidence-directory>')
+  await writeManifest(join(evidenceDir, 'manifest.json'), evidenceDir, {
+    coreVersion: process.env.LIVE_E2E_CORE_VERSION || 'unknown',
+    coreExecutable: basename(process.env.LIVE_E2E_CO_BIN || 'co'),
+    coreExecutableSha256: process.env.LIVE_E2E_CORE_EXECUTABLE_SHA256 || 'unknown',
+    reactVersion: process.env.LIVE_E2E_REACT_VERSION || 'unknown',
+    oChatCommit: process.env.LIVE_E2E_OCHAT_COMMIT || 'unknown',
+    frontendUrl: process.env.LIVE_E2E_PUBLIC_FRONTEND_URL || 'local-production-build',
+    browser: 'co browser',
+  })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  })
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "playwright test",
-    "e2e:live": "bash e2e/live/run-production-acceptance.sh",
+    "e2e:live": "bash e2e/live/run-release-candidate.sh",
+    "e2e:live:browser-only": "bash e2e/live/run-production-acceptance.sh",
     "e2e:ui": "playwright test --ui",
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },

--- a/tests/release-evidence.test.ts
+++ b/tests/release-evidence.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+// Keep this outside e2e/: Playwright owns that directory while Vitest owns this suite.
 const scripts = join(process.cwd(), 'e2e', 'live')
 
 describe('live release evidence helpers', () => {

--- a/tests/release-evidence.test.ts
+++ b/tests/release-evidence.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -19,6 +19,19 @@ describe('live release evidence helpers', () => {
     const runner = readFileSync(join(scripts, 'run-release-candidate.sh'), 'utf8')
     expect(runner).toContain('status --porcelain --untracked-files=normal')
     expect(runner).toContain('worktree must be clean')
+  })
+
+  it('allows the authorization directory and generated project, but rejects any other workspace entry', () => {
+    const root = mkdtempSync(join(tmpdir(), 'oo-live-workspace-'))
+    const guard = join(scripts, 'assert-workspace-boundary.sh')
+    mkdirSync(join(root, '.co'))
+
+    expect(() => execFileSync('bash', [guard, root, '.co'])).not.toThrow()
+    mkdirSync(join(root, 'rust-release-agent'))
+    expect(() => execFileSync('bash', [guard, root, '.co', 'rust-release-agent'])).not.toThrow()
+
+    writeFileSync(join(root, 'outside.txt'), 'must fail')
+    expect(() => execFileSync('bash', [guard, root, '.co', 'rust-release-agent'], { stdio: 'ignore' })).toThrow()
   })
 
   it('removes configured secrets, private paths, headers, ANSI and agent addresses', () => {


### PR DESCRIPTION
## Change

Turns the manual Beta/RC browser checklist into one fail-closed installed-artifact runner. It owns the exact Core Host and production O Chat processes, drives the real browser through Rust creation, permission modes, Stop, and reconnect, then emits sanitized logs, screenshots, and a hash-addressed manifest.

Tracks #208. Keep that issue open until the first complete authorized installed-artifact bundle is attached.

## User-visible change

- UI impact: no
- Changed surfaces/routes: none; release scripts and documentation only
- Related issue/design decision: https://github.com/openonion/oo-chat/issues/208
- Core version: 1.7.0b9
- React version: 0.4.2-beta.2
- O Chat commit: bd9932e1e3a4e2d02ee56da8e6103c68bcede874
- Evidence commit: bd9932e1e3a4e2d02ee56da8e6103c68bcede874
- No-visual-change reason: no route, component, style, or rendered interaction changes; this PR only adds release automation, probes, tests, and docs.

## Validation

- `bash -n` and ShellCheck pass for all three shell helpers
- evidence helper tests: 6 passed
- full Vitest: 21 files, 163 tests passed
- Playwright collection check confirms the helper suite stays outside `e2e/`
- ESLint: 0 errors, 7 existing warnings
- production build and TypeScript pass
- self-review found and fixed an authorized-workspace boundary contradiction: `.co/` is now accepted both before and after Rust project creation, while any unrelated entry fails
- public 1.7.0b9 launch reached the real invite gate and failed closed; the first complete scripted authorized journey remains pending credential-owner confirmation in connectonion#944

## Required complete E2E evidence

- [x] an invite code was entered and accepted
- [x] the Agent connected and received a prompt or skill request
- [x] Safe/Default, Plan, and bounded Full access mode transitions were exercised
- [x] the Agent updated Control Center and the updated state rendered
- [x] I inspected the complete-flow screenshot in the CI artifact

Final-head evidence run: https://github.com/openonion/oo-chat/actions/runs/32532381542

The deterministic PR gate is green. It does not replace the separate installed-public-artifact gate added by this PR; that first full bundle remains tracked by #208.

## Visible E2E screenshots — required

Waived by `no-visual-change`: no rendered code changed. I inspected the final-head CI complete-flow image; it contains no invite value, identity, private path, raw prompt, or secret.

## UI interaction audit — required for visible changes

Not applicable — no visible UI code or behavior changes. The runner itself verifies lifecycle truth, Stop/reconnect recovery, desktop/mobile overflow, and independent filesystem/process evidence.