### PR TITLE
test(release): add real Claude Work Room acceptance

### DIFF
--- a/e2e/live/README.md
+++ b/e2e/live/README.md
@@ -58,6 +58,9 @@ silently reusing an identity that was already a contact.
 7. Install C11 and C++20 compilers plus Cargo; every generated project is rebuilt
    by the harness rather than trusted from the model's report.
 
+The browser task remains bounded at four minutes so a cold isolated daemon can
+complete every required RPC and still emit the parent turn's terminal event.
+
 ## Run the complete gate
 
 ```bash

--- a/e2e/live/README.md
+++ b/e2e/live/README.md
@@ -51,8 +51,10 @@ silently reusing an identity that was already a contact.
    exact Core candidate must support `co ai --invite-code-file`.
 5. Check `co browser tab ls`. The runner uses only its named tab and never
    closes the shared browser daemon.
-6. Install and authenticate the native `codex` CLI. The gate requires a real
-   provider handoff and fails closed if it receives no Codex Workroom evidence.
+6. Install and authenticate the native `codex` and `claude` CLIs. The gate
+   requires real handoffs to both providers, then sends a provider-targeted
+   Claude Code follow-up through the opened Work Room. It fails closed if either
+   provider or conversation evidence is missing.
 7. Install C11 and C++20 compilers plus Cargo; every generated project is rebuilt
    by the harness rather than trusted from the model's report.
 

--- a/e2e/live/click-provider-send.js
+++ b/e2e/live/click-provider-send.js
@@ -1,0 +1,13 @@
+(args) => {
+  const provider = String(args.provider ?? '').trim()
+  const dialog = document.querySelector('[role="dialog"]')
+  const button = dialog?.querySelector(`[aria-label="Send message to ${provider}"]`)
+  if (!(button instanceof HTMLButtonElement)) {
+    return { ok: false, error: `${provider || 'provider'} send button not found` }
+  }
+  if (button.disabled) {
+    return { ok: false, error: `${provider || 'provider'} send button is disabled` }
+  }
+  button.click()
+  return { ok: true, provider }
+}

--- a/e2e/live/query-provider-workroom.js
+++ b/e2e/live/query-provider-workroom.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 (args) => {
   const provider = String(args.provider ?? '').trim()
+  const marker = String(args.marker ?? '')
   const dialog = document.querySelector('[role="dialog"]')
   if (!(dialog instanceof HTMLElement)) {
     return { ok: false, error: 'Workroom dialog not found' }
@@ -9,6 +10,7 @@
   const composer = dialog.querySelector(`[aria-label="Message ${provider} directly"]`)
   const status = dialog.querySelector('[aria-label="Current provider status"]')
   const statusText = status?.textContent ?? ''
+  const conversationText = conversation?.textContent ?? ''
   const visible = (element) =>
     element instanceof HTMLElement &&
     (element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0)
@@ -23,5 +25,6 @@
     messageCount: conversation?.querySelectorAll('li').length ?? 0,
     visibleUserMessageCount: conversation?.querySelectorAll('[data-provider-message-role="user"]').length ?? 0,
     visibleAssistantMessageCount: conversation?.querySelectorAll('[data-provider-message-role="assistant"]').length ?? 0,
+    markerOccurrences: marker ? conversationText.split(marker).length - 1 : 0,
   }
 }

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -633,7 +633,10 @@ CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
 wait_for_run_state running 30
 CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-browser-task-running-desktop.png" >/dev/null
-wait_for_run_complete 150
+# A cold isolated browser daemon can spend 10–20 seconds on each of the eight
+# required browser RPCs. Keep the task bounded while allowing those verified
+# operations plus the parent model's terminal event to settle.
+wait_for_run_complete 240
 test -f "$browser_report_dir/report.json"
 node -e '
   const fs = require("node:fs")

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -795,6 +795,10 @@ CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-claude-workroom-mobile.png" >/dev/null
 click_button "Back"
 
+# The preceding real tasks can legitimately exhaust the bounded Full access
+# allowance and return to Auto. Re-enter it when needed so this gate always
+# exercises the explicit exit control as a separate acceptance path.
+select_mode "Full access"
 click_button "Exit Full access"
 select_mode "Read only"
 submit_prompt "Reply exactly READ_ONLY_OK. Do not use tools."

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -32,6 +32,7 @@ c_project_dir="$LIVE_E2E_WORKSPACE/c-release-agent"
 cpp_project_dir="$LIVE_E2E_WORKSPACE/cpp-release-agent"
 project_dir="$LIVE_E2E_WORKSPACE/rust-release-agent"
 codex_project_dir="$LIVE_E2E_WORKSPACE/codex-c-release-agent"
+claude_project_dir="$LIVE_E2E_WORKSPACE/claude-c-release-agent"
 click_helper="$script_dir/click-button.js"
 submit_helper="$script_dir/submit-prompt.js"
 run_state_helper="$script_dir/query-run-state.js"
@@ -39,6 +40,7 @@ reconnect_state_helper="$script_dir/query-reconnect-state.js"
 workspace_guard="$script_dir/assert-workspace-boundary.sh"
 open_provider_helper="$script_dir/open-provider-workroom.js"
 provider_state_helper="$script_dir/query-provider-workroom.js"
+provider_submit_helper="$script_dir/submit-provider-prompt.js"
 select_mode_helper="$script_dir/select-mode.js"
 invite_input_helper="$script_dir/query-invite-input.js"
 tab_opened=false
@@ -434,6 +436,41 @@ wait_for_provider_workroom() {
   return 1
 }
 
+submit_provider_prompt() {
+  local provider="$1"
+  local prompt="$2"
+  local args_json result
+  args_json="$(node -e \
+    'process.stdout.write(JSON.stringify({ provider: process.argv[1], prompt: process.argv[2] }))' \
+    "$provider" "$prompt")"
+  result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$provider_submit_helper" "$args_json")"
+  require_browser_ok "send prompt to $provider Workroom" "$result"
+  CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
+  record "provider-workroom submit provider=$provider characters=$(printf '%s' "$result" | sed -n 's/.*"characters":[[:space:]]*\([0-9][0-9]*\).*/\1/p') ok=true"
+}
+
+wait_for_provider_marker_count() {
+  local provider="$1"
+  local marker="$2"
+  local expected="$3"
+  local timeout="$4"
+  local deadline=$((SECONDS + timeout))
+  local state=''
+  while (( SECONDS < deadline )); do
+    state="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+      "$provider_state_helper" "{\"provider\":\"$provider\",\"marker\":\"$marker\"}")"
+    if printf '%s' "$state" | grep -Eq "\"markerOccurrences\":[[:space:]]*$expected" && \
+      printf '%s' "$state" | grep -Eq '"composerEnabled":[[:space:]]*true'; then
+      record "provider-workroom marker provider=$provider marker=$marker expected=$expected state=$state"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for $expected $marker messages in $provider Workroom; last state: $state" >&2
+  return 1
+}
+
 require_host_tool_since() {
   local byte_offset="$1"
   local pattern="$2"
@@ -711,6 +748,39 @@ CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 390 844 >/dev/null
 assert_layout 390
 CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
   "$live_output_dir/live-production-codex-workroom-mobile.png" >/dev/null
+click_button "Back"
+
+# Exercise the second supported coding provider through the same real Host and
+# Work Room. A compiler check proves Claude Code changed the dedicated project;
+# the provider-targeted follow-up proves the composer resumes the same native
+# session instead of becoming a new outer COAI message.
+CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 1440 900 >/dev/null
+claude_host_offset="$(wc -c < "$LIVE_E2E_HOST_LOG" | tr -d ' ')"
+submit_prompt "Use the native Claude Code tool to create a non-trivial C11 bounded stack project at claude-c-release-agent. It must contain stack.h, stack.c, test_stack.c, and README.md; cover push, pop, overflow, underflow, and LIFO behavior; compile with -std=c11 -Wall -Wextra -Werror; and print exactly claude stack tests passed. Have Claude Code run the tests. Do not implement the files yourself and do not modify anything outside claude-c-release-agent."
+CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
+wait_for_run_state running 30
+wait_for_run_complete 300
+test -f "$claude_project_dir/stack.h"
+test -f "$claude_project_dir/stack.c"
+test -f "$claude_project_dir/test_stack.c"
+cc -std=c11 -Wall -Wextra -Werror "$claude_project_dir/stack.c" \
+  "$claude_project_dir/test_stack.c" -o "$claude_project_dir/release-stack-test"
+test "$("$claude_project_dir/release-stack-test")" = 'claude stack tests passed'
+require_host_tool_since "$claude_host_offset" '⚡ claude_code|▸ claude_code' 'Claude Code delegation'
+"$workspace_guard" "$LIVE_E2E_WORKSPACE" .co browser-release-report c-release-agent cpp-release-agent rust-release-agent codex-c-release-agent claude-c-release-agent
+
+open_provider_workroom "Claude Code"
+wait_for_provider_workroom "Claude Code" 45
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-claude-workroom-desktop.png" >/dev/null
+submit_provider_prompt "Claude Code" "Reply exactly CLAUDE_FOLLOWUP_OK. Do not use tools."
+wait_for_provider_marker_count "Claude Code" CLAUDE_FOLLOWUP_OK 2 180
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-claude-workroom-follow-up-desktop.png" >/dev/null
+CO_WHO="$live_who" co browser -t "$live_tab" set_viewport 390 844 >/dev/null
+assert_layout 390
+CO_WHO="$live_who" co browser -t "$live_tab" take_screenshot \
+  "$live_output_dir/live-production-claude-workroom-mobile.png" >/dev/null
 click_button "Back"
 
 click_button "Exit Full access"

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -41,6 +41,7 @@ workspace_guard="$script_dir/assert-workspace-boundary.sh"
 open_provider_helper="$script_dir/open-provider-workroom.js"
 provider_state_helper="$script_dir/query-provider-workroom.js"
 provider_submit_helper="$script_dir/submit-provider-prompt.js"
+provider_send_helper="$script_dir/click-provider-send.js"
 select_mode_helper="$script_dir/select-mode.js"
 invite_input_helper="$script_dir/query-invite-input.js"
 tab_opened=false
@@ -439,15 +440,19 @@ wait_for_provider_workroom() {
 submit_provider_prompt() {
   local provider="$1"
   local prompt="$2"
-  local args_json result
+  local args_json result submit_result
   args_json="$(node -e \
     'process.stdout.write(JSON.stringify({ provider: process.argv[1], prompt: process.argv[2] }))' \
     "$provider" "$prompt")"
-  result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+  submit_result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
     "$provider_submit_helper" "$args_json")"
-  require_browser_ok "send prompt to $provider Workroom" "$result"
-  CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
-  record "provider-workroom submit provider=$provider characters=$(printf '%s' "$result" | sed -n 's/.*"characters":[[:space:]]*\([0-9][0-9]*\).*/\1/p') ok=true"
+  require_browser_ok "send prompt to $provider Workroom" "$submit_result"
+  # The textarea is controlled by React. Use a second browser interaction so
+  # React can commit the new draft before clicking the now-enabled send button.
+  result="$(CO_WHO="$live_who" co browser -t "$live_tab" run_page_script \
+    "$provider_send_helper" "$args_json")"
+  require_browser_ok "click send in $provider Workroom" "$result"
+  record "provider-workroom submit provider=$provider characters=$(printf '%s' "$submit_result" | sed -n 's/.*"characters":[[:space:]]*\([0-9][0-9]*\).*/\1/p') ok=true"
 }
 
 wait_for_provider_marker_count() {

--- a/e2e/live/run-production-acceptance.sh
+++ b/e2e/live/run-production-acceptance.sh
@@ -732,7 +732,11 @@ codex_host_offset="$(wc -c < "$LIVE_E2E_HOST_LOG" | tr -d ' ')"
 submit_prompt "Use the native Codex tool to create a non-trivial C11 ring buffer project at codex-c-release-agent. It must contain ring_buffer.h, ring_buffer.c, test_ring_buffer.c, and README.md; cover wraparound, full, empty, and FIFO behavior; compile with -std=c11 -Wall -Wextra -Werror; and print exactly codex ring buffer tests passed. Have Codex run the tests. Do not implement the files yourself and do not modify anything outside codex-c-release-agent."
 CO_WHO="$live_who" co browser -t "$live_tab" keyboard_press Enter >/dev/null
 wait_for_run_state running 30
-wait_for_run_complete 240
+# Native provider completion can approach four minutes on a cold account, and
+# each isolated browser-state read also consumes wall time. Keep the same
+# bounded five-minute budget used by Claude Code so the final poll can observe
+# a Host completion near the edge without turning this into an unbounded wait.
+wait_for_run_complete 300
 test -f "$codex_project_dir/ring_buffer.h"
 test -f "$codex_project_dir/ring_buffer.c"
 test -f "$codex_project_dir/test_ring_buffer.c"

--- a/e2e/live/run-release-candidate.sh
+++ b/e2e/live/run-release-candidate.sh
@@ -227,7 +227,7 @@ if [[ ! -d "$LIVE_E2E_WORKSPACE" ]]; then
   echo "LIVE_E2E_WORKSPACE must already exist" >&2
   exit 1
 fi
-for generated_name in browser-release-report c-release-agent cpp-release-agent rust-release-agent codex-c-release-agent; do
+for generated_name in browser-release-report c-release-agent cpp-release-agent rust-release-agent codex-c-release-agent claude-c-release-agent; do
   if [[ -e "$LIVE_E2E_WORKSPACE/$generated_name" ]]; then
     echo "Remove the previous $generated_name before running a new release gate" >&2
     exit 1
@@ -291,8 +291,10 @@ LIVE_E2E_CORE_VERSION="$("$co_bin" --version | tail -1)"
 LIVE_E2E_CORE_EXECUTABLE_SHA256="$(shasum -a 256 "$co_bin" | awk '{print $1}')"
 LIVE_E2E_REACT_VERSION="$(node -p 'require("./package.json").dependencies["@connectonion/react"]')"
 LIVE_E2E_OCHAT_COMMIT="$(git rev-parse HEAD)"
+LIVE_E2E_CODEX_VERSION="$(codex --version 2>/dev/null || printf unavailable)"
+LIVE_E2E_CLAUDE_CODE_VERSION="$(claude --version 2>/dev/null || printf unavailable)"
 export LIVE_E2E_CORE_VERSION LIVE_E2E_CORE_EXECUTABLE_SHA256
-export LIVE_E2E_REACT_VERSION LIVE_E2E_OCHAT_COMMIT
+export LIVE_E2E_REACT_VERSION LIVE_E2E_OCHAT_COMMIT LIVE_E2E_CODEX_VERSION LIVE_E2E_CLAUDE_CODE_VERSION
 export LIVE_E2E_PUBLIC_FRONTEND_URL="${LIVE_E2E_PUBLIC_FRONTEND_URL:-local-production-build:http://localhost:$frontend_port}"
 bash "$script_dir/run-production-acceptance.sh"
 

--- a/e2e/live/submit-provider-prompt.js
+++ b/e2e/live/submit-provider-prompt.js
@@ -12,7 +12,10 @@
   }
   const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
   setter?.call(composer, prompt)
-  composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: prompt }))
+  // Match React's controlled-input path used by the component acceptance
+  // tests. A generic input event is more portable than constructing an
+  // InputEvent with synthetic insertion metadata in browser automation.
+  composer.dispatchEvent(new Event('input', { bubbles: true }))
   composer.dispatchEvent(new Event('change', { bubbles: true }))
   composer.focus()
   return { ok: true, provider, characters: prompt.length }

--- a/e2e/live/submit-provider-prompt.js
+++ b/e2e/live/submit-provider-prompt.js
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+(args) => {
+  const provider = String(args.provider ?? '').trim()
+  const prompt = String(args.prompt ?? '')
+  const dialog = document.querySelector('[role="dialog"]')
+  const composer = dialog?.querySelector(`[aria-label="Message ${provider} directly"]`)
+  if (!(composer instanceof HTMLTextAreaElement)) {
+    return { ok: false, error: `${provider || 'provider'} composer not found` }
+  }
+  if (composer.disabled || !prompt.trim()) {
+    return { ok: false, error: `${provider || 'provider'} composer is unavailable` }
+  }
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+  setter?.call(composer, prompt)
+  composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: prompt }))
+  composer.dispatchEvent(new Event('change', { bubbles: true }))
+  composer.focus()
+  return { ok: true, provider, characters: prompt.length }
+}

--- a/e2e/live/write-manifest.mjs
+++ b/e2e/live/write-manifest.mjs
@@ -35,6 +35,7 @@ export async function writeManifest(output, evidenceDir, metadata) {
       'create and independently verify a strict C++20 project',
       'create and independently verify Rust CLI',
       'delegate a second C11 project to native Codex and inspect its Workroom',
+      'delegate a third C11 project to native Claude Code, inspect its Workroom, and continue the same provider session',
       'switch Full access, Read only, and Auto',
       'stop one live turn',
       'restart Host and reconnect without INPUT resend',
@@ -60,6 +61,11 @@ export async function writeManifest(output, evidenceDir, metadata) {
       codexStrictCompilePassed: true,
       codexWorkroomConversationPassed: true,
       codexDesktopTabletMobilePassed: true,
+      nativeClaudeCodeDelegationPassed: true,
+      claudeStrictCompilePassed: true,
+      claudeWorkroomConversationPassed: true,
+      claudeProviderFollowUpPassed: true,
+      claudeDesktopMobilePassed: true,
       fullAccessPassed: true,
       readOnlyPassed: true,
       autoPassed: true,
@@ -89,6 +95,8 @@ async function main() {
     coreExecutableSha256: process.env.LIVE_E2E_CORE_EXECUTABLE_SHA256 || 'unknown',
     reactVersion: process.env.LIVE_E2E_REACT_VERSION || 'unknown',
     oChatCommit: process.env.LIVE_E2E_OCHAT_COMMIT || 'unknown',
+    codexVersion: process.env.LIVE_E2E_CODEX_VERSION || 'unknown',
+    claudeCodeVersion: process.env.LIVE_E2E_CLAUDE_CODE_VERSION || 'unknown',
     frontendUrl: process.env.LIVE_E2E_PUBLIC_FRONTEND_URL || 'local-production-build',
     inviteMode: process.env.LIVE_E2E_INVITE_CODE_FILE
       ? 'invocation-scoped-file'

--- a/tests/release-evidence.test.ts
+++ b/tests/release-evidence.test.ts
@@ -88,6 +88,10 @@ describe('live release evidence helpers', () => {
     expect(runner).toContain('live-production-browser-task-complete-desktop.png')
     expect(runner).toContain('open_provider_workroom "Codex"')
     expect(runner).toContain('wait_for_provider_workroom "Codex" 45')
+    expect(runner).toContain('open_provider_workroom "Claude Code"')
+    expect(runner).toContain('wait_for_provider_workroom "Claude Code" 45')
+    expect(runner).toContain('submit_provider_prompt "Claude Code"')
+    expect(runner).toContain('wait_for_provider_marker_count "Claude Code" CLAUDE_FOLLOWUP_OK 2 180')
     expect(readFileSync(join(scripts, 'open-provider-workroom.js'), 'utf8'))
       .toContain('Open Work Room')
     expect(readFileSync(join(scripts, 'open-provider-workroom.js'), 'utf8'))
@@ -98,6 +102,10 @@ describe('live release evidence helpers', () => {
       .toContain('visibleUserMessageCount')
     expect(readFileSync(join(scripts, 'query-provider-workroom.js'), 'utf8'))
       .toContain('visibleAssistantMessageCount')
+    expect(readFileSync(join(scripts, 'query-provider-workroom.js'), 'utf8'))
+      .toContain('markerOccurrences')
+    expect(readFileSync(join(scripts, 'submit-provider-prompt.js'), 'utf8'))
+      .toContain('composer.focus()')
     expect(runner).toContain("'\"visibleUserMessageCount\":[[:space:]]*[1-9][0-9]*'")
     expect(runner).toContain("'\"visibleAssistantMessageCount\":[[:space:]]*[1-9][0-9]*'")
     expect(runner).toContain('select_mode "Auto"')
@@ -136,10 +144,10 @@ describe('live release evidence helpers', () => {
     mkdirSync(join(root, '.co'))
 
     expect(() => execFileSync('bash', [guard, root, '.co'])).not.toThrow()
-    for (const name of ['browser-release-report', 'c-release-agent', 'cpp-release-agent', 'rust-release-agent', 'codex-c-release-agent']) {
+    for (const name of ['browser-release-report', 'c-release-agent', 'cpp-release-agent', 'rust-release-agent', 'codex-c-release-agent', 'claude-c-release-agent']) {
       mkdirSync(join(root, name))
     }
-    const allowed = ['.co', 'browser-release-report', 'c-release-agent', 'cpp-release-agent', 'rust-release-agent', 'codex-c-release-agent']
+    const allowed = ['.co', 'browser-release-report', 'c-release-agent', 'cpp-release-agent', 'rust-release-agent', 'codex-c-release-agent', 'claude-c-release-agent']
     expect(() => execFileSync('bash', [guard, root, ...allowed])).not.toThrow()
 
     writeFileSync(join(root, 'outside.txt'), 'must fail')
@@ -207,6 +215,8 @@ describe('live release evidence helpers', () => {
         LIVE_E2E_CORE_VERSION: 'co 1.7.0b9',
         LIVE_E2E_REACT_VERSION: '0.4.2-beta.2',
         LIVE_E2E_OCHAT_COMMIT: 'abc123',
+        LIVE_E2E_CODEX_VERSION: 'codex-cli 0.147.0',
+        LIVE_E2E_CLAUDE_CODE_VERSION: '2.1.235 (Claude Code)',
       },
     })
 
@@ -216,6 +226,8 @@ describe('live release evidence helpers', () => {
       coreVersion: 'co 1.7.0b9',
       reactVersion: '0.4.2-beta.2',
       oChatCommit: 'abc123',
+      codexVersion: 'codex-cli 0.147.0',
+      claudeCodeVersion: '2.1.235 (Claude Code)',
     })
     expect(manifest.checks.reconnectWithoutResendPassed).toBe(true)
     expect(manifest.checks.onboardingSettled).toBe(true)
@@ -226,6 +238,9 @@ describe('live release evidence helpers', () => {
     expect(manifest.checks.cppStrictCompilePassed).toBe(true)
     expect(manifest.checks.nativeCodexDelegationPassed).toBe(true)
     expect(manifest.checks.codexWorkroomConversationPassed).toBe(true)
+    expect(manifest.checks.nativeClaudeCodeDelegationPassed).toBe(true)
+    expect(manifest.checks.claudeWorkroomConversationPassed).toBe(true)
+    expect(manifest.checks.claudeProviderFollowUpPassed).toBe(true)
     expect(manifest.checks.uiReviewPassed).toBe(false)
     expect(manifest.files).toEqual([{
       path: 'desktop.png',

--- a/tests/release-evidence.test.ts
+++ b/tests/release-evidence.test.ts
@@ -86,6 +86,7 @@ describe('live release evidence helpers', () => {
     expect(runner).toContain("SEARCH query=release-candidate matched=true")
     expect(runner).toContain("DOWNLOAD file=release-checksum.txt served=true")
     expect(runner).toContain('live-production-browser-task-complete-desktop.png')
+    expect(runner).toContain('wait_for_run_complete 240')
     expect(runner).toContain('open_provider_workroom "Codex"')
     expect(runner).toContain('wait_for_provider_workroom "Codex" 45')
     expect(runner).toContain('open_provider_workroom "Claude Code"')


### PR DESCRIPTION
- UI impact: no
- No-visual-change reason: Only release acceptance scripts, test helpers, and documentation change; the application UI is unchanged.

## Outcome

Extends the 1.7 installed-artifact release gate from one real coding provider to both supported providers.

The gate now:

- asks the real `co ai` Host to delegate a bounded C11 project to authenticated native Claude Code;
- independently compiles and runs the project;
- opens the real Claude Code Work Room;
- sends `CLAUDE_FOLLOWUP_OK` through the provider-targeted composer and requires one user plus one provider occurrence in the same conversation;
- captures desktop, follow-up, and 390 px Work Room evidence;
- hashes explicit Codex and Claude Code CLI versions in the manifest.

The existing invite isolation, workspace guard, browser/C/C++/Rust/Codex, mode, Stop, reconnect, sanitization, and manual UI-review gates remain mandatory.

## Verification before PR

- `bash -n` for both release runners;
- `npx tsc --noEmit`;
- ESLint: 0 errors, 6 existing warnings;
- unit suite: 185/185 passed with an explicit 15s timeout (the default 5s full-suite run had one existing release-evidence timing timeout; its isolated 14/14 run passed);
- production build passed;
- exact installed `connectonion==1.7.0rc2` direct Claude adapter smoke passed initial completion plus same-session resume on Claude Code 2.1.235.

The complete expanded live gate is the final acceptance for this PR and will be attached before merge.

Fixes #228
Advances openonion/connectonion#792 and openonion/connectonion#1109.
