### PR TITLE
Consume @connectonion/react 0.4.2 RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.2-beta.3",
+        "@connectonion/react": "0.4.2-rc.0",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-beta.3.tgz",
-      "integrity": "sha512-Q+QvAP6awUPPAxEiisK6VS1siggHSemXAocEXFF9452Awvco0krBDe+l5f52eZJH23HfndSFwZ5eQ+bCKjZZgw==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.2-rc.0.tgz",
+      "integrity": "sha1-zZEh66aYwtkO8iPXvo1aWlo1zXE=",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.2-beta.3",
+    "@connectonion/react": "0.4.2-rc.0",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- pins `@connectonion/react` to the published `0.4.2-rc.0` candidate
- locks the exact registry tarball using the SHA-1 emitted by the npm publish job
- keeps the dependency graph unchanged

- UI impact: no
- No-visual-change reason: Dependency version and lock metadata only; no visible source, style, component, or behavior change.

## Verification

- published React workflow: tests, typecheck, build, pack and npm provenance passed
- cloud O Chat `npm ci`, dependency audit, typecheck, lint and unit tests passed on this exact head
- local O Chat: TypeScript passed; lint 0 errors (6 existing warnings); 182/183 tests passed
- the only local test failure and local Next build failure are sandbox port-binding denials (`Operation not permitted`); CI/Vercel are the authoritative clean-network gate
- `git diff --check` passed

Part of openonion/connectonion#792.