### PR TITLE
fix: open remote chats as retained snapshots

### DIFF
--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -51,6 +51,7 @@ import { InvalidAddress } from '@/components/invalid-address'
 import { acceptsAttachments } from '@/components/chat/skill-offers'
 import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
 import { ActivityStatus, deriveActivityPhase } from '@/components/chat/activity-status'
+import { useRemoteSessionSnapshot } from '@/hooks/use-remote-session-snapshot'
 
 export default function ChatSessionPage() {
   const params = useParams()
@@ -84,7 +85,7 @@ export default function ChatSessionPage() {
     sessionSyncReady,
   } = useChatStore()
 
-  useIdentity()
+  const { identity } = useIdentity()
 
   const agentInfoMap = useAgentInfo([address])
 
@@ -162,6 +163,23 @@ export default function ChatSessionPage() {
     onError: setConnectionError,
   })
 
+  // A conversation discovered from another device has no local SDK transcript.
+  // Read it through the index capability instead of claiming its live session:
+  // the Host deliberately keeps that session single-writer while SESSION_GET is
+  // safe to use from any authenticated device owned by the same identity.
+  const hasRemoteSession = conversation?.remoteRevision !== undefined
+  const remoteSnapshotOnly = hasRemoteSession && hookUI.length === 0
+  const remoteSnapshot = useRemoteSessionSnapshot({
+    agentAddress: address,
+    sessionId,
+    identity,
+    remoteRevision: conversation?.remoteRevision,
+    enabled: hasRemoteSession,
+  })
+  const reloadRemoteSnapshot = remoteSnapshot.reload
+  const visibleConnectionError = connectionError
+    ?? (remoteSnapshotOnly ? remoteSnapshot.error : null)
+
   // Skills come from the authenticated socket once it is up, and from the public relay
   // directory before that — this session is connected, so it is entitled to the full list
   // and the dashboard's buttons should work for every skill the agent actually has.
