### PR TITLE
fix: pin relay-safe session sync client

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,10 @@ backward compatible.
 The index connection uses `sessionSyncOnly`, so opening O Chat does not create an empty
 Agent session merely to populate the sidebar. Route guards wait for the first sync
 attempt before treating a missing remote row as nonexistent.
+Each index CONNECT carries a fresh signed nonce so two pages opened by the same identity
+in one second remain distinct under replay protection. The Host separately recognizes
+the public relay's top-level socket route ID as transport metadata on this index-only
+connection; O Chat never manufactures or interprets that routing field.
 
 ## Home — the agent's dashboard
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectonion/react": "0.4.4-rc.0",
+        "@connectonion/react": "0.4.4-rc.1",
         "@tailwindcss/typography": "^0.5.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "clsx": "^2.1.1",
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@connectonion/react": {
-      "version": "0.4.4-rc.0",
-      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.4-rc.0.tgz",
-      "integrity": "sha512-/s2rIM3xVWbF4nAToXJmRTxnXkKUZuXVNyc0Qu/bPOqVVH/tQ8+a6wFqfwG9jdILVyHsBkSsJGhXtl6crcYV9A==",
+      "version": "0.4.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@connectonion/react/-/react-0.4.4-rc.1.tgz",
+      "integrity": "sha512-Yv5LffcwU4Mme1i4i5qvQsqeKcNmpMmCQxvGiqjGYORAUOctKyT+ILUI7ZCar+F1Poh2gtfg0Cm6uYY3UwZC9Q==",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:shots": "rm -rf e2e-screenshots && playwright test && echo \"screenshots -> e2e-screenshots/\""
   },
   "dependencies": {
-    "@connectonion/react": "0.4.4-rc.0",
+    "@connectonion/react": "0.4.4-rc.1",
     "@tailwindcss/typography": "^0.5.20",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Change

Pin the newly published @connectonion/react 0.4.4-rc.1 registry artifact so parallel same-identity Recent Chat index connections carry distinct signed CONNECT nonces. Document the relay routing-metadata boundary at the O Chat SDK seam. Pairs with openonion/connectonion#1367 for Host 1.8.0a6.

## User-visible change

- UI impact: no
- Changed surfaces/routes: none
- Related issue/design decision: openonion/connectonion#1367
- Core version: 1.8.0a6
- React version: 0.4.4-rc.1
- O Chat commit: 17fe2795a6d82a782a6877f90b29e2ab70953c3c
- Evidence commit: 17fe2795a6d82a782a6877f90b29e2ab70953c3c
- No-visual-change reason: dependency-only protocol correction; no component, route, style, interaction, or rendered state changed

## Verification

- npm test: 25 files, 197 tests passed outside the filesystem sandbox required by the local Host-process fixture.
- npm run lint: passed with 7 existing warnings and no errors.
- npx next build --webpack: production compile, TypeScript, and all 7 routes passed.
- npm audit: 0 vulnerabilities.
- Lockfile resolves the public 0.4.4-rc.1 tarball with registry integrity sha512-Yv5LffcwU4Mme1i4i5qvQsqeKcNmpMmCQxvGiqjGYORAUOctKyT+ILUI7ZCar+F1Poh2gtfg0Cm6uYY3UwZC9Q==.

## UI interaction audit

Not applicable — no rendered source or interaction changed; this PR replaces only the SDK package bytes and architecture prose.

## Release gate

Merge to production only after Vercel preview checks are green. Then run the real same-identity, two-browser hosted-agent synchronization test against the deployed build.