@@ -185,7 +203,7 @@ export default function ChatSessionPage() {
     pendingApproval || pendingAskUser || pendingOnboard
   )
   const activityPhase = deriveActivityPhase({
-    connectionError,
+    connectionError: visibleConnectionError,
     sessionState,
     pendingApproval,
     pendingAskUser,
@@ -208,7 +226,10 @@ export default function ChatSessionPage() {
   // The SDK's per-session store is the transcript's single source of truth;
   // it hydrates synchronously from localStorage, so hookUI already carries
   // the persisted conversation on reload.
-  const displayUI = useMemo((): UI[] => dedupeUI(hookUI), [hookUI])
+  const displayUI = useMemo((): UI[] => dedupeUI([
+    ...(hasRemoteSession ? remoteSnapshot.ui : []),
+    ...hookUI,
+  ]), [hasRemoteSession, hookUI, remoteSnapshot.ui])
 
   // One pending challenge, one control. Before the reader has spoken, the
   // full-screen gate owns onboarding and the same item must not also render as
@@ -235,13 +256,13 @@ export default function ChatSessionPage() {
   const agentOffline = agentInfoMap[address]?.online === false
 
   const handleSend = useCallback((content: string, images?: string[], files?: import('@/components/chat/types').FileAttachment[]) => {
-    if (modeChangePending || agentOffline) return
+    if (modeChangePending || agentOffline || remoteSnapshotOnly) return
     if (!conversation) {
       createConversation(sessionId, address)
     }
     setConnectionError(null)
     send(content, images, files)
-  }, [modeChangePending, agentOffline, conversation, sessionId, address, createConversation, setConnectionError, send])
+  }, [modeChangePending, agentOffline, remoteSnapshotOnly, conversation, sessionId, address, createConversation, setConnectionError, send])
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -266,17 +287,18 @@ export default function ChatSessionPage() {
   // message, send it, and only then meet the gate, with their text already
   // consumed into a run that cannot proceed. That is the ordering #27 fixed for
   // the landing page; a forwarded session link went round it.
-  const connected = useRef(false)
+  const connectedSession = useRef<string | null>(null)
   useEffect(() => {
-    if (connected.current) return
-    connected.current = true
+    if (remoteSnapshotOnly || connectedSession.current === sessionId) return
+    connectedSession.current = sessionId
     connect()
-  }, [connect])
+  }, [connect, remoteSnapshotOnly, sessionId])
 
   const handleReconnect = useCallback(() => {
     setConnectionError(null)
-    reconnect()
-  }, [reconnect, setConnectionError])
+    if (remoteSnapshotOnly) reloadRemoteSnapshot()
+    else reconnect()
+  }, [reconnect, reloadRemoteSnapshot, remoteSnapshotOnly, setConnectionError])
 
   const handleRetry = useCallback(() => {
     if (!lastUserMessage) return
@@ -332,7 +354,18 @@ export default function ChatSessionPage() {
           <FullAccessModeBanner turnsRemaining={turnsLeft} onExit={() => void setSessionMode('auto')} />
         )}
 
-        <CurrentTodoListPanel entries={currentTodoList} />
+      {remoteSnapshotOnly && (
+        <div
+          role="status"
+          className="mx-4 mt-3 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800"
+        >
+          {remoteSnapshot.loading && displayUI.length === 0
+            ? 'Loading synced transcript from the Agent…'
+            : 'Synced from the Agent · read-only on this device while the live session stays with its current connection.'}
+        </div>
+      )}
+
+      <CurrentTodoListPanel entries={currentTodoList} />
 
         {/* Chat with mode status bar (Full access toggle integrated) */}
         <Chat
@@ -344,8 +377,12 @@ export default function ChatSessionPage() {
           onProviderPermission={setProviderPermission}
           providerStopStates={providerStopStates}
           isLoading={isLoading}
-          inputDisabled={modeChangePending || agentOffline}
-          disabledPlaceholder={agentOffline ? 'Agent offline — reconnect to send a message' : undefined}
+          inputDisabled={modeChangePending || agentOffline || remoteSnapshotOnly}
+          disabledPlaceholder={agentOffline
+            ? 'Agent offline — reconnect to send a message'
+            : remoteSnapshotOnly
+              ? 'Synced transcript — continue from the device with the live session'
+              : undefined}
           suggestions={[]}
           pendingAskUser={pendingAskUser}
           onAskUserResponse={respondToAskUser}
@@ -368,12 +405,12 @@ export default function ChatSessionPage() {
               modeRecoveryAction={modeRecoveryAction}
               onModeRetry={retryModeChange}
               sessionState={sessionState}
-              connectionError={connectionError}
+              connectionError={visibleConnectionError}
               onReconnect={handleReconnect}
               activityPhase={activityPhase}
             />
           }
-          connectionError={connectionError}
+          connectionError={visibleConnectionError}
           onRetry={!agentOffline && lastUserMessage ? handleRetry : undefined}
           onReconnect={!agentOffline ? handleReconnect : undefined}
           onDismissError={() => setConnectionError(null)}

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -389,10 +389,10 @@ export default function ChatSessionPage() {
           providerStopStates={providerStopStates}
           isLoading={isLoading}
           inputDisabled={modeChangePending || agentOffline || !canUseLiveSession}
-          disabledPlaceholder={sessionAccess === 'restoring'
-            ? 'Restoring chat…'
-            : agentOffline
+          disabledPlaceholder={agentOffline
             ? 'Agent offline — reconnect to send a message'
+            : sessionAccess === 'restoring'
+            ? 'Restoring chat…'
             : remoteSnapshotOnly
               ? 'Synced transcript — continue from the device with the live session'
               : undefined}

--- a/app/[address]/[sessionId]/page.tsx
+++ b/app/[address]/[sessionId]/page.tsx
@@ -52,6 +52,7 @@ import { acceptsAttachments } from '@/components/chat/skill-offers'
 import { LowBalanceNotice, isLowBalance, OfflineNotice } from '@/components/agent-address'
 import { ActivityStatus, deriveActivityPhase } from '@/components/chat/activity-status'
 import { useRemoteSessionSnapshot } from '@/hooks/use-remote-session-snapshot'
+import { resolveChatSessionAccess } from '@/components/chat/session-access'
 
 export default function ChatSessionPage() {
   const params = useParams()
@@ -168,7 +169,15 @@ export default function ChatSessionPage() {
   // the Host deliberately keeps that session single-writer while SESSION_GET is
   // safe to use from any authenticated device owned by the same identity.
   const hasRemoteSession = conversation?.remoteRevision !== undefined
-  const remoteSnapshotOnly = hasRemoteSession && hookUI.length === 0
+  const sessionAccess = resolveChatSessionAccess({
+    hasHydrated: _hasHydrated,
+    hasConversation: conversation !== undefined,
+    hasLocalTranscript: hookUI.length > 0,
+    hasRemoteRevision: hasRemoteSession,
+    sessionSyncReady: sessionSyncReady[address] === true,
+  })
+  const remoteSnapshotOnly = sessionAccess === 'snapshot'
+  const canUseLiveSession = sessionAccess === 'live'
   const remoteSnapshot = useRemoteSessionSnapshot({
     agentAddress: address,
     sessionId,
@@ -215,13 +224,14 @@ export default function ChatSessionPage() {
   const consumedRef = useRef<string | null>(null)
 
   useEffect(() => {
+    if (!canUseLiveSession) return
     if (consumedRef.current === sessionId) return
     consumedRef.current = sessionId
     const { message: pendingMessage, images: pendingImages, files: pendingFiles } = consumePendingMessage()
     if (pendingMessage) {
       send(pendingMessage, pendingImages ?? undefined, pendingFiles ?? undefined)
     }
-  }, [sessionId, consumePendingMessage, send])
+  }, [canUseLiveSession, sessionId, consumePendingMessage, send])
 
   // The SDK's per-session store is the transcript's single source of truth;
   // it hydrates synchronously from localStorage, so hookUI already carries
@@ -256,13 +266,13 @@ export default function ChatSessionPage() {
   const agentOffline = agentInfoMap[address]?.online === false
 
   const handleSend = useCallback((content: string, images?: string[], files?: import('@/components/chat/types').FileAttachment[]) => {
-    if (modeChangePending || agentOffline || remoteSnapshotOnly) return
+    if (modeChangePending || agentOffline || !canUseLiveSession) return
     if (!conversation) {
       createConversation(sessionId, address)
     }
     setConnectionError(null)
     send(content, images, files)
-  }, [modeChangePending, agentOffline, remoteSnapshotOnly, conversation, sessionId, address, createConversation, setConnectionError, send])
+  }, [modeChangePending, agentOffline, canUseLiveSession, conversation, sessionId, address, createConversation, setConnectionError, send])
 
   // Stable, so the pane's message listener isn't torn down and re-added every render.
   const runSkill = useCallback(
@@ -289,16 +299,17 @@ export default function ChatSessionPage() {
   // the landing page; a forwarded session link went round it.
   const connectedSession = useRef<string | null>(null)
   useEffect(() => {
-    if (remoteSnapshotOnly || connectedSession.current === sessionId) return
+    if (!canUseLiveSession || connectedSession.current === sessionId) return
     connectedSession.current = sessionId
     connect()
-  }, [connect, remoteSnapshotOnly, sessionId])
+  }, [connect, canUseLiveSession, sessionId])
 
   const handleReconnect = useCallback(() => {
+    if (sessionAccess === 'restoring' || sessionAccess === 'missing') return
     setConnectionError(null)
     if (remoteSnapshotOnly) reloadRemoteSnapshot()
     else reconnect()
-  }, [reconnect, reloadRemoteSnapshot, remoteSnapshotOnly, setConnectionError])
+  }, [reconnect, reloadRemoteSnapshot, remoteSnapshotOnly, sessionAccess, setConnectionError])
 
   const handleRetry = useCallback(() => {
     if (!lastUserMessage) return
@@ -377,8 +388,10 @@ export default function ChatSessionPage() {
           onProviderPermission={setProviderPermission}
           providerStopStates={providerStopStates}
           isLoading={isLoading}
-          inputDisabled={modeChangePending || agentOffline || remoteSnapshotOnly}
-          disabledPlaceholder={agentOffline
+          inputDisabled={modeChangePending || agentOffline || !canUseLiveSession}
+          disabledPlaceholder={sessionAccess === 'restoring'
+            ? 'Restoring chat…'
+            : agentOffline
             ? 'Agent offline — reconnect to send a message'
             : remoteSnapshotOnly
               ? 'Synced transcript — continue from the device with the live session'
@@ -399,7 +412,7 @@ export default function ChatSessionPage() {
               turnsLeft={turnsLeft}
               availableModes={availableModes}
               onModeChange={(nextMode) => void setSessionMode(nextMode)}
-              disabled={isLoading || agentOffline}
+              disabled={isLoading || agentOffline || !canUseLiveSession}
               modeChangePending={modeChangePending}
               modeChangeError={modeChangeError}
               modeRecoveryAction={modeRecoveryAction}
@@ -411,7 +424,7 @@ export default function ChatSessionPage() {
             />
           }
           connectionError={visibleConnectionError}
-          onRetry={!agentOffline && lastUserMessage ? handleRetry : undefined}
+          onRetry={canUseLiveSession && !agentOffline && lastUserMessage ? handleRetry : undefined}
           onReconnect={!agentOffline ? handleReconnect : undefined}
           onDismissError={() => setConnectionError(null)}
           skills={skills}

--- a/app/[address]/page.tsx
+++ b/app/[address]/page.tsx
@@ -327,7 +327,7 @@ export default function AgentLandingPage() {
             </div>
 
             {/* The handshake: a few things you can ask right now, in plain words */}
-            {isOnline !== false && (
+            {!needsOnboard && isOnline !== false && (
               <div className="reveal flex flex-wrap justify-center gap-2" style={{ '--reveal-delay': '180ms' } as React.CSSProperties}>
                 {/* The universal opener leads, filled — agent-specific offers follow */}
                 <button
@@ -350,7 +350,7 @@ export default function AgentLandingPage() {
 
 
             {/* Full inventory lives behind one quiet disclosure row */}
-            {(skills.length > 0 || tools.length > 0) && (
+            {!needsOnboard && (skills.length > 0 || tools.length > 0) && (
               <div className="reveal mt-5" style={{ '--reveal-delay': '260ms' } as React.CSSProperties}>
                 <button
                   onClick={() => setSkillsExpanded(!skillsExpanded)}

--- a/components/chat/session-access.test.ts
+++ b/components/chat/session-access.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { resolveChatSessionAccess } from './session-access'
+
+const restored = {
+  hasHydrated: true,
+  hasConversation: true,
+  hasLocalTranscript: false,
+  hasRemoteRevision: false,
+  sessionSyncReady: false,
+}
+
+describe('resolveChatSessionAccess', () => {
+  it('does not claim a live session before persisted state hydrates', () => {
+    expect(resolveChatSessionAccess({ ...restored, hasHydrated: false })).toBe('restoring')
+  })
+
+  it('keeps a hydrated remote-only transcript read-only after reload', () => {
+    expect(resolveChatSessionAccess({ ...restored, hasRemoteRevision: true })).toBe('snapshot')
+  })
+
+  it('waits for the remote index before claiming an unknown deep link', () => {
+    expect(resolveChatSessionAccess({ ...restored, hasConversation: false })).toBe('restoring')
+  })
+
+  it('does not connect a missing session after index discovery finishes', () => {
+    expect(resolveChatSessionAccess({
+      ...restored, hasConversation: false, sessionSyncReady: true,
+    })).toBe('missing')
+  })
+
+  it('allows a new local draft to connect without waiting for the index', () => {
+    expect(resolveChatSessionAccess(restored)).toBe('live')
+  })
+
+  it('preserves the live path for a locally cached transcript', () => {
+    expect(resolveChatSessionAccess({
+      ...restored, hasLocalTranscript: true, hasRemoteRevision: true,
+    })).toBe('live')
+  })
+})

--- a/components/chat/session-access.ts
+++ b/components/chat/session-access.ts
@@ -1,0 +1,23 @@
+interface ChatSessionAccessInput {
+  hasHydrated: boolean
+  hasConversation: boolean
+  hasLocalTranscript: boolean
+  hasRemoteRevision: boolean
+  sessionSyncReady: boolean
+}
+
+/** A cold render must not mistake an unrestored remote chat for a local draft. */
+export function resolveChatSessionAccess({
+  hasHydrated,
+  hasConversation,
+  hasLocalTranscript,
+  hasRemoteRevision,
+  sessionSyncReady,
+}: ChatSessionAccessInput): 'restoring' | 'snapshot' | 'live' | 'missing' {
+  if (!hasHydrated) return 'restoring'
+  if (!hasConversation && !hasLocalTranscript) {
+    return sessionSyncReady ? 'missing' : 'restoring'
+  }
+  if (hasRemoteRevision && !hasLocalTranscript) return 'snapshot'
+  return 'live'
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,6 +93,7 @@ removes JWT/profile fields written by older O Chat alpha stores.
 | `hooks/use-agent-info.ts` | agent profile + online status (cache-first; refetch on tab focus) |
 | `hooks/use-recent-chat-sync.ts` | owner-scoped Host history reconciliation and archive operations |
 | `hooks/use-remote-session-snapshot.ts` | revision-consistent transcript reads that never claim a live session |
+| `components/chat/session-access.ts` | hydration/discovery boundary selecting restoring, snapshot, live, or missing access |
 | `store/chat-store.ts` | the sidebar index |
 | `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
 
@@ -131,6 +132,13 @@ transcript, and closes that socket. A changed sidebar revision triggers another
 revision-consistent snapshot read. A browser that already has the SDK transcript keeps
 the existing live reconnect path; snapshot items and local items are deduplicated at
 the presentation boundary.
+
+The first browser render is not evidence of local ownership. Session routes wait for
+the sidebar store to hydrate; an uncached deep link also waits for its first remote
+index attempt. Until access resolves to `live`, no eager CONNECT, pending input,
+mode change, retry, or reconnect may claim the session. A remote-only route resolves
+to `snapshot`, keeps its composer and mode controls disabled, and refreshes through
+`SESSION_GET` even after a full browser reload.
 
 ## Home — the agent's dashboard
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,6 +92,7 @@ removes JWT/profile fields written by older O Chat alpha stores.
 | `hooks/use-identity.ts` | your keypair + login |
 | `hooks/use-agent-info.ts` | agent profile + online status (cache-first; refetch on tab focus) |
 | `hooks/use-recent-chat-sync.ts` | owner-scoped Host history reconciliation and archive operations |
+| `hooks/use-remote-session-snapshot.ts` | revision-consistent transcript reads that never claim a live session |
 | `store/chat-store.ts` | the sidebar index |
 | `app/api/auth/route.ts` | CORS proxy to `oo.openonion.ai` for login |
 
@@ -121,6 +122,15 @@ Each index CONNECT carries a fresh signed nonce so two pages opened by the same 
 in one second remain distinct under replay protection. The Host separately recognizes
 the public relay's top-level socket route ID as transport metadata on this index-only
 connection; O Chat never manufactures or interprets that routing field.
+
+Opening a row discovered on another device does not send a normal chat `CONNECT`.
+Retained sessions are single-writer, so that would compete with the device already
+attached to the live session. O Chat instead sends `SESSION_GET` over a short-lived
+index-only capability socket, renders the returned `SESSION_SNAPSHOT` as a read-only
+transcript, and closes that socket. A changed sidebar revision triggers another
+revision-consistent snapshot read. A browser that already has the SDK transcript keeps
+the existing live reconnect path; snapshot items and local items are deduplicated at
+the presentation boundary.
 
 ## Home — the agent's dashboard
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,15 @@ oo-chat imports `useAgentForHuman`, `fetchAgentInfo`, and `useVoiceInput` from
 
 ## Recent Chat synchronization
 
+Index discovery cannot host an invitation form. If its authenticated connection
+receives an onboarding challenge, it closes that background connection and marks
+discovery complete. An unknown shared-session route can then return to the Agent
+landing page's existing invitation gate without claiming the linked live session.
+Local drafts retain their normal invitation flow. Offline status takes precedence
+over a restoration placeholder while no connection can be established.
+An already-indexed remote snapshot that requires verification stops loading and
+directs the reader to that homepage; it never falls back to a live-session attach.
+
 The index connection negotiates the OIP Session Sync extension and signs every command
 with the same browser identity used for chat. The Host returns only sessions owned by
 that identity. Cursors are opaque and incremental: O Chat stores the latest cursor per

--- a/e2e/approval-decisions.spec.ts
+++ b/e2e/approval-decisions.spec.ts
@@ -238,9 +238,18 @@ test.describe('the onboarding gate and bounded Full access', () => {
 
   test('a successful invite shows one confirmation, not two', async ({ page, shot }) => {
     const agent = await mockAgent(page, 'onboard-success')
-    // The duplicate was a transcript bug. A shared session reaches the same
-    // authenticated Gate but retains the conversation surface where success is
-    // rendered; the landing page correctly has no transcript to inspect.
+    // The duplicate was a transcript bug. Use a real local draft so discovery
+    // does not correctly redirect an unknown session link to the landing gate.
+    await page.addInitScript(address => {
+      localStorage.setItem('oo-chat-storage', JSON.stringify({
+        state: {
+          conversations: [{
+            sessionId: 'invite-success-session', agentAddress: address, title: 'Local draft',
+            createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(),
+          }], agents: [address], activeSessionId: 'invite-success-session',
+        }, version: 0,
+      }))
+    }, AGENT_ADDRESS)
     await page.goto(`/${AGENT_ADDRESS}/invite-success-session`)
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 20_000 })
 

--- a/e2e/composer.spec.ts
+++ b/e2e/composer.spec.ts
@@ -13,6 +13,25 @@ import { deflateSync } from 'node:zlib'
 import { test, expect } from './fixtures'
 import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
+async function openDraft(page: import('@playwright/test').Page, sessionId: string) {
+  // A missing session link now waits for discovery and returns to the landing
+  // page. Exercise attachment layout on an actual local draft, not mid-redirect.
+  await page.addInitScript(({ address, sessionId }) => {
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations: [{
+          sessionId, agentAddress: address, title: 'Local draft',
+          createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(),
+        }],
+        agents: [address], activeSessionId: sessionId,
+      }, version: 0,
+    }))
+  }, { address: AGENT_ADDRESS, sessionId })
+  await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}/${sessionId}`)
+  await expect(page.getByRole('button', { name: 'Attach file' })).toBeEnabled()
+}
+
 /** A real 64x64 PNG. A 1x1 transparent one renders as nothing, which is how the
  *  first run of this produced a blank thumbnail and a false alarm. */
 function swatch(path: string) {
@@ -44,8 +63,7 @@ test('an attached image and its remove button stay inside the composer', async (
   const file = '/tmp/e2e-swatch.png'
   swatch(file)
 
-  await mockAgent(page)
-  await page.goto(`/${AGENT_ADDRESS}/attach`)
+  await openDraft(page, 'attach')
   await expect(page.getByRole('button', { name: 'Attach file' })).toBeVisible({ timeout: 20_000 })
 
   await page.locator('input[type=file]').first().setInputFiles({
@@ -78,8 +96,7 @@ test('an attached image and its remove button stay inside the composer', async (
 })
 
 test('every composer control clears the touch floor', async ({ page }) => {
-  await mockAgent(page)
-  await page.goto(`/${AGENT_ADDRESS}/touch`)
+  await openDraft(page, 'touch')
   await expect(page.getByRole('button', { name: 'Attach file' })).toBeVisible({ timeout: 20_000 })
 
   for (const name of ['Attach file', 'Start recording', 'Send message']) {

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -11,12 +11,30 @@
 import { test, expect } from './fixtures'
 import { mockAgent, AGENT_ADDRESS } from './mock-agent'
 
+async function openEmptySession(page: import('@playwright/test').Page, sessionId: string) {
+  // Exercise the empty *session* surface, not an unknown link that correctly
+  // redirects after remote discovery. Otherwise DOM reads race that navigation.
+  await page.addInitScript(({ address, sessionId }) => {
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations: [{
+          sessionId, agentAddress: address, title: 'Local draft',
+          createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(),
+        }], agents: [address], activeSessionId: sessionId,
+      }, version: 0,
+    }))
+  }, { address: AGENT_ADDRESS, sessionId })
+  await page.goto(`/${AGENT_ADDRESS}/${sessionId}`)
+  await expect(page.locator('textarea')).toBeEnabled()
+  await expect(page).toHaveURL(new RegExp(`/${sessionId}$`))
+}
+
 test('a fresh session offers the same openers the landing page does', async ({ page, shot }) => {
   await mockAgent(page)
 
   // Straight into a session with an empty transcript — the screen a visitor sees
   // immediately after passing an invite gate.
-  await page.goto(`/${AGENT_ADDRESS}/fresh-session`)
+  await openEmptySession(page, 'fresh-session')
   await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
 
   // The exact offer bestOffers() derives from Scriptbot's deploy skill, asserted
@@ -48,7 +66,7 @@ test('a fresh session offers the same openers the landing page does', async ({ p
 
 test('the universal opener sends what it says', async ({ page }) => {
   await mockAgent(page)
-  await page.goto(`/${AGENT_ADDRESS}/fresh-session-3`)
+  await openEmptySession(page, 'fresh-session-3')
   await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
 
   await page.locator('main').getByRole('button', { name: 'What can you do?' }).click()
@@ -57,7 +75,7 @@ test('the universal opener sends what it says', async ({ page }) => {
 
 test('tapping an opener sends it', async ({ page }) => {
   await mockAgent(page)
-  await page.goto(`/${AGENT_ADDRESS}/fresh-session-2`)
+  await openEmptySession(page, 'fresh-session-2')
   await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
 
   await page.locator('main').getByRole('button', { name: 'Ship the current branch to production' }).click()
@@ -87,7 +105,7 @@ test('an agent with no usable chips still offers the universal opener', async ({
     skills: [{ name: 'debug_dump', description: 'internal' }],
   })
 
-  await page.goto(`/${AGENT_ADDRESS}/fresh-session-4`)
+  await openEmptySession(page, 'fresh-session-4')
   await expect(page.getByText(/send a message|Connected/i).first()).toBeVisible({ timeout: 20_000 })
 
   const pane = page.locator('main')

--- a/e2e/live/README.md
+++ b/e2e/live/README.md
@@ -1,5 +1,31 @@
 # Live production release acceptance
 
+## Two-device Session Sync acceptance
+
+`node e2e/live/session-sync.mjs` tests two isolated browser contexts against a
+real Host and public relay. Run `session_sync_host.py <dedicated-co-dir> <port>`
+on the test server with the exact Core wheel installed (validated with
+`connectonion==1.8.0a8`). This deterministic echo fixture needs no LLM key,
+exposes no tools, and uses open trust only in its disposable test workspace.
+Stop that owned process/container after acceptance; never substitute a customer
+Agent or workspace.
+
+Set `E2E_BASE_URL` to the production build under test, `E2E_AGENT_ADDRESS` to
+the fixture's public address, `E2E_SHOTS_DIR` to an empty evidence directory,
+and `E2E_MNEMONIC` to a disposable test identity. Both contexts import the same
+identity through Settings. Do not use a real recovery phrase. Use a fresh
+identity or Host directory for each run so old retained chats cannot mask the
+assertion that exactly one real conversation is discovered.
+
+The runner verifies same-second CONNECT nonce uniqueness; remote Recent Chat
+discovery without blank draft sessions; snapshot loading; automatic second-turn
+updates; reload without duplicates or live attachment; and archive propagation
+back to the originating device. Any protocol, console, or page error fails the
+run. It writes redacted frame metadata to `evidence.json` and desktop/mobile
+screenshots. Inspect the transcript and archive dialog images before treating a
+passing exit code as release evidence. This supplements, rather than replaces,
+the complete release gate below.
+
 This is the Beta/RC release gate for a real installed `co ai` candidate, the
 exact O Chat production build, and the persistent Co-browser. It does not use
 the mocked Playwright agent or `next dev`.

--- a/e2e/live/session-sync.mjs
+++ b/e2e/live/session-sync.mjs
@@ -1,0 +1,310 @@
+import { chromium } from 'playwright'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://chat.openonion.ai'
+const AGENT_ADDRESS = process.env.E2E_AGENT_ADDRESS
+const SHOTS_DIR = process.env.E2E_SHOTS_DIR
+const STAGGER_MS = Number(process.env.E2E_STAGGER_MS || 0)
+const MNEMONIC = process.env.E2E_MNEMONIC
+const FIXED_NOW_MS = Math.floor(Date.now() / 1000) * 1000
+
+if (!MNEMONIC) throw new Error('E2E_MNEMONIC must name a disposable test identity, never a real user identity')
+if (!AGENT_ADDRESS) throw new Error('E2E_AGENT_ADDRESS is required')
+if (!SHOTS_DIR) throw new Error('E2E_SHOTS_DIR is required')
+fs.mkdirSync(SHOTS_DIR, { recursive: true })
+
+const evidence = {
+  baseUrl: BASE_URL,
+  agentAddress: AGENT_ADDRESS,
+  startedAt: new Date().toISOString(),
+  fixedBrowserTimestamp: Math.floor(FIXED_NOW_MS / 1000),
+  browser: {},
+  protocolFrames: { stationA: [], stationB: [] },
+  consoleErrors: { stationA: [], stationB: [] },
+  checks: {},
+}
+
+function frameSummary(direction, payload) {
+  if (typeof payload !== 'string') return null
+  try {
+    const parsed = JSON.parse(payload)
+    const frame = { direction, type: parsed.type || 'unknown' }
+    if (typeof parsed.request_id === 'string') frame.requestId = parsed.request_id
+    if (typeof parsed.session_id === 'string') frame.sessionId = parsed.session_id
+    if (parsed.protocol && typeof parsed.protocol === 'object') frame.protocol = parsed.protocol
+    if (parsed.payload?.extensions && typeof parsed.payload.extensions === 'object') {
+      frame.requestedExtensions = parsed.payload.extensions
+    }
+    if (parsed.payload?.session_sync_only === 1) frame.sessionSyncOnly = true
+    if (typeof parsed.payload?.timestamp === 'number') frame.connectTimestamp = parsed.payload.timestamp
+    if (typeof parsed.payload?.nonce === 'string') frame.connectNonce = parsed.payload.nonce
+    if (typeof parsed.status === 'string') frame.status = parsed.status
+    if (parsed.type === 'ERROR' && typeof parsed.message === 'string') frame.message = parsed.message
+    if (parsed.type === 'ERROR' && typeof parsed.error === 'string') frame.message = parsed.error
+    return frame
+  } catch {
+    return null
+  }
+}
+
+function observe(page, station) {
+  page.on('console', message => {
+    if (message.type() === 'error') evidence.consoleErrors[station].push(message.text())
+  })
+  page.on('pageerror', error => evidence.consoleErrors[station].push(error.message))
+  page.on('websocket', socket => {
+    socket.on('framesent', event => {
+      const summary = frameSummary('sent', event.payload)
+      if (summary) evidence.protocolFrames[station].push(summary)
+    })
+    socket.on('framereceived', event => {
+      const summary = frameSummary('received', event.payload)
+      if (summary) evidence.protocolFrames[station].push(summary)
+    })
+  })
+}
+
+async function identityAddress(page) {
+  const candidate = page.locator('main div.font-mono').filter({ hasText: /^0x[0-9a-f]{64}$/ }).first()
+  await candidate.waitFor({ state: 'visible', timeout: 20_000 })
+  return (await candidate.innerText()).trim()
+}
+
+async function importSharedIdentity(page) {
+  await page.goto(`${BASE_URL}/settings`, { waitUntil: 'domcontentloaded' })
+  await page.getByRole('heading', { name: 'Settings' }).waitFor({ timeout: 30_000 })
+
+  const recoveryModal = page.getByRole('heading', { name: 'Secure Your Recovery Phrase' })
+  if (await recoveryModal.isVisible({ timeout: 10_000 }).catch(() => false)) {
+    await page.getByRole('button', { name: "I've Stored It Safely" }).click()
+  }
+
+  const before = await identityAddress(page)
+  await page.getByRole('button', { name: 'Import Key' }).click()
+  await page.getByPlaceholder('Paste your 12-word recovery phrase...').fill(MNEMONIC)
+  await page.getByRole('button', { name: 'Import Now' }).click()
+  await page.getByPlaceholder('Paste your 12-word recovery phrase...').waitFor({ state: 'hidden' })
+  const after = await identityAddress(page)
+  if (before === after) throw new Error('Identity import did not replace the fresh identity')
+  return after
+}
+
+async function storedConversations(page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('oo-chat-storage')
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return parsed?.state?.conversations || []
+  })
+}
+
+async function waitFor(condition, description, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      const value = await condition()
+      if (value) return value
+    } catch (error) {
+      lastError = error
+    }
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+  throw new Error(`Timed out waiting for ${description}${lastError ? `: ${lastError.message}` : ''}`)
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  evidence.browser.version = browser.version()
+  const contextA = await browser.newContext({ viewport: { width: 1280, height: 800 } })
+  const contextB = await browser.newContext({ viewport: { width: 390, height: 844 } })
+  await Promise.all([
+    contextA.addInitScript(fixedNow => { Date.now = () => fixedNow }, FIXED_NOW_MS),
+    contextB.addInitScript(fixedNow => { Date.now = () => fixedNow }, FIXED_NOW_MS),
+  ])
+  const pageA = await contextA.newPage()
+  const pageB = await contextB.newPage()
+  observe(pageA, 'stationA')
+  observe(pageB, 'stationB')
+
+  try {
+    const identityA = await importSharedIdentity(pageA)
+    const identityB = await importSharedIdentity(pageB)
+    evidence.identityAddress = identityA
+    evidence.checks.sameIdentityAcrossIsolatedContexts = identityA === identityB
+    if (identityA !== identityB) throw new Error('The two isolated browser contexts have different identities')
+
+    if (STAGGER_MS > 0) {
+      await pageB.goto(`${BASE_URL}/${AGENT_ADDRESS}`, { waitUntil: 'domcontentloaded' })
+      await pageB.getByRole('heading', { name: 'Session Sync E2E', exact: true }).waitFor({ timeout: 30_000 })
+      await new Promise(resolve => setTimeout(resolve, STAGGER_MS))
+      await pageA.goto(`${BASE_URL}/${AGENT_ADDRESS}`, { waitUntil: 'domcontentloaded' })
+      await pageA.getByRole('heading', { name: 'Session Sync E2E', exact: true }).waitFor({ timeout: 30_000 })
+    } else {
+      await Promise.all([
+        pageA.goto(`${BASE_URL}/${AGENT_ADDRESS}`, { waitUntil: 'domcontentloaded' }),
+        pageB.goto(`${BASE_URL}/${AGENT_ADDRESS}`, { waitUntil: 'domcontentloaded' }),
+      ])
+      await Promise.all([
+        pageA.getByRole('heading', { name: 'Session Sync E2E', exact: true }).waitFor({ timeout: 30_000 }),
+        pageB.getByRole('heading', { name: 'Session Sync E2E', exact: true }).waitFor({ timeout: 30_000 }),
+      ])
+    }
+
+    const beforeB = await storedConversations(pageB)
+    evidence.checks.stationBInitiallyEmpty = beforeB.length === 0
+    if (beforeB.length !== 0) throw new Error(`Station B unexpectedly had ${beforeB.length} local conversations`)
+
+    await pageA.getByRole('button', { name: 'What can you do?' }).click()
+    await pageA.getByText('E2E echo: What can you do?').waitFor({ state: 'visible', timeout: 30_000 })
+    await pageA.screenshot({ path: path.join(SHOTS_DIR, '01-station-a-created-desktop.png'), fullPage: true })
+
+    const sessionMatch = pageA.url().match(new RegExp(`${AGENT_ADDRESS}/([^/?#]+)`))
+    if (!sessionMatch) throw new Error(`Station A did not navigate to a session URL: ${pageA.url()}`)
+    evidence.sessionId = sessionMatch[1]
+
+    const syncStarted = Date.now()
+    const remoteB = await waitFor(async () => {
+      const conversations = await storedConversations(pageB)
+      return conversations.find(item => item.sessionId === evidence.sessionId && item.remoteRevision > 0)
+    }, 'Station B remote Recent Chat entry', 35_000)
+    evidence.checks.stationBAutoSyncLatencyMs = Date.now() - syncStarted
+    evidence.checks.stationBRemoteRevision = remoteB.remoteRevision
+    evidence.checks.stationBTitle = remoteB.title
+    const syncedConversationsB = await storedConversations(pageB)
+    evidence.checks.stationBRemoteConversationCount = syncedConversationsB.length
+    evidence.checks.noBlankRemoteConversations = syncedConversationsB.every(item =>
+      typeof item.title === 'string' && item.title.trim() && item.title !== 'Untitled chat')
+    if (syncedConversationsB.length !== 1 || !evidence.checks.noBlankRemoteConversations) {
+      throw new Error(`Station B received non-chat history: ${JSON.stringify(syncedConversationsB)}`)
+    }
+
+    await pageB.getByRole('button', { name: 'Open menu' }).click()
+    const syncedLinkB = pageB.getByRole('link', { name: remoteB.title, exact: true })
+    await syncedLinkB.waitFor({ state: 'visible', timeout: 10_000 })
+    await pageB.screenshot({ path: path.join(SHOTS_DIR, '02-station-b-auto-synced-mobile.png'), fullPage: true })
+    await syncedLinkB.click()
+
+    await pageB.getByText('What can you do?', { exact: true }).first().waitFor({ state: 'visible', timeout: 30_000 })
+    await pageB.getByText('E2E echo: What can you do?').waitFor({ state: 'visible', timeout: 30_000 })
+    evidence.checks.stationBLoadedRemoteTranscript = true
+    evidence.checks.remoteComposerReadOnly = await pageB.locator('textarea').isDisabled()
+    if (!evidence.checks.remoteComposerReadOnly) throw new Error('Remote snapshot composer unexpectedly allows input')
+
+    const followUp = 'Cross-device follow-up'
+    await pageA.locator('textarea').fill(followUp)
+    await pageA.getByRole('button', { name: 'Send message', exact: true }).click()
+    await pageA.getByText(`E2E echo: ${followUp}`, { exact: true }).waitFor({ state: 'visible', timeout: 30_000 })
+    const updateStarted = Date.now()
+    await pageB.getByText(`E2E echo: ${followUp}`, { exact: true }).waitFor({ state: 'visible', timeout: 35_000 })
+    evidence.checks.stationBTranscriptAutoUpdateLatencyMs = Date.now() - updateStarted
+    evidence.checks.stationBTranscriptUpdatedWithoutReload = true
+    await pageB.reload({ waitUntil: 'domcontentloaded' })
+    await pageB.getByText(`E2E echo: ${followUp}`, { exact: true }).waitFor({ state: 'visible', timeout: 30_000 })
+    evidence.checks.remoteTranscriptSurvivesReload = true
+    const expectedMessages = ['What can you do?', 'E2E echo: What can you do?', followUp, `E2E echo: ${followUp}`]
+    evidence.checks.remoteTranscriptHasNoDuplicates = (await Promise.all(expectedMessages.map(text =>
+      pageB.locator('main').getByText(text, { exact: true }).count()))).every(count => count === 1)
+    if (!evidence.checks.remoteTranscriptHasNoDuplicates) throw new Error('Remote transcript duplicated a retained message after reload')
+    if (await pageB.getByText(/Session is already attached|Error: Agent error/).count()) {
+      throw new Error('Remote transcript renders a live-session attachment error after reload')
+    }
+    await pageB.screenshot({ path: path.join(SHOTS_DIR, '03-station-b-remote-transcript-mobile.png'), fullPage: true })
+    await pageB.setViewportSize({ width: 1280, height: 800 })
+    await pageB.screenshot({ path: path.join(SHOTS_DIR, '03b-station-b-remote-transcript-desktop.png'), fullPage: true })
+    await pageB.setViewportSize({ width: 390, height: 844 })
+
+    await pageB.getByRole('button', { name: 'Open menu' }).click()
+    const rowB = pageB.getByRole('link', { name: remoteB.title, exact: true }).locator('..')
+    await rowB.getByRole('button', { name: 'Archive chat' }).click()
+    const dialog = pageB.getByRole('alertdialog')
+    await dialog.getByText('Archive this chat?').waitFor({ state: 'visible' })
+    await pageB.waitForTimeout(500)
+    await pageB.screenshot({ path: path.join(SHOTS_DIR, '04-station-b-archive-confirm-mobile.png'), fullPage: true })
+    await dialog.getByRole('button', { name: 'Archive', exact: true }).click()
+
+    await waitFor(async () => !(await storedConversations(pageB)).some(item => item.sessionId === evidence.sessionId), 'Station B archive removal')
+    const archiveStarted = Date.now()
+    await waitFor(async () => !(await storedConversations(pageA)).some(item => item.sessionId === evidence.sessionId), 'Station A archive propagation', 35_000)
+    evidence.checks.stationAArchivePropagationLatencyMs = Date.now() - archiveStarted
+    evidence.checks.archivePropagatedBackToStationA = true
+    await pageA.screenshot({ path: path.join(SHOTS_DIR, '05-station-a-archive-propagated-desktop.png'), fullPage: true })
+
+    const allFrames = [...evidence.protocolFrames.stationA, ...evidence.protocolFrames.stationB]
+    const indexConnectA = evidence.protocolFrames.stationA.find(frame =>
+      frame.direction === 'sent' && frame.type === 'CONNECT' && frame.sessionSyncOnly === true)
+    const indexConnectB = evidence.protocolFrames.stationB.find(frame =>
+      frame.direction === 'sent' && frame.type === 'CONNECT' && frame.sessionSyncOnly === true)
+    evidence.checks.indexConnectsShareFrozenTimestamp = Boolean(
+      indexConnectA?.connectTimestamp
+      && indexConnectA.connectTimestamp === indexConnectB?.connectTimestamp
+      && indexConnectA.connectTimestamp === evidence.fixedBrowserTimestamp)
+    evidence.checks.indexConnectNoncesAreDistinct = Boolean(
+      indexConnectA?.connectNonce
+      && indexConnectB?.connectNonce
+      && indexConnectA.connectNonce !== indexConnectB.connectNonce)
+    evidence.checks.bothIndexConnectionsAccepted = ['stationA', 'stationB'].every(station =>
+      evidence.protocolFrames[station].some(frame =>
+        frame.direction === 'received' && frame.type === 'CONNECTED' && frame.status === 'index'))
+    evidence.checks.noReplayOrResumeErrors = !allFrames.some(frame =>
+      frame.type === 'ERROR'
+      && /replay|session_sync_only cannot resume/i.test(frame.message || ''))
+    evidence.checks.noProtocolErrors = !allFrames.some(frame => frame.type === 'ERROR')
+    evidence.checks.stationBNeverClaimsLiveSession = !evidence.protocolFrames.stationB.some(frame =>
+      frame.direction === 'sent' && frame.type === 'CONNECT'
+      && frame.sessionId === evidence.sessionId && frame.sessionSyncOnly !== true)
+    evidence.checks.protocolNegotiatedSessionSync = allFrames.some(frame =>
+      frame.type === 'CONNECT'
+      && frame.sessionSyncOnly === true
+      && frame.requestedExtensions?.['session-sync']?.includes?.('0.1'))
+    evidence.checks.sawSessionSyncResult = allFrames.some(frame => frame.type === 'SESSION_SYNC_RESULT')
+    evidence.checks.sawSessionGetResult = allFrames.some(frame => frame.type === 'SESSION_SNAPSHOT')
+    evidence.checks.sawSessionUpdateResult = allFrames.some(frame => frame.type === 'SESSION_UPDATED')
+
+    for (const [name, passed] of Object.entries({
+      sameIdentityAcrossIsolatedContexts: evidence.checks.sameIdentityAcrossIsolatedContexts,
+      stationBInitiallyEmpty: evidence.checks.stationBInitiallyEmpty,
+      stationBLoadedRemoteTranscript: evidence.checks.stationBLoadedRemoteTranscript,
+      stationBTranscriptUpdatedWithoutReload: evidence.checks.stationBTranscriptUpdatedWithoutReload,
+      remoteTranscriptSurvivesReload: evidence.checks.remoteTranscriptSurvivesReload,
+      remoteTranscriptHasNoDuplicates: evidence.checks.remoteTranscriptHasNoDuplicates,
+      remoteComposerReadOnly: evidence.checks.remoteComposerReadOnly,
+      noBlankRemoteConversations: evidence.checks.noBlankRemoteConversations,
+      archivePropagatedBackToStationA: evidence.checks.archivePropagatedBackToStationA,
+      indexConnectsShareFrozenTimestamp: evidence.checks.indexConnectsShareFrozenTimestamp,
+      indexConnectNoncesAreDistinct: evidence.checks.indexConnectNoncesAreDistinct,
+      bothIndexConnectionsAccepted: evidence.checks.bothIndexConnectionsAccepted,
+      noReplayOrResumeErrors: evidence.checks.noReplayOrResumeErrors,
+      noProtocolErrors: evidence.checks.noProtocolErrors,
+      stationBNeverClaimsLiveSession: evidence.checks.stationBNeverClaimsLiveSession,
+      protocolNegotiatedSessionSync: evidence.checks.protocolNegotiatedSessionSync,
+      sawSessionSyncResult: evidence.checks.sawSessionSyncResult,
+      sawSessionGetResult: evidence.checks.sawSessionGetResult,
+      sawSessionUpdateResult: evidence.checks.sawSessionUpdateResult,
+    })) {
+      if (!passed) throw new Error(`Required acceptance check failed: ${name}`)
+    }
+    if (Object.values(evidence.consoleErrors).some(errors => errors.length)) {
+      throw new Error('A browser reported console or page errors; inspect evidence.json')
+    }
+    evidence.status = 'passed'
+  } catch (error) {
+    evidence.status = 'failed'
+    evidence.error = error.stack || error.message
+    await pageA.screenshot({ path: path.join(SHOTS_DIR, 'failure-station-a.png'), fullPage: true }).catch(() => {})
+    await pageB.screenshot({ path: path.join(SHOTS_DIR, 'failure-station-b.png'), fullPage: true }).catch(() => {})
+    throw error
+  } finally {
+    evidence.finishedAt = new Date().toISOString()
+    fs.writeFileSync(path.join(SHOTS_DIR, 'evidence.json'), JSON.stringify(evidence, null, 2))
+    await contextA.close()
+    await contextB.close()
+    await browser.close()
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/e2e/live/session_sync_host.py
+++ b/e2e/live/session_sync_host.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from connectonion import host
+
+
+class _Tools:
+    def names(self) -> list[str]:
+        return []
+
+
+class _LLM:
+    model = "deterministic-e2e-echo"
+
+
+class EchoAgent:
+    name = "Session Sync E2E"
+    system_prompt = "A deterministic agent used only for OIP session-sync acceptance."
+    tools = _Tools()
+    llm = _LLM()
+    skills: list[object] = []
+
+    def __init__(self) -> None:
+        self.current_session: dict = {"messages": [], "trace": [], "turn": 0}
+
+    def input(
+        self,
+        prompt: str,
+        *,
+        session: dict | None = None,
+        images: object = None,
+        files: object = None,
+    ) -> str:
+        del images, files
+        current = dict(session or {})
+        messages = list(current.get("messages") or [])
+        result = f"E2E echo: {prompt}"
+        now = time.time()
+        messages.extend([
+            {
+                "role": "user",
+                "content": prompt,
+                "id": f"e2e-user-{uuid.uuid4()}",
+                "created_at": now,
+            },
+            {
+                "role": "assistant",
+                "content": result,
+                "id": f"e2e-agent-{uuid.uuid4()}",
+                "created_at": now,
+            },
+        ])
+        current.update({
+            "messages": messages,
+            "trace": list(current.get("trace") or []),
+            "turn": int(current.get("turn") or 0) + 1,
+        })
+        self.current_session = current
+        return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: session_sync_host.py <co-dir> <port>")
+    host(
+        EchoAgent,
+        port=int(sys.argv[2]),
+        trust="open",
+        co_dir=Path(sys.argv[1]),
+        summary="Deterministic OIP session-sync acceptance agent",
+    )
+

--- a/e2e/mock-agent.ts
+++ b/e2e/mock-agent.ts
@@ -22,7 +22,7 @@ export const PAYEE_ADDRESS =
 export const AGENT_ADDRESS =
   '0xe2e7e57a9e0c4f1b8d3a6c5e9f2b1a4d7c8e0f3a6b9c2d5e8f1a4b7c0d3e6f9a'
 
-export type Scenario = 'reply' | 'cache-usage' | 'tools' | 'coding-agent' | 'coding-agent-permissions' | 'coding-agent-claude' | 'coding-agent-claude-completed' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval' | 'coding-agent-stale-approval' | 'coding-agent-stop-ack-no-terminal' | 'coding-agent-stop-no-ack' | 'coding-agent-stop-delayed-ack' | 'coding-agent-stop-fresh-state' | 'coding-agent-stop-rejected' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'onboard-success' | 'pr-evidence' | 'ask-user' | 'todo-list' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel'
+export type Scenario = 'reply' | 'cache-usage' | 'tools' | 'coding-agent' | 'coding-agent-permissions' | 'coding-agent-claude' | 'coding-agent-claude-completed' | 'coding-agent-completed' | 'coding-agent-failed' | 'coding-agent-long-approval' | 'coding-agent-stale-approval' | 'coding-agent-stop-ack-no-terminal' | 'coding-agent-stop-no-ack' | 'coding-agent-stop-delayed-ack' | 'coding-agent-stop-fresh-state' | 'coding-agent-stop-rejected' | 'approval' | 'error' | 'error-once' | 'offline' | 'dashboard' | 'dashboard-approval' | 'busy' | 'long-reply' | 'drop' | 'gate-midway' | 'balance-drains' | 'dashboard-drains' | 'dashboard-error' | 'dashboard-drop' | 'onboard-payment' | 'onboard-success' | 'pr-evidence' | 'ask-user' | 'todo-list' | 'mode-delay' | 'mode-reject' | 'mode-disconnect' | 'cancel' | 'retained-session'
 
 /** What /info and the AGENT_PROFILE frame agree on. Also what the landing page renders. */
 export const PROFILE = {
@@ -157,8 +157,48 @@ export async function mockAgent(
         text?: string
         optionId?: string
         confirmRisk?: boolean
+        request_id?: string
+        payload?: { session_sync_only?: number }
       }
       sent.push(msg)
+
+      if (scenario === 'retained-session') {
+        const summary = {
+          session_id: 'remote-session', revision: 7, title: 'Synced from my phone',
+          activity: 'idle', last_outcome: 'completed', last_sequence: 2,
+          created_at: '2026-08-20T09:00:00.000Z', updated_at: '2026-09-01T09:30:00.000Z',
+        }
+        if (msg.type === 'CONNECT') {
+          connects += 1
+          setTimeout(() => {
+            if (msg.payload?.session_sync_only !== 1) {
+              send(ws, { type: 'ERROR', message: 'Session is already attached to another connection' })
+              return
+            }
+            send(ws, {
+              type: 'CONNECTED', session_id: 'index-socket', status: 'index',
+              protocol: { name: 'oip', version: '0.1', extensions: { 'session-sync': '0.1' } },
+            })
+          }, 0)
+        } else if (msg.type === 'SESSION_SYNC') {
+          send(ws, {
+            type: 'SESSION_SYNC_RESULT', request_id: msg.request_id,
+            sessions: [summary], removed_session_ids: [], cursor: 'retained-cursor',
+          })
+        } else if (msg.type === 'SESSION_GET') {
+          send(ws, {
+            type: 'SESSION_SNAPSHOT', request_id: msg.request_id, summary,
+            snapshot_revision: 7,
+            records: [
+              { sequence: 1, record_id: 'retained-u', kind: 'input', occurred_at: summary.created_at,
+                data: { id: 'retained-u', type: 'user', content: 'A message from my phone' } },
+              { sequence: 2, record_id: 'retained-a', kind: 'output', occurred_at: summary.updated_at,
+                data: { id: 'retained-a', type: 'agent', content: 'Retained reply from the Agent' } },
+            ],
+          })
+        }
+        return
+      }
 
       // An offline agent answers nothing. Replying to CONNECT with a profile is
       // proof of life, and the app is right to treat it as such — which is why

--- a/e2e/onboard.spec.ts
+++ b/e2e/onboard.spec.ts
@@ -129,7 +129,7 @@ test.describe('a shared session link', () => {
   const SHARED = `/${AGENT_ADDRESS}/forwarded-session-link`
 
   test('gates before the reader writes anything', async ({ page, shot }) => {
-    await mockAgent(page, 'onboard-payment')
+    const agent = await mockAgent(page, 'onboard-payment')
     await page.goto(SHARED)
 
     // The landing page opens its socket eagerly, so ONBOARD_REQUIRED arrives and
@@ -159,6 +159,7 @@ test.describe('a shared session link', () => {
     await expect(page.getByPlaceholder(/invite code/i), 'two invite fields exist for one challenge').toHaveCount(1)
     await expect(page.getByRole('button', { name: /continue/i }), 'two Continue buttons exist for one challenge').toHaveCount(1)
     await expect(page.getByText(/verification required/i)).toHaveCount(0)
+    expect(agent.sent('CONNECT').some(frame => frame.session_id === 'forwarded-session-link')).toBe(false)
 
     await shot('single-verifier')
   })

--- a/e2e/recent-chat-sync.spec.ts
+++ b/e2e/recent-chat-sync.spec.ts
@@ -40,6 +40,17 @@ function row(sidebar: ReturnType<Page['locator']>, title: string) {
   return sidebar.getByRole('link', { name: title }).locator('..')
 }
 
+test('A fresh browser sends its landing-page message after initial hydration', async ({ page, shot }) => {
+  const agent = await mockAgent(page)
+  await page.goto(`/${AGENT_ADDRESS}`)
+  await expect(page.getByRole('heading', { name: PROFILE.name, exact: true })).toBeVisible()
+  await page.getByRole('button', { name: 'What can you do?' }).click()
+  await expect.poll(() => agent.sent('INPUT').length).toBe(1)
+  await expect(page.locator('textarea')).toBeEnabled()
+  await expect(page.getByPlaceholder('Restoring chat…')).toHaveCount(0)
+  await shot('fresh-browser-first-message')
+})
+
 test('Recent Chat names local deletion and remote archive truthfully', async ({ page, shot }) => {
   await page.setViewportSize({ width: 1280, height: 800 })
   const sidebar = await recentChat(page)

--- a/e2e/recent-chat-sync.spec.ts
+++ b/e2e/recent-chat-sync.spec.ts
@@ -74,3 +74,32 @@ test('Recent Chat names local deletion and remote archive truthfully', async ({ 
   await expect(page.getByRole('alertdialog').getByRole('button', { name: 'Archive' })).toBeVisible()
   await shot('after-remote-archive-mobile')
 })
+
+for (const cached of [true, false]) {
+  test(`Remote transcript ${cached ? 'restores its cached index' : 'discovers a deep link'} without claiming the live session`, async ({ page, shot }) => {
+    await page.addInitScript(({ address, cached }) => {
+      localStorage.setItem('oo-chat-storage', JSON.stringify({
+        state: {
+          agents: [address], activeSessionId: null,
+          conversations: cached ? [{
+            sessionId: 'remote-session', agentAddress: address, title: 'Synced from my phone',
+            remoteRevision: 7, createdAt: '2026-08-20T09:00:00.000Z', updatedAt: '2026-09-01T09:30:00.000Z',
+          }] : [],
+        }, version: 0,
+      }))
+    }, { address: AGENT_ADDRESS, cached })
+    const agent = await mockAgent(page, 'retained-session')
+    await page.goto(`/${AGENT_ADDRESS}/remote-session`)
+    await expect(page.getByText('Retained reply from the Agent', { exact: true })).toBeVisible()
+    await expect(page.locator('textarea')).toBeDisabled()
+    await page.reload()
+    await expect(page.getByText('Retained reply from the Agent', { exact: true })).toBeVisible()
+    await expect(page.getByText('Session is already attached', { exact: false })).toHaveCount(0)
+    await expect(page.locator('textarea')).toBeDisabled()
+    expect(agent.sent('SESSION_GET').length).toBeGreaterThanOrEqual(2)
+    expect(agent.sent('CONNECT').every(frame =>
+      (frame.payload as { session_sync_only?: number })?.session_sync_only === 1,
+    )).toBe(true)
+    await shot('remote-snapshot-after-reload')
+  })
+}

--- a/e2e/recent-chat-sync.spec.ts
+++ b/e2e/recent-chat-sync.spec.ts
@@ -114,3 +114,31 @@ for (const cached of [true, false]) {
     await shot('remote-snapshot-after-reload')
   })
 }
+
+test('A missing remote session returns to the landing page without claiming it', async ({ page }) => {
+  const agent = await mockAgent(page, 'retained-session')
+  await page.goto(`/${AGENT_ADDRESS}/missing-session`)
+  await expect(page).toHaveURL(new RegExp(`/${AGENT_ADDRESS}$`))
+  expect(agent.sent('CONNECT').some(frame => frame.session_id === 'missing-session')).toBe(false)
+})
+
+test('A retained snapshot requiring verification shows recovery instead of loading forever', async ({ page, shot }) => {
+  await page.addInitScript(address => {
+    localStorage.setItem('oo-chat-storage', JSON.stringify({
+      state: {
+        conversations: [{
+          sessionId: 'remote-session', agentAddress: address, title: 'Retained chat', remoteRevision: 7,
+          createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(),
+        }], agents: [address], activeSessionId: 'remote-session',
+      }, version: 0,
+    }))
+  }, AGENT_ADDRESS)
+  const agent = await mockAgent(page, 'onboard-payment')
+  await page.goto(`/${AGENT_ADDRESS}/remote-session`)
+  await expect(page.getByText('Open the Agent homepage to complete verification before loading this synced chat.', { exact: false })).toBeVisible()
+  await expect(page.locator('textarea')).toBeDisabled()
+  expect(agent.sent('CONNECT').every(frame =>
+    (frame.payload as { session_sync_only?: number })?.session_sync_only === 1,
+  )).toBe(true)
+  await shot('remote-snapshot-verification-required')
+})

--- a/hooks/use-recent-chat-sync.ts
+++ b/hooks/use-recent-chat-sync.ts
@@ -70,6 +70,17 @@ export function useRecentChatSync(agentAddresses: string[]) {
 
     const task = (async () => {
       const client = clientFor(agentAddress)
+      let needsOnboarding = false
+      // Index discovery has no invitation form of its own. A trust challenge
+      // must release the waiting route so the landing page can present the
+      // authenticated gate, without claiming the requested live session.
+      client.onMessage = () => {
+        if (!client.ui.some(item => item.type === 'onboard_required')) return
+        needsOnboarding = true
+        client.onMessage = null
+        client.reset()
+        clients.current.delete(agentAddress)
+      }
       const key = cursorKey(identity.address, agentAddress)
       const hasRemoteCache = useChatStore.getState().conversations.some(
         conversation => conversation.agentAddress === agentAddress
@@ -98,6 +109,7 @@ export function useRecentChatSync(agentAddresses: string[]) {
         )
         localStorage.setItem(key, result.cursor)
       } catch (error) {
+        if (needsOnboarding) return
         if (error instanceof SessionSyncError && error.code === 'unsupported_extension') {
           unsupported.current.add(agentAddress)
           client.reset()
@@ -105,6 +117,8 @@ export function useRecentChatSync(agentAddresses: string[]) {
           return
         }
         console.warn(`[oo-chat] Recent Chat sync failed for ${agentAddress}`, error)
+      } finally {
+        client.onMessage = null
       }
     })().finally(() => {
       setSessionSyncReady(agentAddress, true)

--- a/hooks/use-remote-session-snapshot.test.ts
+++ b/hooks/use-remote-session-snapshot.test.ts
@@ -24,7 +24,7 @@ describe('fetchRemoteSessionSnapshot', () => {
     })
     const reset = vi.fn()
     const reconnect = vi.fn()
-    const createClient = vi.fn(() => ({ getSession, reset, reconnect }))
+    const createClient = vi.fn(() => ({ getSession, reset, reconnect, ui: [], onMessage: null }))
 
     const result = await fetchRemoteSessionSnapshot({
       agentAddress: '0xagent',
@@ -47,6 +47,7 @@ describe('fetchRemoteSessionSnapshot', () => {
     const failure = new Error('snapshot unavailable')
     const reset = vi.fn()
     const createClient = vi.fn(() => ({
+      ui: [], onMessage: null,
       getSession: vi.fn().mockRejectedValue(failure),
       reset,
     }))
@@ -58,5 +59,23 @@ describe('fetchRemoteSessionSnapshot', () => {
       createClient,
     })).rejects.toBe(failure)
     expect(reset).toHaveBeenCalledOnce()
+  })
+
+  it('releases a snapshot blocked on verification instead of loading forever', async () => {
+    const client = {
+      ui: [{ id: 'gate', type: 'onboard_required' }] as ChatItem[],
+      onMessage: null as (() => void) | null,
+      reset: vi.fn(),
+      getSession: vi.fn(async () => {
+        client.onMessage?.()
+        throw new Error('Connection closed during authentication')
+      }),
+    }
+    await expect(fetchRemoteSessionSnapshot({
+      agentAddress: '0xagent', sessionId: 'session-1', identity,
+      createClient: () => client,
+    })).rejects.toThrow('Open the Agent homepage to complete verification')
+    expect(client.reset).toHaveBeenCalled()
+    expect(client.onMessage).toBeNull()
   })
 })

--- a/hooks/use-remote-session-snapshot.test.ts
+++ b/hooks/use-remote-session-snapshot.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BrowserIdentity, ChatItem } from '@connectonion/react'
+import { fetchRemoteSessionSnapshot } from './use-remote-session-snapshot'
+
+const identity = { address: '0xreader', sign: vi.fn() } as unknown as BrowserIdentity
+const records: ChatItem[] = [
+  { id: 'user-1', type: 'user', content: 'hello' },
+  { id: 'agent-1', type: 'agent', content: 'world' },
+]
+
+describe('fetchRemoteSessionSnapshot', () => {
+  it('reads a retained transcript through an index-only client without claiming the live session', async () => {
+    const getSession = vi.fn().mockResolvedValue({
+      notModified: false,
+      summary: { session_id: 'session-1' },
+      snapshotRevision: 7,
+      records: records.map((data, index) => ({
+        sequence: index + 1,
+        record_id: `record-${index + 1}`,
+        kind: index === 0 ? 'input' : 'output',
+        occurred_at: '2026-09-01T00:00:00.000Z',
+        data,
+      })),
+    })
+    const reset = vi.fn()
+    const reconnect = vi.fn()
+    const createClient = vi.fn(() => ({ getSession, reset, reconnect }))
+
+    const result = await fetchRemoteSessionSnapshot({
+      agentAddress: '0xagent',
+      sessionId: 'session-1',
+      identity,
+      createClient,
+    })
+
+    expect(createClient).toHaveBeenCalledWith('0xagent', {
+      signer: identity,
+      sessionSyncOnly: true,
+    })
+    expect(getSession).toHaveBeenCalledWith('session-1')
+    expect(reconnect).not.toHaveBeenCalled()
+    expect(reset).toHaveBeenCalledOnce()
+    expect(result).toEqual({ snapshotRevision: 7, ui: records })
+  })
+
+  it('always closes the capability socket when snapshot retrieval fails', async () => {
+    const failure = new Error('snapshot unavailable')
+    const reset = vi.fn()
+    const createClient = vi.fn(() => ({
+      getSession: vi.fn().mockRejectedValue(failure),
+      reset,
+    }))
+
+    await expect(fetchRemoteSessionSnapshot({
+      agentAddress: '0xagent',
+      sessionId: 'session-1',
+      identity,
+      createClient,
+    })).rejects.toBe(failure)
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})

--- a/hooks/use-remote-session-snapshot.ts
+++ b/hooks/use-remote-session-snapshot.ts
@@ -10,6 +10,8 @@ import {
 } from '@connectonion/react'
 
 interface SnapshotClient {
+  readonly ui: ChatItem[]
+  onMessage: (() => void) | null
   getSession(sessionId: string, options?: SessionGetOptions): Promise<SessionGetResult>
   reset(): void
 }
@@ -45,6 +47,13 @@ export async function fetchRemoteSessionSnapshot({
     signer: identity,
     sessionSyncOnly: true,
   })
+  let needsOnboarding = false
+  client.onMessage = () => {
+    if (!client.ui.some(item => item.type === 'onboard_required')) return
+    needsOnboarding = true
+    client.onMessage = null
+    client.reset()
+  }
   try {
     const result = ifRevision === undefined
       ? await client.getSession(sessionId)
@@ -56,7 +65,13 @@ export async function fetchRemoteSessionSnapshot({
       snapshotRevision: result.snapshotRevision,
       ui: result.records.map(record => record.data),
     }
+  } catch (error) {
+    if (needsOnboarding) {
+      throw new Error('Open the Agent homepage to complete verification before loading this synced chat.')
+    }
+    throw error
   } finally {
+    client.onMessage = null
     client.reset()
   }
 }

--- a/hooks/use-remote-session-snapshot.ts
+++ b/hooks/use-remote-session-snapshot.ts
@@ -1,0 +1,138 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  connect,
+  type BrowserIdentity,
+  type ChatItem,
+  type SessionGetOptions,
+  type SessionGetResult,
+} from '@connectonion/react'
+
+interface SnapshotClient {
+  getSession(sessionId: string, options?: SessionGetOptions): Promise<SessionGetResult>
+  reset(): void
+}
+
+type SnapshotClientFactory = (
+  agentAddress: string,
+  options: { signer: BrowserIdentity; sessionSyncOnly: true },
+) => SnapshotClient
+
+interface FetchRemoteSessionSnapshotOptions {
+  agentAddress: string
+  sessionId: string
+  identity: BrowserIdentity
+  ifRevision?: number
+  createClient?: SnapshotClientFactory
+}
+
+interface RemoteSessionSnapshot {
+  snapshotRevision: number
+  /** Null means the caller's existing snapshot is already current. */
+  ui: ChatItem[] | null
+}
+
+/** Read one retained transcript without attaching to its single-writer live session. */
+export async function fetchRemoteSessionSnapshot({
+  agentAddress,
+  sessionId,
+  identity,
+  ifRevision,
+  createClient = connect,
+}: FetchRemoteSessionSnapshotOptions): Promise<RemoteSessionSnapshot> {
+  const client = createClient(agentAddress, {
+    signer: identity,
+    sessionSyncOnly: true,
+  })
+  try {
+    const result = ifRevision === undefined
+      ? await client.getSession(sessionId)
+      : await client.getSession(sessionId, { ifRevision })
+    if (result.notModified) {
+      return { snapshotRevision: result.revision, ui: null }
+    }
+    return {
+      snapshotRevision: result.snapshotRevision,
+      ui: result.records.map(record => record.data),
+    }
+  } finally {
+    client.reset()
+  }
+}
+
+interface UseRemoteSessionSnapshotOptions {
+  agentAddress: string
+  sessionId: string
+  identity: BrowserIdentity | null
+  remoteRevision?: number
+  enabled: boolean
+}
+
+interface SnapshotState {
+  key: string
+  ui: ChatItem[]
+  snapshotRevision?: number
+  loading: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: SnapshotState = {
+  key: '',
+  ui: [],
+  loading: false,
+  error: null,
+}
+
+/** Keep a remote-only route on a revision-consistent Host snapshot. */
+export function useRemoteSessionSnapshot({
+  agentAddress,
+  sessionId,
+  identity,
+  remoteRevision,
+  enabled,
+}: UseRemoteSessionSnapshotOptions) {
+  const key = `${agentAddress}:${sessionId}`
+  const [state, setState] = useState<SnapshotState>(EMPTY_STATE)
+  const latestRevision = useRef<{ key: string; revision?: number }>({ key })
+  const [reloadToken, setReloadToken] = useState(0)
+
+  useEffect(() => {
+    if (!enabled || !identity) return
+    let cancelled = false
+    const previousRevision = latestRevision.current.key === key
+      ? latestRevision.current.revision
+      : undefined
+    fetchRemoteSessionSnapshot({
+      agentAddress,
+      sessionId,
+      identity,
+      ifRevision: previousRevision,
+    }).then(result => {
+      if (cancelled) return
+      latestRevision.current = { key, revision: result.snapshotRevision }
+      setState(current => ({
+        key,
+        ui: result.ui ?? (current.key === key ? current.ui : []),
+        snapshotRevision: result.snapshotRevision,
+        loading: false,
+        error: null,
+      }))
+    }).catch(error => {
+      if (cancelled) return
+      setState(current => ({
+        key,
+        ui: current.key === key ? current.ui : [],
+        snapshotRevision: current.key === key ? current.snapshotRevision : undefined,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Could not load synced transcript',
+      }))
+    })
+    return () => { cancelled = true }
+  }, [agentAddress, enabled, identity, key, reloadToken, remoteRevision, sessionId])
+
+  const reload = useCallback(() => setReloadToken(value => value + 1), [])
+  return state.key === key
+    ? { ...state, reload }
+    : { ...EMPTY_STATE, loading: enabled && Boolean(identity), reload }
+}

--- a/store/chat-store.test.ts
+++ b/store/chat-store.test.ts
@@ -35,6 +35,19 @@ describe('chat store credential boundary', () => {
     })
   })
 
+  it.each([false, true])('finishes initial synchronous hydration (cached=%s)', async (cached) => {
+    if (cached) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        state: { conversations: [], agents: ['0xagent'], activeSessionId: null }, version: 0,
+      }))
+    }
+    vi.resetModules()
+    const { useChatStore } = await import('./chat-store')
+    // Do not rehydrate a second time: the first page load must be usable.
+    expect(useChatStore.getState()._hasHydrated).toBe(true)
+    expect(useChatStore.persist.hasHydrated()).toBe(true)
+  })
+
   it('scrubs JWT and profile fields left by an older persisted store', async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       state: {

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -53,6 +53,7 @@ interface ChatState {
 }
 
 interface ChatActions {
+  setHasHydrated: () => void
   createConversation: (sessionId: string, agentAddress: string) => void
   selectConversation: (sessionId: string) => void
   deleteConversation: (sessionId: string) => void
@@ -88,6 +89,8 @@ export const useChatStore = create<ChatStore>()(
       pendingFiles: null,
       _hasHydrated: false,
       sessionSyncReady: {},
+
+      setHasHydrated: () => set({ _hasHydrated: true }),
 
       createConversation: (sessionId, agentAddress) => {
         const exists = get().conversations.some(c => c.sessionId === sessionId)
@@ -251,8 +254,10 @@ export const useChatStore = create<ChatStore>()(
     }),
     {
       name: 'oo-chat-storage',
-      onRehydrateStorage: () => () => {
-        useChatStore.setState({ _hasHydrated: true })
+      onRehydrateStorage: () => (state) => {
+        // Storage can restore synchronously while create() is still running.
+        // Use the restored state's action, not the uninitialized exported hook.
+        state?.setHasHydrated()
       },
       // Exclude transient state from persistence. Nothing here carries
       // images — the transcript (and its sanitizing) lives in the SDK store.


### PR DESCRIPTION
## Change

Remote-only chats open through OIP `SESSION_GET -> SESSION_SNAPSHOT` on a read-only index connection. The page waits for local hydration and remote discovery before deciding whether it may connect to a live session. First browser initialization, unknown shared links, invitation gates, offline recovery, and existing local drafts are covered by regressions.

## User-visible change

- UI impact: yes
- Changed surfaces/routes: Recent Chat, `/[address]` invitation gate, and `/[address]/[sessionId]` remote transcript/recovery states
- Related issue/design decision: https://github.com/openonion/connectonion/pull/1371
- Core version: 1.8.0a8
- React version: 0.4.4-rc.1
- O Chat commit: 4fbdeade8984bebd4d648bf82cbf05d29d65ca7f
- Evidence commit: 4fbdeade8984bebd4d648bf82cbf05d29d65ca7f
- No-visual-change reason: not applicable

## Required complete E2E evidence

- [x] an invite code was entered and accepted;
- [x] the Agent connected and received a prompt or skill request;
- [x] Safe/Default, Plan, and bounded Full access mode transitions were exercised;
- [x] the Agent updated Control Center and the updated state rendered;
- [x] I inspected `pr-release-evidence-invite-prompt-modes-and-control-center--complete-flow.png` in the CI `pr-e2e-evidence` artifact.

Final-head CI: https://github.com/openonion/oo-chat/actions/runs/33591439503 — the `e2e` job passed all 208 unit tests and 214 browser/screenshot checks. Its exact-head `pr-e2e-evidence` artifact was downloaded and the complete-flow image inspected. The separate direct-image declaration gate remains blocked on authorized upload, not a test failure.

## Visible E2E screenshots — required

<!-- e2e-screenshots:start -->
### Before
New surface: remote-only sessions previously attempted an invalid live attachment; initial hydration could also leave a fresh browser stuck in restoration.

### After — desktop
`03b-station-b-remote-transcript-desktop.png` was inspected at the final head. Direct GitHub attachment is pending explicit upload authorization.

### After — narrow/mobile
`03-station-b-remote-transcript-mobile.png` was inspected at 390×844 at the final head. Direct GitHub attachment is pending explicit upload authorization.

### Critical states
`04-station-b-archive-confirm-mobile.png` was inspected. The final real-Host run covers initial send, remote discovery, read-only transcript, second-turn automatic refresh, full reload, deduplication, no live-session claim, and archive propagation. Browser regressions separately cover missing links, offline status, invitation-gated discovery and retained snapshots, fresh storage, cached indices, and local draft attachments.

- [x] I inspected every image at the final PR head.
- [x] Images contain no secret, invite code, identity material, private path, customer data, raw reasoning, or sensitive prompt.
<!-- e2e-screenshots:end -->

The three images above currently exist only in local test evidence. The safety reviewer denied external file upload; explicit approval was requested and is still pending. No visual gate is waived, and this PR is not claimed as deployed.

## UI interaction audit — required for visible changes

- [x] 1. First-glance hierarchy: remote read-only status precedes the transcript.
- [x] 2. Primary action: the disabled composer does not imply live-session ownership.
- [x] 3. Sensitive actions: archive remains confirmed; invitation forms use the existing authenticated gate.
- [x] 4. Evidence: transcript content and revision come from the Host snapshot.
- [x] 5. Progress: discovery/snapshot loading does not become a live attach.
- [x] 6. Detail: only reconstructed ChatItems are rendered.
- [x] 7. Recovery: verification-required snapshots stop loading with a concrete next step; offline status takes precedence.
- [x] 8. Desktop: status, transcript, and composer fit without overflow.
- [x] 9. Mobile: status, two turns, and archive confirmation are readable at 390px.
- [x] 10. Accessibility: semantic disabled controls; no suggestion actions behind the invitation gate.

## Verification

- `npm test` — 27 files / 208 tests passed.
- `npm run lint` — 0 errors, 7 existing warnings.
- `npx next build --webpack` — passed.
- Full local Chromium suite: 211 passed, plus 3 screenshot integrity checks. The empty-session fixture was then corrected to create real local drafts, preserving every original assertion; it passed 25 checks across five repetitions with two workers. Final-head CI passed 214 browser/screenshot checks.
- Real two-context acceptance against public Host a8 on `agents-vm` passed at this head, using a local production frontend build and the public relay: new chat discovery 1.513 s, second-turn refresh 17.900 s, archive propagation 8.540 s. Exactly one remote chat; no empty sessions, duplicate messages, protocol errors, console/page errors, or remote live-session claims. Both initial index CONNECTs used the same frozen timestamp and distinct nonces.
- Reproduction is checked in: `e2e/live/session-sync.mjs`, `e2e/live/session_sync_host.py`, and `e2e/live/README.md`. Use only a disposable identity and isolated test Host.

An earlier expanded run had green assertions but a visible attachment error. It is invalid evidence. The checked-in runner now rejects every protocol error and explicitly checks the rendered error state and outbound live-session claims.

## Release boundary

Core a8 is public at https://github.com/openonion/connectonion/releases/tag/v1.8.0a8 and docs PR https://github.com/wu-changxing/connectonion-docs-site/pull/132 is merged. The test-server wheel matches public PyPI SHA-256 `49e54783173ab1c2aa1bdcba3670292ff4d9d83a2e0649e2b5da553b1666de56`. Stable is unchanged. Remote snapshots remain read-only while the originating device owns the live session; concurrent writers are not introduced.
